### PR TITLE
At attribute creation set pool.fields_by_model to None

### DIFF
--- a/base_custom_attributes/custom_attributes.py
+++ b/base_custom_attributes/custom_attributes.py
@@ -310,7 +310,8 @@ class attribute_attribute(orm.Model):
                     cr, uid, f_vals, {'manual': True})
         vals['state'] = 'manual'
         # set fields_by_model to None to force the reload of _columns in _init
-        # This change is mandatory to create column specific to attribute in the database when import csv
+        # This change is mandatory to create column specific to attribute
+        # in the database when import csv
         old_vals = self.pool.fields_by_model
         try:
             self.pool.fields_by_model = None

--- a/base_custom_attributes/custom_attributes.py
+++ b/base_custom_attributes/custom_attributes.py
@@ -309,7 +309,17 @@ class attribute_attribute(orm.Model):
                 vals['serialization_field_id'] = field_obj.create(
                     cr, uid, f_vals, {'manual': True})
         vals['state'] = 'manual'
-        return super(attribute_attribute, self).create(cr, uid, vals, context)
+        # set fields_by_model to None to force the reload of _columns in _init
+        # This change is mandatory to create column specific to attribute in the database when import csv
+        old_vals = self.pool.fields_by_model
+        try:
+            self.pool.fields_by_model = None
+            res = super(attribute_attribute, self).create(cr, uid, vals, context)
+        except Exception:
+            raise
+        finally:
+            self.pool.fields_by_model = old_vals
+        return res
 
     def onchange_field_description(self, cr, uid, ids, field_description,
                                    name, create_date, context=None):


### PR DESCRIPTION
When create a new attribute force the value of pool.fields_by_model to None to recompute _columns.

If this value is not None, in some case, columns are not created in the database.

Exemple:
-load a csv as demo data
-migrate data
