### PR TITLE
search first product.price.type instead of take id 1

### DIFF
--- a/product_pricelist_fixed_price/model/product_pricelist_item.py
+++ b/product_pricelist_fixed_price/model/product_pricelist_item.py
@@ -44,8 +44,10 @@ class product_pricelist_item(orm.Model):
     def onchange_base_ext(self, cr, uid, ids, base_ext, context=None):
         if base_ext == -3:
             # Simulate be based on first found price that allows the trick
+            base = self.pool['product.price.type'].search(cr, uid, [],
+                                                          limit=1, order='id')
             return {
-                'value': {'base': 1,
-                          'price_discount': -1,}
+                'value': {'base': base[0],
+                          'price_discount': -1, }
             }
         return {'value': {'base': base_ext}}


### PR DESCRIPTION
In some case (rare) product.price.type with id 1 doesn't exist, so it is not possible to set base 1.

To reproduce the problem, simply delete product price type with id 1 and set fixed price on pricelist item. Save doesn't work, because base is empty.
