### PR TITLE
Add product_code_mandatory and product_code_unique

### DIFF
--- a/product_code_mandatory/__init__.py
+++ b/product_code_mandatory/__init__.py
@@ -1,0 +1,1 @@
+import product

--- a/product_code_mandatory/__openerp__.py
+++ b/product_code_mandatory/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP Module
+#    
+#    Copyright (C) 2010-2011 BREMSKERL-REIBBELAGWERKE EMMERLING GmbH & Co. KG
+#    Author Marco Dieckhoff
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Make product code mandatory",
+    "version": "1.01",
+    "depends": ["product"],
+    "author": "Marco Dieckhoff, BREMSKERL",
+    "category": "Inventory Control",
+    "description": """Makes product code (default_code) a mandatory field 
+    """,
+    'depends' : ['product'],
+    "init_xml": [],
+    'update_xml': [],
+    'demo_xml': [],
+    'installable': True,
+    'active': False,
+#    'certificate': '${certificate}',
+}

--- a/product_code_mandatory/product.py
+++ b/product_code_mandatory/product.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from openerp.osv import osv, fields
+
+
+class product_code_mandatory_product(osv.osv):
+    _name = "product.product"
+    _inherit = "product.product"
+
+    _columns = {
+        'default_code':  fields.char('Reference', size=64, required=True),
+    }
+
+    _defaults ={
+        'default_code': lambda *a: 'NEW',
+    }

--- a/product_code_unique/__init__.py
+++ b/product_code_unique/__init__.py
@@ -1,0 +1,1 @@
+import product

--- a/product_code_unique/__openerp__.py
+++ b/product_code_unique/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP Module
+#    
+#    Copyright (C) 2010-2011 BREMSKERL-REIBBELAGWERKE EMMERLING GmbH & Co. KG
+#    Author Marco Dieckhoff
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Make product code unique",
+    "version": "1.01",
+    "depends": ["product"],
+    "author": "Marco Dieckhoff, BREMSKERL",
+    "category": "Inventory Control",
+    "description": """Makes product code (default_code) a unique field 
+    """,
+    'depends': ['product'],
+    "init_xml": [],
+    'update_xml': [],
+    'demo_xml': [],
+    'installable': True,
+    'active': False,
+#    'certificate': '${certificate}',
+}

--- a/product_code_unique/i18n/de.po
+++ b/product_code_unique/i18n/de.po
@@ -1,0 +1,50 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* product_code_unique
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 6.0.1\n"
+"Report-Msgid-Bugs-To: support@openerp.com\n"
+"POT-Creation-Date: 2011-03-24 15:58+0000\n"
+"PO-Revision-Date: 2011-03-24 15:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#: model:ir.model,name:product_code_unique.model_product_product
+#. module: product_code_unique
+msgid "Product"
+msgstr "Produkt"
+
+#: model:ir.module.module,description:product_code_unique.module_meta_information
+#. module: product_code_unique
+msgid "Makes product code (default_code) a unique field \n"
+msgstr "Produkt-Referenz (und Variante) muss eindeutig sein.\n"
+#: constraint:product.product:0
+#. module: product_code_unique
+msgid "Error: Invalid ean code"
+msgstr "Fehler: Falscher EAN code"
+
+#: code:addons\product_code_unique\product.py:38
+#. module: product_code_unique
+#, python-format
+msgid " (copy)"
+msgstr " (Kopie)"
+
+#: code:addons\product_code_unique\product.py:24
+#: constraint:product.product:0
+#: sql_constraint:product.product:0
+#. module: product_code_unique
+#, python-format
+msgid "Reference/Variant has to be unique."
+msgstr "Referenz/Variante muss eindeutig sein."
+
+#: model:ir.module.module,shortdesc:product_code_unique.module_meta_information
+#. module: product_code_unique
+msgid "Make product code unique"
+msgstr "Macht die Produktreferenz (und Variante) eindeutig"
+

--- a/product_code_unique/i18n/product-code-unique.pot
+++ b/product_code_unique/i18n/product-code-unique.pot
@@ -1,0 +1,50 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* product_code_unique
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 6.0.1\n"
+"Report-Msgid-Bugs-To: https://bugs.launchpad.net/bremskerl-addons/\n"
+"POT-Creation-Date: 2011-03-24 15:58+0000\n"
+"PO-Revision-Date: 2011-03-24 15:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#: model:ir.model,name:product_code_unique.model_product_product
+#. module: product_code_unique
+msgid "Product"
+msgstr ""
+
+#: model:ir.module.module,description:product_code_unique.module_meta_information
+#. module: product_code_unique
+msgid "Makes product code (default_code) a unique field \n"
+msgstr ""
+#: constraint:product.product:0
+#. module: product_code_unique
+msgid "Error: Invalid ean code"
+msgstr ""
+
+#: code:addons\product_code_unique\product.py:38
+#. module: product_code_unique
+#, python-format
+msgid " (copy)"
+msgstr ""
+
+#: code:addons\product_code_unique\product.py:24
+#: constraint:product.product:0
+#: sql_constraint:product.product:0
+#. module: product_code_unique
+#, python-format
+msgid "Reference/Variant has to be unique."
+msgstr ""
+
+#: model:ir.module.module,shortdesc:product_code_unique.module_meta_information
+#. module: product_code_unique
+msgid "Make product code unique"
+msgstr ""
+

--- a/product_code_unique/product.py
+++ b/product_code_unique/product.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from openerp.osv import osv
+from openerp.tools.translate import _
+
+
+class product_code_unique_product(osv.osv):
+    _name = "product.product"
+    _inherit = "product.product"
+
+    def _check_defaultcode_and_variants(self, cr, uid, ids):
+        for product in self.browse(cr, uid, ids):
+            res = self.search(cr, uid, [('default_code', '=', product.default_code),
+                                         ('variants', '=', product.variants)
+                                       ])
+            # Result may contain the current product if it's active: we remove it here.
+            if product.id in res:
+                res.remove(product.id)
+            if len(res):
+                # If we have any results left
+                # we have duplicate entries
+                return False
+        return True
+
+    _constraints = [(_check_defaultcode_and_variants,
+                    _('Reference/Variant has to be unique.'),
+                    ['default_code', 'variants'])
+                   ]
+
+    _sql_constraints = [('default_code_uniq', 'unique (default_code, variants)', """Reference/Variant has to be unique."""),]
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if context is None:
+            context = {}
+
+        if not default:
+            default = {}
+        if 'default_code' not in default:
+            default = default.copy()
+            product = self.read(cr, uid, id, ['default_code'], context=context)
+            default['default_code'] = product['default_code'] + _(' (copy)')
+
+        return super(product_code_unique_product, self).copy(cr=cr, uid=uid, id=id, default=default, context=context)


### PR DESCRIPTION
This PR supersedes the merge proposal made on Launchpad some time ago by @lbellier: https://code.launchpad.net/~numerigraphe-team/openerp-product-attributes/7.0-add-bremskrel-modules/+merge/219858
"I propose these 2 new modules :
product_code_mandatory: all is in the module name.
product_code_unique: having a unique product code, without sequence.
These modules have come from BREMSKERL branch (they are OK to merge).
Loïc BELLIER"
