### PR TITLE
[ADD] product_manufacturer: add module removed in Odoo 8.0

### DIFF
--- a/product_m2mcategories/views/product_view.xml
+++ b/product_m2mcategories/views/product_view.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data>
         <record id="product_normal_form_view_add_categids" model="ir.ui.view">
-            <field name="name">product.normal.form</field>
+            <field name="name">product.normal.form.add.categids</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field eval="7" name="priority"/>

--- a/product_m2mcategories/views/product_view.xml
+++ b/product_m2mcategories/views/product_view.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data>
         <record id="product_normal_form_view_add_categids" model="ir.ui.view">
-            <field name="name">product.normal.form.add.categids</field>
+            <field name="name">product.normal.form</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field eval="7" name="priority"/>

--- a/product_manufacturer/README.rst
+++ b/product_manufacturer/README.rst
@@ -1,0 +1,8 @@
+A module that adds manufacturers and attributes on the product form.
+====================================================================
+
+You can now define the following for a product:
+-----------------------------------------------
+    * Manufacturer
+    * Manufacturer Product Name
+    * Manufacturer Product Code

--- a/product_manufacturer/__init__.py
+++ b/product_manufacturer/__init__.py
@@ -1,0 +1,21 @@
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/product_manufacturer/__openerp__.py
+++ b/product_manufacturer/__openerp__.py
@@ -1,0 +1,45 @@
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Products Manufacturers',
+    'version': '1.0',
+    'author': 'OpenERP SA',
+    'contributors': ['Acysos SL <info@acysos.com>'],
+    'category': 'Purchase Management',
+    'depends': ['product'],
+    'demo': [],
+    'description': """
+A module that adds manufacturers and attributes on the product form.
+====================================================================
+
+You can now define the following for a product:
+-----------------------------------------------
+    * Manufacturer
+    * Manufacturer Product Name
+    * Manufacturer Product Code
+    * Product Attributes
+    """,
+    'data': [
+        'security/ir.model.access.csv',
+        'views/product_manufacturer_view.xml'
+    ],
+    'auto_install': False,
+    'installable': True,
+}

--- a/product_manufacturer/__openerp__.py
+++ b/product_manufacturer/__openerp__.py
@@ -34,10 +34,8 @@ You can now define the following for a product:
     * Manufacturer
     * Manufacturer Product Name
     * Manufacturer Product Code
-    * Product Attributes
     """,
     'data': [
-        'security/ir.model.access.csv',
         'views/product_manufacturer_view.xml'
     ],
     'auto_install': False,

--- a/product_manufacturer/__openerp__.py
+++ b/product_manufacturer/__openerp__.py
@@ -25,16 +25,6 @@
     'category': 'Purchase Management',
     'depends': ['product'],
     'demo': [],
-    'description': """
-A module that adds manufacturers and attributes on the product form.
-====================================================================
-
-You can now define the following for a product:
------------------------------------------------
-    * Manufacturer
-    * Manufacturer Product Name
-    * Manufacturer Product Code
-    """,
     'data': [
         'views/product_manufacturer_view.xml'
     ],

--- a/product_manufacturer/i18n/ar.po
+++ b/product_manufacturer/i18n/ar.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "كود تصنيع المنتج"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "المنتج"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "اسم قالب المنتج"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "سمات المنتج"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "سمات المنتج"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "الخاصية"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "قيمة"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "صفات"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "اسم مصنع المنتج"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "مصنّع"

--- a/product_manufacturer/i18n/ar.po
+++ b/product_manufacturer/i18n/ar.po
@@ -1,0 +1,72 @@
+# Arabic translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Arabic <ar@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "كود تصنيع المنتج"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "المنتج"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "اسم قالب المنتج"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "سمات المنتج"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "سمات المنتج"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "الخاصية"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "قيمة"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "صفات"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "اسم مصنع المنتج"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "مصنّع"

--- a/product_manufacturer/i18n/bg.po
+++ b/product_manufacturer/i18n/bg.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Код на производител"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Продукт"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Име на шаблона на продукта"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Атрибути на продукта"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Атрибути на продукта"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Атрибут"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Стойност"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Атрибути"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Име на производител"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Производител"

--- a/product_manufacturer/i18n/bg.po
+++ b/product_manufacturer/i18n/bg.po
@@ -1,0 +1,72 @@
+# Bulgarian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Bulgarian <bg@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Код на производител"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Продукт"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Име на шаблона на продукта"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Атрибути на продукта"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Атрибути на продукта"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Атрибут"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Стойност"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Атрибути"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Име на производител"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Производител"

--- a/product_manufacturer/i18n/bs.po
+++ b/product_manufacturer/i18n/bs.po
@@ -1,0 +1,72 @@
+# Bosnian translation for openobject-addons
+# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-10-30 00:09+0000\n"
+"Last-Translator: Bosko Stojakovic <bluesoft83@gmail.com>\n"
+"Language-Team: Bosnian <bs@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Proizvođačka šifra artikla"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Proizvod"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Naziv predloška proizvoda"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributi proizvoda"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributi proizvoda"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atribut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Vrijednost"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributi"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Proizvođački naziv proizvoda"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Proizvođač"

--- a/product_manufacturer/i18n/bs.po
+++ b/product_manufacturer/i18n/bs.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Proizvođačka šifra artikla"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Proizvod"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Naziv predloška proizvoda"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributi proizvoda"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributi proizvoda"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atribut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Vrijednost"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributi"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Proizvođački naziv proizvoda"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Proizvođač"

--- a/product_manufacturer/i18n/ca.po
+++ b/product_manufacturer/i18n/ca.po
@@ -1,0 +1,72 @@
+# Catalan translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Catalan <ca@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Codi de producte del fabricant"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producte"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nom de plantilla de producte"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributs de producte"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributs del producte"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atribut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributs"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nom del producte del fabricant"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricant"

--- a/product_manufacturer/i18n/ca.po
+++ b/product_manufacturer/i18n/ca.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Codi de producte del fabricant"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producte"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nom de plantilla de producte"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributs de producte"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributs del producte"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atribut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributs"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nom del producte del fabricant"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricant"

--- a/product_manufacturer/i18n/cs.po
+++ b/product_manufacturer/i18n/cs.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Kód výrobku od výrobce"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Výrobek"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Název šalony výrobku"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Vlastnosti výrobku"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Vlastnosti výrobku"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Vlastnost"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Hodnota"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Vlastnosti"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Název výrobku od výrobce"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Výrobce"

--- a/product_manufacturer/i18n/cs.po
+++ b/product_manufacturer/i18n/cs.po
@@ -1,0 +1,72 @@
+# Czech translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-31 10:46+0000\n"
+"Last-Translator: Jan Grmela <Unknown>\n"
+"Language-Team: Czech <cs@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Kód výrobku od výrobce"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Výrobek"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Název šalony výrobku"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Vlastnosti výrobku"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Vlastnosti výrobku"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Vlastnost"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Hodnota"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Vlastnosti"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Název výrobku od výrobce"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Výrobce"

--- a/product_manufacturer/i18n/da.po
+++ b/product_manufacturer/i18n/da.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Producent varenummer"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Vare"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Vare skabelon navn"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Vare egenskaber"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Vare Egenskaber"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Egenskab"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Værdi"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Egenskaber"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Producent Vare Navn"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Producent"

--- a/product_manufacturer/i18n/da.po
+++ b/product_manufacturer/i18n/da.po
@@ -1,0 +1,72 @@
+# Danish translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-10-14 15:36+0000\n"
+"Last-Translator: Morten Schou <ms@msteknik.dk>\n"
+"Language-Team: Danish <da@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Producent varenummer"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Vare"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Vare skabelon navn"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Vare egenskaber"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Vare Egenskaber"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Egenskab"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Værdi"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Egenskaber"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Producent Vare Navn"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Producent"

--- a/product_manufacturer/i18n/de.po
+++ b/product_manufacturer/i18n/de.po
@@ -1,0 +1,72 @@
+# German translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2014-01-25 18:05+0000\n"
+"Last-Translator: Ralf Hilgenstock <rh@dialoge.info>\n"
+"Language-Team: German <de@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2014-01-26 05:15+0000\n"
+"X-Generator: Launchpad (build 16914)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Hersteller-Artikelnummer"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produkt"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Produkt Vorlagenname"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Produkteigenschaften"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Produkteigenschaften"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Eigenschaft"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Wert"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Eigenschaften"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Hersteller-Produktname"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Hersteller"

--- a/product_manufacturer/i18n/de.po
+++ b/product_manufacturer/i18n/de.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Hersteller-Artikelnummer"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produkt"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Produkt Vorlagenname"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Produkteigenschaften"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Produkteigenschaften"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Eigenschaft"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Wert"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Eigenschaften"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Hersteller-Produktname"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Hersteller"

--- a/product_manufacturer/i18n/el.po
+++ b/product_manufacturer/i18n/el.po
@@ -1,0 +1,72 @@
+# Greek translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Greek <el@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Κωδικός Κατασκευαστή"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Προϊόν"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Όνομα Προτύπου Προϊόντος"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Ιδιότητες προϊόντος"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Χαρακτηριστικά Προϊόντος"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Χαρακτηριστικό"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Τιμή"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Ιδιότητες"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Όνομα Προϊόντος Κατασκευαστή"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Κατασκευαστής"

--- a/product_manufacturer/i18n/el.po
+++ b/product_manufacturer/i18n/el.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Κωδικός Κατασκευαστή"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Προϊόν"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Όνομα Προτύπου Προϊόντος"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Ιδιότητες προϊόντος"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Χαρακτηριστικά Προϊόντος"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Χαρακτηριστικό"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Τιμή"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Ιδιότητες"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Όνομα Προϊόντος Κατασκευαστή"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Κατασκευαστής"

--- a/product_manufacturer/i18n/es.po
+++ b/product_manufacturer/i18n/es.po
@@ -1,21 +1,25 @@
-# Spanish translation for openobject-addons
-# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
-# This file is distributed under the same license as the openobject-addons package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_manufacturer
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: openobject-addons\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2013-06-07 19:37+0000\n"
-"PO-Revision-Date: 2012-12-21 23:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: Spanish <es@li.org>\n"
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-01-09 17:17+0000\n"
+"PO-Revision-Date: 2015-01-09 17:17+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
-"X-Generator: Launchpad (build 16831)\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_manufacturer
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"
 
 #. module: product_manufacturer
 #: field:product.template,manufacturer_pref:0
@@ -23,50 +27,8 @@ msgid "Manufacturer Product Code"
 msgstr "Código producto fabricante"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nombre de plantilla de producto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos de producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos del producto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nombre producto fabricante"
 
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,manufacturer:0
-msgid "Manufacturer"
-msgstr "Fabricante"
+

--- a/product_manufacturer/i18n/es.po
+++ b/product_manufacturer/i18n/es.po
@@ -1,0 +1,72 @@
+# Spanish translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Spanish <es@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código producto fabricante"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nombre de plantilla de producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos de producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos del producto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nombre producto fabricante"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_AR.po
+++ b/product_manufacturer/i18n/es_AR.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Código del Fabricante del Producto"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nombre de Plantilla de Producto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos del producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos del Producto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nombre del Fabricante del Producto"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_AR.po
+++ b/product_manufacturer/i18n/es_AR.po
@@ -1,0 +1,72 @@
+# Spanish (Argentina) translation for openobject-addons
+# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2014-06-13 12:41+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Spanish (Argentina) <es_AR@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2014-06-14 06:42+0000\n"
+"X-Generator: Launchpad (build 17045)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código del Fabricante del Producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nombre de Plantilla de Producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos del producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos del Producto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nombre del Fabricante del Producto"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_CR.po
+++ b/product_manufacturer/i18n/es_CR.po
@@ -1,0 +1,72 @@
+# Spanish (Costa Rica) translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Spanish (Costa Rica) <es_CR@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código producto fabricante"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nombre de plantilla de producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos de producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos del producto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nombre producto fabricante"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_CR.po
+++ b/product_manufacturer/i18n/es_CR.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Código producto fabricante"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nombre de plantilla de producto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos de producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos del producto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nombre producto fabricante"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_EC.po
+++ b/product_manufacturer/i18n/es_EC.po
@@ -1,0 +1,72 @@
+# Spanish (Ecuador) translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Spanish (Ecuador) <es_EC@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nombre de plantilla de producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos de producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_EC.po
+++ b/product_manufacturer/i18n/es_EC.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr ""
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nombre de plantilla de producto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos de producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr ""
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_MX.po
+++ b/product_manufacturer/i18n/es_MX.po
@@ -25,65 +25,12 @@ msgstr ""
 "Un módulo que añade fabricantes y atributos en el formulario de producto"
 
 #. module: product_manufacturer
-#: field:product.template,manufacturer_pref:0
-msgid "Manufacturer Product Code"
-msgstr "Código producto fabricante"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nombre de plantilla de producto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos de producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos del producto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: constraint:product.product:0
-msgid "Error: Invalid ean code"
-msgstr "Error: Código EAN no válido"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
-#: model:ir.module.module,shortdesc:product_manufacturer.module_meta_information
-msgid "Products Attributes & Manufacturers"
-msgstr "Fabricantes y atributos de los productos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nombre producto fabricante"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_MX.po
+++ b/product_manufacturer/i18n/es_MX.po
@@ -1,0 +1,89 @@
+# Spanish translation for openobject-addons
+# Copyright (c) 2010 Rosetta Contributors and Canonical Ltd 2010
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2010.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2011-01-11 11:15+0000\n"
+"PO-Revision-Date: 2010-12-08 21:40+0000\n"
+"Last-Translator: Jordi Esteve (www.zikzakmedia.com) "
+"<jesteve@zikzakmedia.com>\n"
+"Language-Team: Spanish <es@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2011-09-05 05:46+0000\n"
+"X-Generator: Launchpad (build 13830)\n"
+
+#. module: product_manufacturer
+#: model:ir.module.module,description:product_manufacturer.module_meta_information
+msgid "A module that add manufacturers and attributes on the product form"
+msgstr ""
+"Un módulo que añade fabricantes y atributos en el formulario de producto"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código producto fabricante"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nombre de plantilla de producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos de producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos del producto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: constraint:product.product:0
+msgid "Error: Invalid ean code"
+msgstr "Error: Código EAN no válido"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: model:ir.module.module,shortdesc:product_manufacturer.module_meta_information
+msgid "Products Attributes & Manufacturers"
+msgstr "Fabricantes y atributos de los productos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nombre producto fabricante"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_VE.po
+++ b/product_manufacturer/i18n/es_VE.po
@@ -19,63 +19,9 @@ msgstr ""
 "X-Generator: Launchpad (build 13830)\n"
 
 #. module: product_manufacturer
-#: model:ir.module.module,description:product_manufacturer.module_meta_information
-msgid "A module that add manufacturers and attributes on the product form"
-msgstr ""
-"Un módulo que añade fabricantes y atributos en el formulario de producto"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pref:0
 msgid "Manufacturer Product Code"
 msgstr "Código producto fabricante"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nombre de plantilla de producto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos de producto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos del producto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: constraint:product.product:0
-msgid "Error: Invalid ean code"
-msgstr "Error: Código EAN no válido"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
-#: model:ir.module.module,shortdesc:product_manufacturer.module_meta_information
-msgid "Products Attributes & Manufacturers"
-msgstr "Fabricantes y atributos de los productos"
 
 #. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
@@ -83,7 +29,7 @@ msgid "Manufacturer Product Name"
 msgstr "Nombre producto fabricante"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/es_VE.po
+++ b/product_manufacturer/i18n/es_VE.po
@@ -1,0 +1,89 @@
+# Spanish translation for openobject-addons
+# Copyright (c) 2010 Rosetta Contributors and Canonical Ltd 2010
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2010.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2011-01-11 11:15+0000\n"
+"PO-Revision-Date: 2010-12-08 21:40+0000\n"
+"Last-Translator: Jordi Esteve (www.zikzakmedia.com) "
+"<jesteve@zikzakmedia.com>\n"
+"Language-Team: Spanish <es@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2011-09-05 05:46+0000\n"
+"X-Generator: Launchpad (build 13830)\n"
+
+#. module: product_manufacturer
+#: model:ir.module.module,description:product_manufacturer.module_meta_information
+msgid "A module that add manufacturers and attributes on the product form"
+msgstr ""
+"Un módulo que añade fabricantes y atributos en el formulario de producto"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código producto fabricante"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nombre de plantilla de producto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos de producto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos del producto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: constraint:product.product:0
+msgid "Error: Invalid ean code"
+msgstr "Error: Código EAN no válido"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: model:ir.module.module,shortdesc:product_manufacturer.module_meta_information
+msgid "Products Attributes & Manufacturers"
+msgstr "Fabricantes y atributos de los productos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nombre producto fabricante"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/et.po
+++ b/product_manufacturer/i18n/et.po
@@ -1,0 +1,72 @@
+# Estonian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-10-09 14:47+0000\n"
+"Last-Translator: lyyser <Unknown>\n"
+"Language-Team: Estonian <et@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Tootja tootekood"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Toode"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Toote malli nimi"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Toote omadused"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Toote omadused"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atribuut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Väärtus"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Omadused"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Tootja tootenimi"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Tootja"

--- a/product_manufacturer/i18n/et.po
+++ b/product_manufacturer/i18n/et.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Tootja tootekood"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Toode"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Toote malli nimi"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Toote omadused"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Toote omadused"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atribuut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Väärtus"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Omadused"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Tootja tootenimi"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Tootja"

--- a/product_manufacturer/i18n/fi.po
+++ b/product_manufacturer/i18n/fi.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Valmistajan tuotekoodi"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Tuote"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Tuotemallipohjan nimi"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Tuotteen attribuutit"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Tuotteen attribuutit"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Attribuutti"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Arvo"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Attribuutit"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Valmistajan tuotenimi"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Valmistaja"

--- a/product_manufacturer/i18n/fi.po
+++ b/product_manufacturer/i18n/fi.po
@@ -1,0 +1,72 @@
+# Finnish translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Finnish <fi@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Valmistajan tuotekoodi"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Tuote"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Tuotemallipohjan nimi"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Tuotteen attribuutit"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Tuotteen attribuutit"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Attribuutti"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Arvo"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Attribuutit"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Valmistajan tuotenimi"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Valmistaja"

--- a/product_manufacturer/i18n/fr.po
+++ b/product_manufacturer/i18n/fr.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Code produit du fabriquant"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produit"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nom du modèle de produit"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Attributs du produit"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Attributs du produit"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Attribut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valeur"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Caractéristiques"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nom du produit chez le fabricant"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricant"

--- a/product_manufacturer/i18n/fr.po
+++ b/product_manufacturer/i18n/fr.po
@@ -1,0 +1,72 @@
+# French translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-01-04 11:29+0000\n"
+"Last-Translator: Ronan Fontenay <Unknown>\n"
+"Language-Team: French <fr@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Code produit du fabriquant"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produit"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nom du modèle de produit"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Attributs du produit"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Attributs du produit"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Attribut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valeur"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Caractéristiques"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nom du produit chez le fabricant"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricant"

--- a/product_manufacturer/i18n/gl.po
+++ b/product_manufacturer/i18n/gl.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Código produto fabricante"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nome do modelo de produto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos do produto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos do produto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nome produto fabricante"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/gl.po
+++ b/product_manufacturer/i18n/gl.po
@@ -1,0 +1,72 @@
+# Galician translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Galician <gl@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código produto fabricante"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nome do modelo de produto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos do produto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos do produto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nome produto fabricante"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/hr.po
+++ b/product_manufacturer/i18n/hr.po
@@ -1,0 +1,72 @@
+# Croatian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Croatian <hr@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Proizvođačka šifra artikla"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Proizvod"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Naziv predloška proizvoda"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Značajke proizvoda"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Značajke proizvoda"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Značajka"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Vrijednost"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Značajke"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Proizvođački naziv artikla"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Proizvođač"

--- a/product_manufacturer/i18n/hr.po
+++ b/product_manufacturer/i18n/hr.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Proizvođačka šifra artikla"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Proizvod"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Naziv predloška proizvoda"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Značajke proizvoda"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Značajke proizvoda"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Značajka"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Vrijednost"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Značajke"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Proizvođački naziv artikla"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Proizvođač"

--- a/product_manufacturer/i18n/hu.po
+++ b/product_manufacturer/i18n/hu.po
@@ -1,0 +1,72 @@
+# Hungarian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Hungarian <hu@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Gyártói termékkód"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Termék"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Terméksablon neve"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Termék tulajdonságok"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Termék tulajdonságok"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Tulajdonság"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Érték"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Tulajdonságok"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Gyártói termék megnevezés"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Gyártó"

--- a/product_manufacturer/i18n/hu.po
+++ b/product_manufacturer/i18n/hu.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Gyártói termékkód"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Termék"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Terméksablon neve"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Termék tulajdonságok"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Termék tulajdonságok"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Tulajdonság"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Érték"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Tulajdonságok"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Gyártói termék megnevezés"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Gyártó"

--- a/product_manufacturer/i18n/it.po
+++ b/product_manufacturer/i18n/it.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Codice prodotto del produttore"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Prodotto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nome modello prodotto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Attributi prodotto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Attributi prodotto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Attributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valore"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Attributi"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nome prodotto del produttore"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Produttore"

--- a/product_manufacturer/i18n/it.po
+++ b/product_manufacturer/i18n/it.po
@@ -1,0 +1,72 @@
+# Italian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Italian <it@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Codice prodotto del produttore"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Prodotto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nome modello prodotto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Attributi prodotto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Attributi prodotto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Attributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valore"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Attributi"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nome prodotto del produttore"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Produttore"

--- a/product_manufacturer/i18n/ja.po
+++ b/product_manufacturer/i18n/ja.po
@@ -1,0 +1,72 @@
+# Japanese translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Japanese <ja@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "製造者製品コード"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "製品"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "製品テンプレート名"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "製品属性"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "製品属性"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "属性"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "値"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "属性"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "製造者製品名"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "製造者"

--- a/product_manufacturer/i18n/ja.po
+++ b/product_manufacturer/i18n/ja.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "製造者製品コード"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "製品"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "製品テンプレート名"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "製品属性"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "製品属性"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "属性"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "値"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "属性"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "製造者製品名"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "製造者"

--- a/product_manufacturer/i18n/lt.po
+++ b/product_manufacturer/i18n/lt.po
@@ -1,0 +1,72 @@
+# Lithuanian translation for openobject-addons
+# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-05-07 10:16+0000\n"
+"Last-Translator: Paulius Sladkevičius @ hbee <paulius@hacbee.com>\n"
+"Language-Team: Lithuanian <lt@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Produkto kodas"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produktas"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Reikšmė"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Produkto pavadinimas"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Gamintojas"

--- a/product_manufacturer/i18n/lt.po
+++ b/product_manufacturer/i18n/lt.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Produkto kodas"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produktas"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr ""
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Reikšmė"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr ""
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Produkto pavadinimas"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Gamintojas"

--- a/product_manufacturer/i18n/lv.po
+++ b/product_manufacturer/i18n/lv.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr ""
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr ""
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr ""
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr ""
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr ""

--- a/product_manufacturer/i18n/lv.po
+++ b/product_manufacturer/i18n/lv.po
@@ -1,0 +1,72 @@
+# Latvian translation for openobject-addons
+# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2014-02-14 10:44+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Latvian <lv@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2014-02-15 07:37+0000\n"
+"X-Generator: Launchpad (build 16916)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr ""

--- a/product_manufacturer/i18n/mk.po
+++ b/product_manufacturer/i18n/mk.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Код на производителот на производот"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Производ"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Име на урнек на производ"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Атрибути на производ"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Атрибути на производ"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Атрибут"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Вредност"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Атрибути"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Име на производител на производ"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Производител"

--- a/product_manufacturer/i18n/mk.po
+++ b/product_manufacturer/i18n/mk.po
@@ -1,0 +1,72 @@
+# Macedonian translation for openobject-addons
+# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-03-01 15:51+0000\n"
+"Last-Translator: Sofce Dimitrijeva <Unknown>\n"
+"Language-Team: Macedonian <mk@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Код на производителот на производот"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Производ"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Име на урнек на производ"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Атрибути на производ"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Атрибути на производ"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Атрибут"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Вредност"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Атрибути"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Име на производител на производ"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Производител"

--- a/product_manufacturer/i18n/mn.po
+++ b/product_manufacturer/i18n/mn.po
@@ -1,0 +1,72 @@
+# Mongolian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Mongolian <mn@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Үйлдвэрлэгчийн барааны код"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Бараа"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Барааны загварын нэр"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Барааны онцлог"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Барааны онцлогууд"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Аттрибут"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Утга"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Атрибут"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Үйлдвэрлэгчийн барааны нэр"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Үйлдвэрлэгч"

--- a/product_manufacturer/i18n/mn.po
+++ b/product_manufacturer/i18n/mn.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Үйлдвэрлэгчийн барааны код"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Бараа"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Барааны загварын нэр"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Барааны онцлог"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Барааны онцлогууд"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Аттрибут"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Утга"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Атрибут"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Үйлдвэрлэгчийн барааны нэр"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Үйлдвэрлэгч"

--- a/product_manufacturer/i18n/nb.po
+++ b/product_manufacturer/i18n/nb.po
@@ -1,0 +1,72 @@
+# Norwegian Bokmal translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Norwegian Bokmal <nb@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Produsent produktkode"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produkt"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Produkt template navn"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Produkt attributter"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Produktattributter"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Attributt"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Verdi"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Attributter"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Produsents produktnavn"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Produsent"

--- a/product_manufacturer/i18n/nb.po
+++ b/product_manufacturer/i18n/nb.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Produsent produktkode"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produkt"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Produkt template navn"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Produkt attributter"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Produktattributter"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Attributt"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Verdi"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Attributter"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Produsents produktnavn"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Produsent"

--- a/product_manufacturer/i18n/nl.po
+++ b/product_manufacturer/i18n/nl.po
@@ -1,0 +1,72 @@
+# Dutch translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-11-06 20:39+0000\n"
+"Last-Translator: Stefan Rijnhart (Therp) <Unknown>\n"
+"Language-Team: Dutch <nl@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Productcode fabrikant"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Product"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Product Sjabloon Naam"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Product kenmerken"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Product kenmerken"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Kenmerk"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Waarde"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Kenmerken"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Productomschrijving fabrikant"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabrikant"

--- a/product_manufacturer/i18n/nl.po
+++ b/product_manufacturer/i18n/nl.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Productcode fabrikant"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Product"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Product Sjabloon Naam"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Product kenmerken"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Product kenmerken"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Kenmerk"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Waarde"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Kenmerken"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Productomschrijving fabrikant"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabrikant"

--- a/product_manufacturer/i18n/pl.po
+++ b/product_manufacturer/i18n/pl.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Kod producenta produktu"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produkt"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nazwa szablonu produktu"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atrybuty produktu"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atrybuty produktu"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atrybut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Wartość"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atrybuty"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nazwa produktu u producenta"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Producent"

--- a/product_manufacturer/i18n/pl.po
+++ b/product_manufacturer/i18n/pl.po
@@ -1,0 +1,72 @@
+# Polish translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Polish <pl@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Kod producenta produktu"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produkt"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nazwa szablonu produktu"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atrybuty produktu"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atrybuty produktu"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atrybut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Wartość"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atrybuty"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nazwa produktu u producenta"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Producent"

--- a/product_manufacturer/i18n/product_manufacturer.pot
+++ b/product_manufacturer/i18n/product_manufacturer.pot
@@ -1,13 +1,13 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
 #	* product_manufacturer
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-06-07 19:37+0000\n"
-"PO-Revision-Date: 2013-06-07 19:37+0000\n"
+"POT-Creation-Date: 2015-01-09 17:17+0000\n"
+"PO-Revision-Date: 2015-01-09 17:17+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,46 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_manufacturer
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr ""
+
+#. module: product_manufacturer
 #: field:product.template,manufacturer_pref:0
 msgid "Manufacturer Product Code"
-msgstr ""
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr ""
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
 msgstr ""
 
 #. module: product_manufacturer
@@ -63,9 +31,4 @@ msgstr ""
 msgid "Manufacturer Product Name"
 msgstr ""
 
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,manufacturer:0
-msgid "Manufacturer"
-msgstr ""
 

--- a/product_manufacturer/i18n/product_manufacturer.pot
+++ b/product_manufacturer/i18n/product_manufacturer.pot
@@ -1,0 +1,71 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* product_manufacturer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-06-07 19:37+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr ""
+

--- a/product_manufacturer/i18n/pt.po
+++ b/product_manufacturer/i18n/pt.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Código do artigo (fabricante)"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Artigo"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nome do modelo do artigo"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos do artigo"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos do artigo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nome do artigo (fabricante)"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/pt.po
+++ b/product_manufacturer/i18n/pt.po
@@ -1,0 +1,72 @@
+# Portuguese translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Portuguese <pt@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código do artigo (fabricante)"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Artigo"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nome do modelo do artigo"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos do artigo"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos do artigo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nome do artigo (fabricante)"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/pt_BR.po
+++ b/product_manufacturer/i18n/pt_BR.po
@@ -1,0 +1,72 @@
+# Brazilian Portuguese translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Código de Fabricação do Produto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Nome do Modelo de Produto"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributos do produto"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributos de Produto"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atributo"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valor"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atributos"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Nome de Fabricação do Produto"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Fabricante"

--- a/product_manufacturer/i18n/pt_BR.po
+++ b/product_manufacturer/i18n/pt_BR.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Código de Fabricação do Produto"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Nome do Modelo de Produto"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributos do produto"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributos de Produto"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atributo"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valor"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atributos"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Nome de Fabricação do Produto"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Fabricante"

--- a/product_manufacturer/i18n/ro.po
+++ b/product_manufacturer/i18n/ro.po
@@ -1,0 +1,72 @@
+# Romanian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-02-17 16:26+0000\n"
+"Last-Translator: ERPSystems.ro <Unknown>\n"
+"Language-Team: Romanian <ro@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Codul Producatorului Produsului"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produs"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Numele Sablonului Produsului"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atribute produs"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atribute Produs"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atribut (caracteristica)"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Valoare"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Atribute"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Numele Producatorului Produsului"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Producator"

--- a/product_manufacturer/i18n/ro.po
+++ b/product_manufacturer/i18n/ro.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Codul Producatorului Produsului"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produs"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Numele Sablonului Produsului"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atribute produs"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atribute Produs"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atribut (caracteristica)"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Valoare"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Atribute"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Numele Producatorului Produsului"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Producator"

--- a/product_manufacturer/i18n/ru.po
+++ b/product_manufacturer/i18n/ru.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Код продукта у производителя"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Продукция"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Шаблон имени продукта"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Атрибуты продукта"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Атрибуты ТМЦ"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Атрибут"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Значение"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Атрибуты"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Название используемое производителем"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Производитель"

--- a/product_manufacturer/i18n/ru.po
+++ b/product_manufacturer/i18n/ru.po
@@ -1,0 +1,72 @@
+# Russian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Russian <ru@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Код продукта у производителя"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Продукция"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Шаблон имени продукта"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Атрибуты продукта"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Атрибуты ТМЦ"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Атрибут"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Значение"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Атрибуты"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Название используемое производителем"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Производитель"

--- a/product_manufacturer/i18n/sl.po
+++ b/product_manufacturer/i18n/sl.po
@@ -1,0 +1,72 @@
+# Slovenian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-02-14 14:10+0000\n"
+"Last-Translator: Dušan Laznik (Mentis) <laznik@mentis.si>\n"
+"Language-Team: Slovenian <sl@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Dobaviteljeva koda izdelka"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Izdelek"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Ime predloge produkta"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Lasnosti izdelka"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Lasnosti izdelka"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Lastnost"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Vrednost"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Lastnosti"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Dobaviteljevo ime izdelka"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Proizvajalec"

--- a/product_manufacturer/i18n/sl.po
+++ b/product_manufacturer/i18n/sl.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Dobaviteljeva koda izdelka"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Izdelek"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Ime predloge produkta"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Lasnosti izdelka"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Lasnosti izdelka"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Lastnost"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Vrednost"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Lastnosti"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Dobaviteljevo ime izdelka"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Proizvajalec"

--- a/product_manufacturer/i18n/sr.po
+++ b/product_manufacturer/i18n/sr.po
@@ -1,0 +1,72 @@
+# Serbian translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Serbian <sr@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Proizvođačka šifra artikla"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Proizvod"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Naziv predloška proizvoda"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Atributi Proizvoda"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Atributi Proizvoda"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Atribut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Vrednost"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Aтрибути"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Proizvođačev Naziv Proizvoda"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Proizvođač"

--- a/product_manufacturer/i18n/sr.po
+++ b/product_manufacturer/i18n/sr.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Proizvođačka šifra artikla"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Proizvod"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Naziv predloška proizvoda"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Atributi Proizvoda"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Atributi Proizvoda"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Atribut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Vrednost"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Aтрибути"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Proizvođačev Naziv Proizvoda"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Proizvođač"

--- a/product_manufacturer/i18n/sr@latin.po
+++ b/product_manufacturer/i18n/sr@latin.po
@@ -1,0 +1,72 @@
+# Serbian Latin translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Serbian Latin <sr@latin@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Osobine Proizvoda"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr ""

--- a/product_manufacturer/i18n/sr@latin.po
+++ b/product_manufacturer/i18n/sr@latin.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr ""
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr ""
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Osobine Proizvoda"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr ""
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr ""
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr ""

--- a/product_manufacturer/i18n/sv.po
+++ b/product_manufacturer/i18n/sv.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Tillverkarens produktnummer"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Produkt"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Produktmallnamn"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Produktattribut"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Produktattribut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Attribut"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Värde"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Attribut"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Tillverkarens produktnamn"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Tillverkare"

--- a/product_manufacturer/i18n/sv.po
+++ b/product_manufacturer/i18n/sv.po
@@ -1,0 +1,72 @@
+# Swedish translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Swedish <sv@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Tillverkarens produktnummer"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Produkt"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Produktmallnamn"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Produktattribut"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Produktattribut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Attribut"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Värde"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Attribut"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Tillverkarens produktnamn"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Tillverkare"

--- a/product_manufacturer/i18n/tr.po
+++ b/product_manufacturer/i18n/tr.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "Üreticinin Ürün Kodu"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "Ürün"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "Ürün Şablonu Adı"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "Ürün öznitelikleri"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "Ürün Öznitelikleri"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "Öznitelik"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "Değer"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "Öznitelikler"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "Üreticinin Ürün Adı"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "Üretici"

--- a/product_manufacturer/i18n/tr.po
+++ b/product_manufacturer/i18n/tr.po
@@ -1,0 +1,72 @@
+# Turkish translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-02-26 16:20+0000\n"
+"Last-Translator: Ayhan KIZILTAN <Unknown>\n"
+"Language-Team: Turkish <tr@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "Üreticinin Ürün Kodu"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "Ürün"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "Ürün Şablonu Adı"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "Ürün öznitelikleri"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "Ürün Öznitelikleri"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "Öznitelik"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "Değer"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "Öznitelikler"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "Üreticinin Ürün Adı"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "Üretici"

--- a/product_manufacturer/i18n/zh_CN.po
+++ b/product_manufacturer/i18n/zh_CN.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr "制造商产品代码"
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr "产品"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr "产品模板名称"
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr "产品属性"
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr "产品属性"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr "属性"
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr "值"
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr "属性"
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr "制造商产品名称"
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr "制造商"

--- a/product_manufacturer/i18n/zh_CN.po
+++ b/product_manufacturer/i18n/zh_CN.po
@@ -1,0 +1,72 @@
+# Chinese (Simplified) translation for openobject-addons
+# Copyright (c) 2012 Rosetta Contributors and Canonical Ltd 2012
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2012-12-21 23:00+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr "制造商产品代码"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr "产品"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr "产品模板名称"
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr "产品属性"
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr "产品属性"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr "属性"
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr "值"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr "属性"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr "制造商产品名称"
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr "制造商"

--- a/product_manufacturer/i18n/zh_TW.po
+++ b/product_manufacturer/i18n/zh_TW.po
@@ -1,0 +1,72 @@
+# Chinese (Traditional) translation for openobject-addons
+# Copyright (c) 2013 Rosetta Contributors and Canonical Ltd 2013
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2013-06-07 19:37+0000\n"
+"PO-Revision-Date: 2013-02-01 04:37+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2013-11-21 06:27+0000\n"
+"X-Generator: Launchpad (build 16831)\n"
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pref:0
+msgid "Manufacturer Product Code"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_product
+#: field:product.manufacturer.attribute,product_id:0
+msgid "Product"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+msgid "Product Template Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
+msgid "Product attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.manufacturer.attribute:0
+#: view:product.template:0
+msgid "Product Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,name:0
+msgid "Attribute"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.manufacturer.attribute,value:0
+msgid "Value"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,attribute_ids:0
+msgid "Attributes"
+msgstr ""
+
+#. module: product_manufacturer
+#: field:product.template,manufacturer_pname:0
+msgid "Manufacturer Product Name"
+msgstr ""
+
+#. module: product_manufacturer
+#: view:product.template:0
+#: field:product.template,manufacturer:0
+msgid "Manufacturer"
+msgstr ""

--- a/product_manufacturer/i18n/zh_TW.po
+++ b/product_manufacturer/i18n/zh_TW.po
@@ -23,50 +23,12 @@ msgid "Manufacturer Product Code"
 msgstr ""
 
 #. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_product
-#: field:product.manufacturer.attribute,product_id:0
-msgid "Product"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-msgid "Product Template Name"
-msgstr ""
-
-#. module: product_manufacturer
-#: model:ir.model,name:product_manufacturer.model_product_manufacturer_attribute
-msgid "Product attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.manufacturer.attribute:0
-#: view:product.template:0
-msgid "Product Attributes"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,name:0
-msgid "Attribute"
-msgstr ""
-
-#. module: product_manufacturer
-#: field:product.manufacturer.attribute,value:0
-msgid "Value"
-msgstr ""
-
-#. module: product_manufacturer
-#: view:product.template:0
-#: field:product.template,attribute_ids:0
-msgid "Attributes"
-msgstr ""
-
-#. module: product_manufacturer
 #: field:product.template,manufacturer_pname:0
 msgid "Manufacturer Product Name"
 msgstr ""
 
 #. module: product_manufacturer
-#: view:product.template:0
+#: view:product.template:product_manufacturer.product_template_manufacturer_form_view
 #: field:product.template,manufacturer:0
 msgid "Manufacturer"
 msgstr ""

--- a/product_manufacturer/models/__init__.py
+++ b/product_manufacturer/models/__init__.py
@@ -1,0 +1,20 @@
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import product_manufacturer

--- a/product_manufacturer/models/product_manufacturer.py
+++ b/product_manufacturer/models/product_manufacturer.py
@@ -27,15 +27,3 @@ class ProductTemplate(models.Model):
     manufacturer = fields.Many2one('res.partner', 'Manufacturer')
     manufacturer_pname = fields.Char('Manufacturer Product Name')
     manufacturer_pref = fields.Char('Manufacturer Product Code')
-    manufacturer_attribute_ids = fields.One2many(
-        'product.manufacturer.attribute', 'product_id', 'Attributes')
-
-
-class ProductAttribute(models.Model):
-    _name = "product.manufacturer.attribute"
-    _description = "Product attributes"
-
-    name = fields.Char('Attribute', required=True)
-    value = fields.Char('Value')
-    product_id = fields.Many2one('product.template', 'Product',
-                                 ondelete='cascade')

--- a/product_manufacturer/models/product_manufacturer.py
+++ b/product_manufacturer/models/product_manufacturer.py
@@ -27,8 +27,8 @@ class ProductTemplate(models.Model):
     manufacturer = fields.Many2one('res.partner', 'Manufacturer')
     manufacturer_pname = fields.Char('Manufacturer Product Name')
     manufacturer_pref = fields.Char('Manufacturer Product Code')
-    manufacturer_attribute_ids = fields.One2many('product.manufacturer.attribute',
-                                    'product_id', 'Attributes')
+    manufacturer_attribute_ids = fields.One2many(
+        'product.manufacturer.attribute', 'product_id', 'Attributes')
 
 
 class ProductAttribute(models.Model):

--- a/product_manufacturer/models/product_manufacturer.py
+++ b/product_manufacturer/models/product_manufacturer.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
     manufacturer = fields.Many2one('res.partner', 'Manufacturer')
     manufacturer_pname = fields.Char('Manufacturer Product Name')
     manufacturer_pref = fields.Char('Manufacturer Product Code')
-    attribute_ids = fields.One2many('product.manufacturer.attribute',
+    manufacturer_attribute_ids = fields.One2many('product.manufacturer.attribute',
                                     'product_id', 'Attributes')
 
 
@@ -37,5 +37,5 @@ class ProductAttribute(models.Model):
 
     name = fields.Char('Attribute', required=True)
     value = fields.Char('Value')
-    product_id = fields.Many2one('product.product', 'Product',
+    product_id = fields.Many2one('product.template', 'Product',
                                  ondelete='cascade')

--- a/product_manufacturer/models/product_manufacturer.py
+++ b/product_manufacturer/models/product_manufacturer.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    manufacturer = fields.Many2one('res.partner', 'Manufacturer')
+    manufacturer_pname = fields.Char('Manufacturer Product Name')
+    manufacturer_pref = fields.Char('Manufacturer Product Code')
+    attribute_ids = fields.One2many('product.manufacturer.attribute',
+                                    'product_id', 'Attributes')
+
+
+class ProductAttribute(models.Model):
+    _name = "product.manufacturer.attribute"
+    _description = "Product attributes"
+
+    name = fields.Char('Attribute', required=True)
+    value = fields.Char('Value')
+    product_id = fields.Many2one('product.product', 'Product',
+                                 ondelete='cascade')

--- a/product_manufacturer/security/ir.model.access.csv
+++ b/product_manufacturer/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_manufacturer_attribute,product.manufacturer.attribute,model_product_manufacturer_attribute,base.group_user,1,1,1,1

--- a/product_manufacturer/security/ir.model.access.csv
+++ b/product_manufacturer/security/ir.model.access.csv
@@ -1,2 +1,0 @@
-id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_product_manufacturer_attribute,product.manufacturer.attribute,model_product_manufacturer_attribute,base.group_user,1,1,1,1

--- a/product_manufacturer/views/product_manufacturer_view.xml
+++ b/product_manufacturer/views/product_manufacturer_view.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="product.product_template_manufacturer_form_view">
+            <field name="name">product.template.manufacturer.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view" />
+            <field name="arch" type="xml">
+                <group name="procurement" position="inside">
+                    <group string="Manufacturer">
+                        <field name="manufacturer" context="{'default_supplier':True, 'default_customer':False}"/>
+                        <field name="manufacturer_pname"/>
+                        <field name="manufacturer_pref"/>
+                    </group>
+                    <group string="Attributes">
+                        <field name="attribute_ids" colspan="4" nolabel="1">
+                            <tree string="Product Attributes" editable="bottom">
+                                <field name="name"/>
+                                <field name="value"/>
+                            </tree>
+                        </field>
+                    </group>
+                </group>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_manufacturer_attribute_tree_view">
+            <field name="name">product.manufacturer.attribute.tree</field>
+            <field name="model">product.manufacturer.attribute</field>
+            <field name="arch" type="xml">
+                <tree string="Product Attributes" editable="bottom">
+                    <field name="name"/>
+                    <field name="value"/>
+                </tree>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="product_manufacturer_attribute_form_view">
+            <field name="name">product.manufacturer.attribute.form</field>
+            <field name="model">product.manufacturer.attribute</field>
+            <field name="arch" type="xml">
+                <form string="Product Template Name" version="7.0">
+                    <group>
+                        <field name="name"/>
+                        <field name="value"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+

--- a/product_manufacturer/views/product_manufacturer_view.xml
+++ b/product_manufacturer/views/product_manufacturer_view.xml
@@ -14,7 +14,7 @@
                         <field name="manufacturer_pref"/>
                     </group>
                     <group string="Attributes">
-                        <field name="attribute_ids" colspan="4" nolabel="1">
+                        <field name="manufacturer_attribute_ids" colspan="4" nolabel="1">
                             <tree string="Product Attributes" editable="bottom">
                                 <field name="name"/>
                                 <field name="value"/>

--- a/product_manufacturer/views/product_manufacturer_view.xml
+++ b/product_manufacturer/views/product_manufacturer_view.xml
@@ -7,7 +7,7 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field name="arch" type="xml">
-                <group name="procurement" position="inside">
+                <xpath expr="//page[@string='Procurements']/group[@name='procurement']" position="inside">
                     <group string="Manufacturer">
                         <field name="manufacturer" context="{'default_supplier':True, 'default_customer':False}"/>
                         <field name="manufacturer_pname"/>
@@ -21,7 +21,7 @@
                             </tree>
                         </field>
                     </group>
-                </group>
+                </xpath>
             </field>
         </record>
 

--- a/product_manufacturer/views/product_manufacturer_view.xml
+++ b/product_manufacturer/views/product_manufacturer_view.xml
@@ -7,44 +7,13 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field name="arch" type="xml">
-                <xpath expr="//group[@name='procurement_uom']" position="after">
+                <group name="procurement" position="inside">
                     <group string="Manufacturer">
                         <field name="manufacturer" context="{'default_supplier':True, 'default_customer':False}"/>
                         <field name="manufacturer_pname"/>
                         <field name="manufacturer_pref"/>
                     </group>
-                    <group string="Attributes">
-                        <field name="manufacturer_attribute_ids" colspan="4" nolabel="1">
-                            <tree string="Product Attributes" editable="bottom">
-                                <field name="name"/>
-                                <field name="value"/>
-                            </tree>
-                        </field>
-                    </group>
-                </xpath>
-            </field>
-        </record>
-
-        <record model="ir.ui.view" id="product_manufacturer_attribute_tree_view">
-            <field name="name">product.manufacturer.attribute.tree</field>
-            <field name="model">product.manufacturer.attribute</field>
-            <field name="arch" type="xml">
-                <tree string="Product Attributes" editable="bottom">
-                    <field name="name"/>
-                    <field name="value"/>
-                </tree>
-            </field>
-        </record>
-        <record model="ir.ui.view" id="product_manufacturer_attribute_form_view">
-            <field name="name">product.manufacturer.attribute.form</field>
-            <field name="model">product.manufacturer.attribute</field>
-            <field name="arch" type="xml">
-                <form string="Product Template Name" version="7.0">
-                    <group>
-                        <field name="name"/>
-                        <field name="value"/>
-                    </group>
-                </form>
+                </group>
             </field>
         </record>
 

--- a/product_manufacturer/views/product_manufacturer_view.xml
+++ b/product_manufacturer/views/product_manufacturer_view.xml
@@ -7,7 +7,7 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field name="arch" type="xml">
-                <xpath expr="//page[@string='Procurements']/group[@name='procurement']" position="inside">
+                <xpath expr="//group[@name='procurement_uom']" position="after">
                     <group string="Manufacturer">
                         <field name="manufacturer" context="{'default_supplier':True, 'default_customer':False}"/>
                         <field name="manufacturer_pname"/>

--- a/product_manufacturer/views/product_manufacturer_view.xml
+++ b/product_manufacturer/views/product_manufacturer_view.xml
@@ -2,10 +2,10 @@
 <openerp>
     <data>
 
-        <record model="ir.ui.view" id="product.product_template_manufacturer_form_view">
+        <record model="ir.ui.view" id="product_template_manufacturer_form_view">
             <field name="name">product.template.manufacturer.form</field>
             <field name="model">product.template</field>
-            <field name="inherit_id" ref="product.product_template_form_view" />
+            <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
                 <group name="procurement" position="inside">
                     <group string="Manufacturer">


### PR DESCRIPTION
Hello,

Odoo has removed this module from 8.0. For my installations is useful, so I have migrated to the new API.

I think that can be useful for someone, so I request to add to the community repository.

Greetings,
Ignacio Ibeas
