### PR TITLE
Product brand improvements

### DIFF
--- a/product_brand/README.rst
+++ b/product_brand/README.rst
@@ -1,5 +1,5 @@
-Product Brand Manage [product_brand]
-===========
+Product Brand Manager [product_brand]
+=====================================
 
 This module allows odoo users to easily manage product brands. You can
 define brands, attach a logo and a description to them. 
@@ -44,11 +44,11 @@ Credits
 Contributors
 ------------
 
-Mathieu Lemercier <mathieu@netandco.net>
-Franck Bret <franck@netandco.net>
-Seraphine Lantible <s.lantible@gmail.com>
-Gunnar Wagner <vrms@netcologne.de>
-Leonardo Donelli <donelli@webmonks.it>
+* Mathieu Lemercier <mathieu@netandco.net>
+* Franck Bret <franck@netandco.net>
+* Seraphine Lantible <s.lantible@gmail.com>
+* Gunnar Wagner <vrms@netcologne.de>
+* Leonardo Donelli <donelli@webmonks.it>
 
 Maintainer
 ----------

--- a/product_brand/README.rst
+++ b/product_brand/README.rst
@@ -35,7 +35,6 @@ For further information, please visit:
 Known issues / Roadmap
 ======================
 
-* A view to list or sort products by brand
 * add a field with brands assiciated to a Customer or Supplier on 
   the Customers/Suppliers Form View
 
@@ -49,6 +48,7 @@ Mathieu Lemercier <mathieu@netandco.net>
 Franck Bret <franck@netandco.net>
 Seraphine Lantible <s.lantible@gmail.com>
 Gunnar Wagner <vrms@netcologne.de>
+Leonardo Donelli <donelli@webmonks.it>
 
 Maintainer
 ----------

--- a/product_brand/__openerp__.py
+++ b/product_brand/__openerp__.py
@@ -32,7 +32,7 @@
     'name': 'Product Brand Manager',
     'version': '0.1',
     'category': 'Product',
-    'summary': ' brand',
+    'summary': 'Add brand to products',
     'author': 'NetAndCo, Akretion, Prisnet Telecommunications SA'
               ', MONK Software, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
@@ -40,6 +40,6 @@
     'data': [
         'product_brand_view.xml',
         'security/ir.model.access.csv'
-        ],
+    ],
     'installable': True,
 }

--- a/product_brand/__openerp__.py
+++ b/product_brand/__openerp__.py
@@ -33,9 +33,8 @@
     'version': '0.1',
     'category': 'Product',
     'summary': ' brand',
-    'author': "NetAndCo, Akretion,"
-              "Prisnet Telecommunications SA,"
-              "Odoo Community Association (OCA)",
+    'author': 'NetAndCo, Akretion, Prisnet Telecommunications SA'
+              ', MONK Software, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': ['product'],
     'data': [

--- a/product_brand/product_brand.py
+++ b/product_brand/product_brand.py
@@ -33,6 +33,16 @@ from openerp.osv import orm, fields
 
 class product_brand(orm.Model):
     _name = 'product.brand'
+
+    def _get_products_count(self, cr, uid, ids, fields, arg, context=None):
+        product_model = self.pool['product.template']
+        res = {}
+        for brand in self.browse(cr, uid, ids, context=context):
+            n_products = product_model.search(
+                cr, uid, [('product_brand_id', '=', brand.id)], count=True)
+            res[brand.id] = n_products
+        return res
+
     _columns = {
         'name': fields.char('Brand Name'),
         'description': fields.text('Description', translate=True),
@@ -42,6 +52,11 @@ class product_brand(orm.Model):
             ondelete='restrict'
         ),
         'logo': fields.binary('Logo File'),
+        'products_count': fields.function(
+            _get_products_count,
+            string='Branded Products',
+            type='integer',
+        ),
     }
 
 

--- a/product_brand/product_brand.py
+++ b/product_brand/product_brand.py
@@ -36,7 +36,7 @@ from openerp import models, fields, api
 class ProductBrand(models.Model):
     _name = 'product.brand'
 
-    name = fields.Char('Brand Name')
+    name = fields.Char('Brand Name', required=True)
     description = fields.Text('Description', translate=True)
     partner_id = fields.Many2one(
         'res.partner',

--- a/product_brand/product_brand.py
+++ b/product_brand/product_brand.py
@@ -1,70 +1,66 @@
 # -*- encoding: utf-8 -*-
 ###############################################################################
-# #                                                                           #
-# product_brand for Odoo #                                                    #
-# Copyright (C) 2009 NetAndCo (<http://www.netandco.net>). #                  #
-# Copyright (C) 2011 Akretion Benoît Guillot <benoit.guillot@akretion.com> #  #
-# Copyright (C) 2014 prisnet.ch Seraphine Lantible <s.lantible@gmail.com> #   #
+#                                                                             #
+# product_brand for Odoo                                                      #
+# Copyright (C) 2009 NetAndCo (<http://www.netandco.net>).                    #
+# Copyright (C) 2011 Akretion Benoît Guillot <benoit.guillot@akretion.com>    #
+# Copyright (C) 2014 prisnet.ch Seraphine Lantible <s.lantible@gmail.com>     #
+# Copyright (C) 2015 Leonardo Donelli                                         #
 # Contributors                                                                #
-# Mathieu Lemercier, mathieu@netandco.net, #                                  #
-# Franck Bret, franck@netandco.net #                                          #
+# Mathieu Lemercier, mathieu@netandco.net                                     #
+# Franck Bret, franck@netandco.net                                            #
 # Seraphine Lantible, s.lantible@gmail.com, http://www.prisnet.ch             #
-# #                                                                           #
-# This program is free software: you can redistribute it and/or modify #      #
-# it under the terms of the GNU Affero General Public License as #            #
-# published by the Free Software Foundation, either version 3 of the #        #
-# License, or (at your option) any later version. #                           #
-# #                                                                           #
-# This program is distributed in the hope that it will be useful, #           #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of #            #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the #              #
-# GNU Affero General Public License for more details. #                       #
-# #                                                                           #
-# You should have received a copy of the GNU Affero General Public License #  #
-# along with this program. If not, see <http://www.gnu.org/licenses/>. #      #
-# #                                                                           #
+# Leonardo Donelli, donelli@webmonks.it, http://www.wearemonk.com             #
+#                                                                             #
+# This program is free software: you can redistribute it and/or modify        #
+# it under the terms of the GNU Affero General Public License as              #
+# published by the Free Software Foundation, either version 3 of the          #
+# License, or (at your option) any later version.                             #
+#                                                                             #
+# This program is distributed in the hope that it will be useful,             #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                #
+# GNU Affero General Public License for more details.                         #
+#                                                                             #
+# You should have received a copy of the GNU Affero General Public License    #
+# along with this program. If not, see <http://www.gnu.org/licenses/>.        #
+#                                                                             #
 ###############################################################################
 ###############################################################################
 # Product Brand is an Openobject module wich enable Brand management for      #
 # products                                                                    #
 ###############################################################################
-from openerp.osv import orm, fields
+from openerp import models, fields
 
 
-class product_brand(orm.Model):
+class ProductBrand(models.Model):
     _name = 'product.brand'
 
-    def _get_products_count(self, cr, uid, ids, fields, arg, context=None):
-        product_model = self.pool['product.template']
-        res = {}
-        for brand in self.browse(cr, uid, ids, context=context):
-            n_products = product_model.search(
-                cr, uid, [('product_brand_id', '=', brand.id)], count=True)
-            res[brand.id] = n_products
-        return res
+    name = fields.Char('Brand Name')
+    description = fields.Text('Description', translate=True)
+    partner_id = fields.Many2one(
+        'res.partner',
+        string='Partner',
+        help='Select a partner for this brand if it exists',
+        ondelete='restrict'
+    )
+    logo = fields.Binary('Logo File')
+    products_count = fields.Integer(
+        string='Number of products',
+        compute='_get_products_count',
+    )
 
-    _columns = {
-        'name': fields.char('Brand Name'),
-        'description': fields.text('Description', translate=True),
-        'partner_id': fields.many2one(
-            'res.partner', 'partner',
-            help='Select a partner for this brand if it exists.',
-            ondelete='restrict'
-        ),
-        'logo': fields.binary('Logo File'),
-        'products_count': fields.function(
-            _get_products_count,
-            string='Branded Products',
-            type='integer',
-        ),
-    }
+    def _get_products_count(self):
+        for brand in self:
+            brand.products_count = self.env['product.template'].search_count(
+                [('product_brand_id', '=', brand.id)]
+            )
 
-
-class product_template(orm.Model):
+class ProductTemplate(models.Model):
     _inherit = 'product.template'
-    _columns = {
-        'product_brand_id': fields.many2one(
-            'product.brand', 'Brand',
-            help='Select a brand for this product.'
-        ),
-    }
+
+    product_brand_id = fields.Many2one(
+        'product.brand',
+        string='Brand',
+        help='Select a brand for this product'
+    )

--- a/product_brand/product_brand.py
+++ b/product_brand/product_brand.py
@@ -30,7 +30,7 @@
 # Product Brand is an Openobject module wich enable Brand management for      #
 # products                                                                    #
 ###############################################################################
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class ProductBrand(models.Model):
@@ -45,16 +45,21 @@ class ProductBrand(models.Model):
         ondelete='restrict'
     )
     logo = fields.Binary('Logo File')
+    product_ids = fields.One2many(
+        'product.template',
+        'product_brand_id',
+        string='Brand Products',
+    )
     products_count = fields.Integer(
         string='Number of products',
         compute='_get_products_count',
     )
 
+    @api.one
+    @api.depends('product_ids')
     def _get_products_count(self):
-        for brand in self:
-            brand.products_count = self.env['product.template'].search_count(
-                [('product_brand_id', '=', brand.id)]
-            )
+        self.products_count = len(self.product_ids)
+
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -95,6 +95,7 @@
                 <kanban>
                     <field name="logo"/>
                     <field name="products_count"/>
+                    <field name="description"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_vignette oe_semantic_html_override">
@@ -114,7 +115,12 @@
                                             <t t-esc="record.products_count.value"/> Products
                                         </a>
                                     </div>
-                                    <field name="description"/>
+                                    <span>
+                                        <t t-esc="record.description.value.substr(0,200)"/>
+                                        <t t-if="record.description.value.length > 200">
+                                            <a type="open"><b>...</b></a>
+                                        </t>
+                                    </span>
                                 </div>
                             </div>
                         </t>

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -19,6 +19,14 @@
             </field>
         </record>
 
+        <act_window
+            id="action_open_brand_products"
+            name="Brand Products"
+            res_model="product.template"
+            view_type="form"
+            view_mode="tree,form"
+            domain="[('product_brand_id', '=', active_id)]"/>
+
         <record model="ir.ui.view" id="view_product_brand_form">
             <field name="name">product.brand.form</field>
             <field name="model">product.brand</field>
@@ -33,6 +41,15 @@
                         <h1>
                           <field name="name"/>
                         </h1>
+                      </div>
+                      <div class="oe_right oe_button_box">
+                        <button
+                            class="oe_inline oe_stat_button"
+                            type="action"
+                            name="%(action_open_brand_products)d"
+                            icon="fa-cubes">
+                          <field name="products_count" string="Products" widget="statinfo" />
+                        </button>
                       </div>
                       <group>
                         <field name="partner_id"/>
@@ -89,6 +106,10 @@
             <field name="view_mode">tree,form</field>
         </record>
 
-        <menuitem name="Brand management" id="menu_product_brand" action="action_product_brand" parent="product.prod_config_main"/>
+        <menuitem
+            name="Product Brands"
+            id="menu_product_brand"
+            action="action_product_brand"
+            parent="base.menu_product"/>
     </data>
 </openerp>

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -24,10 +24,10 @@
             name="Brand Products"
             res_model="product.template"
             view_type="form"
-            view_mode="tree,form"
+            view_mode="kanban,form,tree"
             domain="[('product_brand_id', '=', active_id)]"/>
 
-        <record model="ir.ui.view" id="view_product_brand_form">
+        <record id="view_product_brand_form" model="ir.ui.view">
             <field name="name">product.brand.form</field>
             <field name="model">product.brand</field>
             <field name="arch" type="xml">
@@ -62,7 +62,7 @@
             </field>
         </record>
 
-        <record model="ir.ui.view" id="view_product_brand_tree">
+        <record id="view_product_brand_tree" model="ir.ui.view">
             <field name="name">product.brand.tree</field>
             <field name="model">product.brand</field>
             <field name="arch" type="xml">
@@ -71,6 +71,41 @@
                     <field name="description"/>
                     <field name="partner_id"/>
                 </tree>
+            </field>
+        </record>
+
+        <record id="view_product_brand_kanban" model="ir.ui.view">
+            <field name="name">product.brand.kanban</field>
+            <field name="model">product.brand</field>
+            <field name="arch" type="xml">
+                <kanban>
+                    <field name="logo"/>
+                    <field name="products_count"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_vignette oe_semantic_html_override">
+                                <a type="open">
+                                  <img t-att-src="kanban_image('product.product', 'logo', record.id.value)"
+                                       class="oe_kanban_image"/>
+                                </a>
+                                <div class="oe_kanban_details">
+                                    <h4>
+                                        <a type="open">
+                                            <field name="name"/>
+                                        </a>
+                                    </h4>
+                                    <div>
+                                      <a name="%(product_brand.action_open_brand_products)d"
+                                         type="action">
+                                        <t t-esc="record.products_count.value"/> Products
+                                      </a>
+                                    </div>
+                                    <field name="description"/>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
             </field>
         </record>
 
@@ -88,7 +123,7 @@
             </field>
         </record>
 
-         <record model="ir.ui.view" id="product_template_form_brand_add">
+         <record id="product_template_form_brand_add" model="ir.ui.view">
             <field name="name">product.template.product.form</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
@@ -155,7 +190,7 @@
             <field name="name">Brand</field>
             <field name="res_model">product.brand</field>
             <field name="view_type">form</field>
-            <field name="view_mode">tree,form</field>
+            <field name="view_mode">kanban,form,tree</field>
         </record>
 
         <menuitem

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -99,6 +99,32 @@
               </field>
         </record>
 
+         <record id="view_product_template_kanban_brand" model="ir.ui.view">
+            <field name="name">product kanban view: add brand</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_kanban_view" />
+            <field name="arch" type="xml">
+                <xpath expr="//h4" position="after">
+                  <div>
+                    <a t-if="record.product_brand_id" name="fds" type="action">
+                      <field name="product_brand_id"/>
+                    </a>
+                  </div>
+                </xpath>
+              </field>
+        </record>
+
+         <record id="view_product_template_tree_brand" model="ir.ui.view">
+            <field name="name">product tree view: add brand</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_tree_view" />
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                  <field name="product_brand_id"/>
+                </field>
+              </field>
+        </record>
+
         <record model="ir.actions.act_window" id="action_product_brand">
             <field name="name">Brand</field>
             <field name="res_model">product.brand</field>

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -3,8 +3,13 @@
   product_brand for Odoo
   Copyright (C) 2009 NetAndCo <http://www.netandco.net>.
   Copyright (C) 2011 Akretion Benoît Guillot <benoit.guillot@akretion.com>
-  Copyright (C) 2014 prisnet.ch Seraphine Lantible <s.lantible@gmail.com> 
-    Contributors, Mathieu Lemercier <mathieu@netandco.net>, Franck Bret <franck@netandco.net>, Seraphine Lantible <s.lantible@gmail.com>
+  Copyright (C) 2014 prisnet.ch Seraphine Lantible <s.lantible@gmail.com>
+  Copyright (C) 2015 Leonardo Donelli <http://www.wearemonk.com>
+  Contributors:
+  Mathieu Lemercier <mathieu@netandco.net>
+  Franck Bret <franck@netandco.net>
+  Seraphine Lantible <s.lantible@gmail.com>
+  Leonardo Donelli <donelli@webmonks.it>
 -->
 <openerp>
     <data>
@@ -13,8 +18,8 @@
             <field name="model">product.brand</field>
             <field name="arch" type="xml">
                 <search string="Product Brand">
-                   <field name="name"/>
-                   <field name="partner_id"/>
+                    <field name="name"/>
+                    <field name="partner_id"/>
                 </search>
             </field>
         </record>
@@ -27,37 +32,46 @@
             view_mode="kanban,form,tree"
             domain="[('product_brand_id', '=', active_id)]"/>
 
+        <act_window
+            id="action_open_single_product_brand"
+            name="Product Brand"
+            res_model="product.brand"
+            view_type="form"
+            view_mode="kanban,form,tree"
+            target="current"
+            domain="[('product_ids', 'in', active_id)]"/>
+
         <record id="view_product_brand_form" model="ir.ui.view">
             <field name="name">product.brand.form</field>
             <field name="model">product.brand</field>
             <field name="arch" type="xml">
                 <form string="Product Brand" version="7.0">
-                  <sheet>
-                      <field name="logo" widget="image" class="oe_avatar oe_left"/>
-                      <div class="oe_title">
-                        <div class="oe_edit_only">
-                          <label for="name" string="Brand Name"/>
+                    <sheet>
+                        <field name="logo" widget="image" class="oe_avatar oe_left"/>
+                        <div class="oe_title">
+                            <div class="oe_edit_only">
+                                <label for="name" string="Brand Name"/>
+                            </div>
+                            <h1>
+                                <field name="name"/>
+                            </h1>
                         </div>
-                        <h1>
-                          <field name="name"/>
-                        </h1>
-                      </div>
-                      <div class="oe_right oe_button_box">
-                        <button
-                            class="oe_inline oe_stat_button"
-                            type="action"
-                            name="%(action_open_brand_products)d"
-                            icon="fa-cubes">
-                          <field name="products_count" string="Products" widget="statinfo" />
-                        </button>
-                      </div>
-                      <group>
-                        <field name="partner_id"/>
-                      </group>
-                      <group string="Description">
-                        <field name="description" nolabel="1"/>
-                      </group>
-                  </sheet>
+                        <div class="oe_right oe_button_box">
+                            <button
+                                class="oe_inline oe_stat_button"
+                                type="action"
+                                name="%(action_open_brand_products)d"
+                                icon="fa-cubes">
+                                <field name="products_count" string="Products" widget="statinfo" />
+                            </button>
+                        </div>
+                        <group>
+                            <field name="partner_id"/>
+                        </group>
+                        <group string="Description">
+                            <field name="description" nolabel="1"/>
+                        </group>
+                    </sheet>
                 </form>
             </field>
         </record>
@@ -85,8 +99,8 @@
                         <t t-name="kanban-box">
                             <div class="oe_kanban_vignette oe_semantic_html_override">
                                 <a type="open">
-                                  <img t-att-src="kanban_image('product.product', 'logo', record.id.value)"
-                                       class="oe_kanban_image"/>
+                                    <img t-att-src="kanban_image('product.product', 'logo', record.id.value)"
+                                         class="oe_kanban_image"/>
                                 </a>
                                 <div class="oe_kanban_details">
                                     <h4>
@@ -95,10 +109,10 @@
                                         </a>
                                     </h4>
                                     <div>
-                                      <a name="%(product_brand.action_open_brand_products)d"
-                                         type="action">
-                                        <t t-esc="record.products_count.value"/> Products
-                                      </a>
+                                        <a name="%(product_brand.action_open_brand_products)d"
+                                           type="action">
+                                            <t t-esc="record.products_count.value"/> Products
+                                        </a>
                                     </div>
                                     <field name="description"/>
                                 </div>
@@ -139,67 +153,68 @@
             </field>
         </record>
 
-         <record id="product_template_form_brand_add" model="ir.ui.view">
+        <record id="product_template_form_brand_add" model="ir.ui.view">
             <field name="name">product.template.product.form</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field name="arch" type="xml">
                 <field name="name" position="after"  >
-                  <field name="product_brand_id" placeholder="Brand"/>
+                    <field name="product_brand_id" placeholder="Brand"/>
                 </field>
-              </field>
+            </field>
         </record>
 
-         <record id="view_product_template_kanban_brand" model="ir.ui.view">
+        <record id="view_product_template_kanban_brand" model="ir.ui.view">
             <field name="name">product kanban view: add brand</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_kanban_view" />
             <field name="arch" type="xml">
                 <xpath expr="//h4" position="after">
-                  <div>
-                    <a t-if="record.product_brand_id" name="fds" type="action">
-                      <field name="product_brand_id"/>
-                    </a>
-                  </div>
+                    <div>
+                        <a t-if="record.product_brand_id" type="action"
+                           name="%(action_open_single_product_brand)d">
+                            <field name="product_brand_id"/>
+                        </a>
+                    </div>
                 </xpath>
-              </field>
+            </field>
         </record>
 
-         <record id="view_product_variant_kanban_brand" model="ir.ui.view">
+        <record id="view_product_variant_kanban_brand" model="ir.ui.view">
             <field name="name">product variant kanban view: add brand</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_kanban_view" />
             <field name="arch" type="xml">
                 <xpath expr="//h4" position="after">
-                  <div>
-                    <a t-if="record.product_brand_id" name="fds" type="action">
-                      <field name="product_brand_id"/>
-                    </a>
-                  </div>
+                    <div>
+                        <a t-if="record.product_brand_id" type="open">
+                            <field name="product_brand_id"/>
+                        </a>
+                    </div>
                 </xpath>
-              </field>
+            </field>
         </record>
 
-         <record id="view_product_template_tree_brand" model="ir.ui.view">
+        <record id="view_product_template_tree_brand" model="ir.ui.view">
             <field name="name">product tree view: add brand</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_tree_view" />
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                  <field name="product_brand_id"/>
+                    <field name="product_brand_id"/>
                 </field>
-              </field>
+            </field>
         </record>
 
-         <record id="view_product_variant_tree_brand" model="ir.ui.view">
+        <record id="view_product_variant_tree_brand" model="ir.ui.view">
             <field name="name">product variant tree view: add brand</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_product_tree_view" />
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                  <field name="product_brand_id"/>
+                    <field name="product_brand_id"/>
                 </field>
-              </field>
+            </field>
         </record>
 
         <record model="ir.actions.act_window" id="action_product_brand">

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -118,7 +118,23 @@
                     <field name="product_brand_id"/>
                 </field>
                 <group string='Group by...' position="inside">
-                    <filter string="Brand" name="groupby_brand" domain="[]" context="{'group_by' : 'product_brand_id'}"/>
+                    <filter string="Brand" name="groupby_brand" domain="[]"
+                            context="{'group_by' : 'product_brand_id'}"/>
+                </group>
+            </field>
+        </record>
+
+        <record id="view_product_template_search_brand" model="ir.ui.view">
+            <field name="name">product.template.search.brand</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_search_view"/>
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field name="product_brand_id"/>
+                </field>
+                <group string='Group by...' position="inside">
+                    <filter string="Brand" name="groupby_brand" domain="[]"
+                            context="{'group_by' : 'product_brand_id'}"/>
                 </group>
             </field>
         </record>

--- a/product_brand/product_brand_view.xml
+++ b/product_brand/product_brand_view.xml
@@ -114,10 +114,36 @@
               </field>
         </record>
 
+         <record id="view_product_variant_kanban_brand" model="ir.ui.view">
+            <field name="name">product variant kanban view: add brand</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_kanban_view" />
+            <field name="arch" type="xml">
+                <xpath expr="//h4" position="after">
+                  <div>
+                    <a t-if="record.product_brand_id" name="fds" type="action">
+                      <field name="product_brand_id"/>
+                    </a>
+                  </div>
+                </xpath>
+              </field>
+        </record>
+
          <record id="view_product_template_tree_brand" model="ir.ui.view">
             <field name="name">product tree view: add brand</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_tree_view" />
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                  <field name="product_brand_id"/>
+                </field>
+              </field>
+        </record>
+
+         <record id="view_product_variant_tree_brand" model="ir.ui.view">
+            <field name="name">product variant tree view: add brand</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_product_tree_view" />
             <field name="arch" type="xml">
                 <field name="name" position="after">
                   <field name="product_brand_id"/>

--- a/product_brand/security/ir.model.access.csv
+++ b/product_brand/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_product_brand_product_manager","product.brand","model_product_brand","base.group_partner_manager",1,1,1,1
+"access_product_brand_public","product.brand.public","model_product_brand",,1,0,0,0


### PR DESCRIPTION
Various improvements to the product_brand module:
- Show brand in kanban and tree views of both `product.template` and `product.product`
- Rename the brands menu and move it in the Products menu (`base.menu_product`) where it's more visible
- Create smart button for brands with products count and action to open the brand's products
- Create kanban view for brand and show that by default
