### PR TITLE
[ADD] modules to restrict the users that can view the product cost.

### DIFF
--- a/product_cost_security/__init__.py
+++ b/product_cost_security/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#             <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/product_cost_security/__openerp__.py
+++ b/product_cost_security/__openerp__.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#             <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Product Cost Security',
+    'version': '1.0',
+    'author': 'Eficent',
+    "website": "www.eficent.com",
+    'category': 'Products',
+    'depends': ['product'],
+    'demo': [],
+    'description': """
+Product Cost Security
+=====================
+This module adds a new user group "Display product cost". The module itself
+will not apply the restriction, but needs to be complemented with a module
+that actually implements the restriction in a view, such as:
+- product_standard_price_visible
+- stock_standard_price_visible
+
+
+Installation
+============
+
+No specific installation steps are required.
+
+Configuration
+=============
+
+No specific configuration steps are required.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+
+Known issues / Roadmap
+======================
+
+No issues have been identified with this module.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+    """,
+    'data': [
+        'security/product_security.xml',
+    ],
+    'auto_install': False,
+    'installable': True,
+    'images': [],
+}

--- a/product_cost_security/i18n/es.po
+++ b/product_cost_security/i18n/es.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-14 12:38+0000\n"
+"PO-Revision-Date: 2015-05-14 14:38+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: product_cost_security
+#: model:res.groups,name:product_cost_security.group_product_standard_price_visible
+msgid "Display product cost"
+msgstr "Mostrar coste del producto"

--- a/product_cost_security/i18n/product_cost_security.po
+++ b/product_cost_security/i18n/product_cost_security.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-14 12:37+0000\n"
+"PO-Revision-Date: 2015-05-14 12:37+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_cost_security
+#: model:res.groups,name:product_cost_security.group_product_standard_price_visible
+msgid "Display product cost"
+msgstr ""
+

--- a/product_cost_security/security/product_security.xml
+++ b/product_cost_security/security/product_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data noupdate="0">
+
+    <record id="group_product_standard_price_visible" model="res.groups">
+        <field name="name">Display product cost</field>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    </record>
+
+</data>
+</openerp>

--- a/product_standard_price_visible/__init__.py
+++ b/product_standard_price_visible/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#             <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/product_standard_price_visible/__openerp__.py
+++ b/product_standard_price_visible/__openerp__.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#             <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Product Standard Price Visible',
+    'version': '1.0',
+    'author': 'Eficent',
+    "website": "www.eficent.com",
+    'category': 'Products',
+    'depends': ['product', 'product_cost_security'],
+    'demo': [],
+    'description': """
+Product Standard Price Visible
+==============================
+This module restricts the visibility of the field 'cost' associated to the
+product only to users that belong to the group 'Display product cost'.
+
+Installation
+============
+
+No specific installation steps are required.
+
+Configuration
+=============
+
+No specific configuration steps are required.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+
+Known issues / Roadmap
+======================
+
+No issues have been identified with this module.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Moises Lopez <moylop260@vauxoo.com>
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+    """,
+    'data': [
+        'view/product.xml',        
+    ],
+    'auto_install': False,
+    'installable': True,
+    'images': [],
+}

--- a/product_standard_price_visible/i18n/es.po
+++ b/product_standard_price_visible/i18n/es.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-14 12:40+0000\n"
+"PO-Revision-Date: 2015-05-14 12:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_standard_price_visible
+#: view:product.product:0
+msgid "product_cost_security.product_standard_price_visible"
+msgstr "product_cost_security.product_standard_price_visible"
+

--- a/product_standard_price_visible/i18n/product_standard_price_visible.po
+++ b/product_standard_price_visible/i18n/product_standard_price_visible.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-14 12:39+0000\n"
+"PO-Revision-Date: 2015-05-14 12:39+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_standard_price_visible
+#: view:product.product:0
+msgid "product_cost_security.product_standard_price_visible"
+msgstr ""
+

--- a/product_standard_price_visible/model/__init__.py
+++ b/product_standard_price_visible/model/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import product

--- a/product_standard_price_visible/model/product.py
+++ b/product_standard_price_visible/model/product.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv, fields, expression
+from openerp import SUPERUSER_ID
+
+
+class product_product(osv.osv):
+    _inherit = 'product.product'
+
+    def _is_standard_price_visible_hook(self, cr, uid, ids, name, args,
+                                        context=None):
+        res = dict.fromkeys(ids, True)
+        model_data_obj = self.pool.get('ir.model.data')
+        res_groups_obj = self.pool.get('res.groups')
+        for product in self.browse(cr, uid, ids, context=context):
+            # Check if user belongs to the group
+            group_id = model_data_obj._get_id(
+                cr, uid, 'product_standard_price_visible',
+                'group_product_standard_price_visible')
+            if group_id:
+                res_id = model_data_obj.read(cr, uid, [group_id],
+                                             ['res_id'])[0]['res_id']
+                group = res_groups_obj.browse(
+                    cr, uid, res_id, context=context)
+                group_user_ids = [user.id for user
+                                  in group.users]
+                group_user_ids.append(SUPERUSER_ID)
+                if uid in group_user_ids:
+                    res[product.id] = True
+        return res
+
+    def _is_standard_price_visible(self, cr, uid, ids, name, args,
+                                   context=None):
+        if context is None:
+            context = {}
+        return self._is_standard_price_visible_hook(
+            cr, uid, ids, name, args, context=context)
+
+    _columns = {
+        'standard_price_visible': fields.function(
+            _is_standard_price_visible,
+            string="Standard price is visible",
+            method=True, type='boolean')
+    }

--- a/product_standard_price_visible/security/product_security.xml
+++ b/product_standard_price_visible/security/product_security.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data noupdate="0">
+
+    <record id="group_product_standard_price_visible" model="res.groups">
+        <field name="name">Display product cost</field>
+        <field name="users"
+               eval="[(4, ref('base.user_root'))]"/>
+    </record>
+
+</data>
+</openerp>

--- a/product_standard_price_visible/view/product.xml
+++ b/product_standard_price_visible/view/product.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data>
+
+        <record id="product_template_form_view" model="ir.ui.view">
+            <field name="name">product.template.common.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <field name="standard_price" position="attributes">
+                    <attribute name="groups">product_cost_security.product_standard_price_visible</attribute>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/stock_product_standard_price_visible/__init__.py
+++ b/stock_product_standard_price_visible/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#             <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/stock_product_standard_price_visible/__openerp__.py
+++ b/stock_product_standard_price_visible/__openerp__.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#             <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Product stock standard price visible',
+    'version': '1.0',
+    'author': 'Eficent',
+    "website": "www.eficent.com",
+    'category': 'Products',
+    'depends': ['product_cost_security', 'stock'],
+    'demo': [],
+    'description': """
+Product stock standard price visible
+====================================
+This module restricts the visibility of the field 'cost' associated to the
+product only to users that belong to the group 'Display product cost',
+in stock-related views.
+
+
+Installation
+============
+
+No specific installation steps are required.
+
+Configuration
+=============
+
+No specific configuration steps are required.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+
+Known issues / Roadmap
+======================
+
+No issues have been identified with this module.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Moises Lopez <moylop260@vauxoo.com>
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+    """,
+    'data': [
+        'view/product.xml',
+    ],
+    'auto_install': False,
+    'installable': True,
+    'images': [],
+}

--- a/stock_product_standard_price_visible/i18n/es.po
+++ b/stock_product_standard_price_visible/i18n/es.po
@@ -1,0 +1,21 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_standard_price_visible
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-14 12:40+0000\n"
+"PO-Revision-Date: 2015-05-14 12:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_standard_price_visible
+#: view:product.product:0
+msgid "product_cost_security.group_product_standard_price_visible"
+msgstr "product_cost_security.group_product_standard_price_visible"

--- a/stock_product_standard_price_visible/i18n/stock_standard_price_visible.po
+++ b/stock_product_standard_price_visible/i18n/stock_standard_price_visible.po
@@ -1,0 +1,22 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_standard_price_visible
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-14 12:40+0000\n"
+"PO-Revision-Date: 2015-05-14 12:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_standard_price_visible
+#: view:product.product:0
+msgid "product_cost_security.group_product_standard_price_visible"
+msgstr ""
+

--- a/stock_product_standard_price_visible/view/product.xml
+++ b/stock_product_standard_price_visible/view/product.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data>
+        <record id="view_template_property_form" model="ir.ui.view">
+            <field name="name">product.template.stock.property.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='standard_price']" position="attributes">
+                    <attribute name="groups">product_cost_security.group_product_standard_price_visible</attribute>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
# Product Cost Security

This module adds a new user group "Display product cost". The module itself
will not apply the restriction, but needs to be complemented with a module
that actually implements the restriction in a view, such as:
- product_standard_price_visible
- stock_standard_price_visible
# Product Standard Price Visible

This module restricts the visibility of the field 'cost' associated to the
product only to users that belong to the group 'Display product cost'.
# Product stock standard price visible

This module restricts the visibility of the field 'cost' associated to the
product only to users that belong to the group 'Display product cost',
in stock-related views.
