### PR TITLE
8.0 greenify product attribute

### DIFF
--- a/product_sequence/README.rst
+++ b/product_sequence/README.rst
@@ -4,6 +4,14 @@ A module that adds sequence to the product.
 This module allows to associate a sequence to the product reference.
 The reference (default code) is unique (SQL constraint) and required.
 
+Installation
+============
+
+Prior to installing this module, if you have any existing products you should ensure
+they already have a unique reference (or no reference) set.  Products with a default_code of
+'/' or empty will automatically be assigned a code of "!!mig!!" followed by the system id for that product.
+
+Otherwise the setting of the unique constraint will fail and the module will fail to install.
 
 Bug Tracker
 ===========
@@ -13,7 +21,6 @@ In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
 `here <https://github.com/OCA/product-attribute/issues/new?body=module:%20product_sequence%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
-
 Credits
 =======
 
@@ -21,6 +28,7 @@ Contributors
 ------------
 
 * Angel Moya <angel.moya@domatix.com>
+* Graeme Gellatly <g@o4sb.com>
 
 Maintainer
 ----------

--- a/product_sequence/__init__.py
+++ b/product_sequence/__init__.py
@@ -21,3 +21,4 @@
 ##############################################################################
 
 from . import models
+from .models.product_product import update_null_and_slash_codes

--- a/product_sequence/__openerp__.py
+++ b/product_sequence/__openerp__.py
@@ -34,6 +34,10 @@
     'data': [
         'data/product_sequence.xml',
     ],
+    'demo': [
+        'demo/product_product.xml'
+    ],
+    'pre_init_hook': 'update_null_and_slash_codes',
     'auto_install': False,
     'installable': True,
 }

--- a/product_sequence/demo/product_product.xml
+++ b/product_sequence/demo/product_product.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <record id="product.product_product_consultant" model="product.product">
+            <field name="default_code">SERVICE</field>
+        </record>
+
+        <record id="product.product_product_1" model="product.product">
+            <field name="default_code">OSM</field>
+        </record>
+
+        <record id="product.product_product_2" model="product.product">
+            <field name="default_code">OSA</field>
+        </record>
+    </data>
+</openerp>

--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -23,6 +23,19 @@ from openerp import models, fields, api
 from openerp.tools.translate import _
 
 
+def update_null_and_slash_codes(cr):  # pragma: no cover
+    """
+    Updates existing codes matching the default '/' or
+    empty. Primarily this ensures installation does not
+    fail for demo data.
+    :param cr: database cursor
+    :return: void
+    """
+    cr.execute("UPDATE product_product "
+               "SET default_code = '!!mig!!' || id "
+               "WHERE default_code IS NULL OR default_code = '/';")
+
+
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 


### PR DESCRIPTION
Updates auto_init to set a default code in case one does not exist.  Otherwise it causes failures in setting the unique index.

Addresses #77 and replaces #78 
