### PR TITLE
[ADD] Product image tab

### DIFF
--- a/product_image_tab/README.md
+++ b/product_image_tab/README.md
@@ -1,2 +1,0 @@
-This module adds a new tab to the product screen where the image is displayed
-in full size.

--- a/product_image_tab/README.md
+++ b/product_image_tab/README.md
@@ -1,0 +1,2 @@
+This module adds a new tab to the product screen where the image is displayed
+in full size.

--- a/product_image_tab/README.rst
+++ b/product_image_tab/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Show full product image
+=======================
+
+This module adds a new tab to the product screen where the image is displayed
+in full size.
+
+Usage
+=====
+
+The image is visible in a new tab on the product view.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/135/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/product-attribute/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Ondřej Kuzník <ondrej.kuznik@credativ.co.uk>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_image_tab/__openerp__.py
+++ b/product_image_tab/__openerp__.py
@@ -1,34 +1,17 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2015 credativ Ltd (<http://credativ.co.uk>).
-#    All Rights Reserved
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# (c) 2015 credativ ltd. - Ondřej Kuzník
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
     'name': 'Show full product image',
-    'version': '1.0',
+    'version': '8.0.1.0.0',
     'category': 'UI',
-    'author': 'credativ ltd',
-    'website': 'http://www.credativ.co.uk',
+    'author': 'credativ ltd., '
+              'Odoo Community Association (OCA)',
+    'website': 'https://odoo-community.org/',
+    'license': 'AGPL-3',
     'depends': [
         'product',
     ],
     'data': ['views/product_view.xml'],
-    'installable': True,
 }

--- a/product_image_tab/__openerp__.py
+++ b/product_image_tab/__openerp__.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2015 credativ Ltd (<http://credativ.co.uk>).
+#    All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Show full product image',
+    'version': '1.0',
+    'category': 'UI',
+    'author': 'credativ ltd',
+    'website': 'http://www.credativ.co.uk',
+    'depends': [
+        'product',
+    ],
+    'data': ['views/product_view.xml'],
+    'installable': True,
+}

--- a/product_image_tab/views/product_view.xml
+++ b/product_image_tab/views/product_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="product_template_form_view" model="ir.ui.view">
+            <field name="name">product.template.form.view</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <notebook position="inside">
+                    <page string="Image" attrs="{'invisible': [('image', '=', False)]}">
+                        <field name="image" widget="image" class="oe_inline"/>
+                    </page>
+                </notebook>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This adds an Image tab to the product, where the image can be seen in its full size.

I know there is a WIP pull request to get more images to be associated with a product, but I have no idea if it's possible to integrate with it and how. This just enhances the default experience, being able to view the full image without downloading it to disk first (e.g. when needed to speed up product identification during stock takes).
