### PR TITLE
[product_supplierinfo_for_customer] Use product supplier info also for customers

### DIFF
--- a/product_supplierinfo_for_customer/README.rst
+++ b/product_supplierinfo_for_customer/README.rst
@@ -1,0 +1,19 @@
+Use product supplier info also for customers
+============================================
+
+This modules allows to use supplier info, available in _Procurements_ tab 
+from the product, also for customers, allowing to define prices per 
+customer and product.
+
+For these prices to be used in sale prices calculations, you will have
+to create a pricelist with a rule with option "Based on" is "Supplier prices
+on the product form" (although the text is not clear enough).
+
+Credits
+=======
+
+Contributors
+------------
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+

--- a/product_supplierinfo_for_customer/README.rst
+++ b/product_supplierinfo_for_customer/README.rst
@@ -1,13 +1,40 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+============================================
 Use product supplier info also for customers
 ============================================
 
-This modules allows to use supplier info, available in _Procurements_ tab 
-from the product, also for customers, allowing to define prices per 
-customer and product.
+This modules allows to use supplier info structure, available in
+*Procurements* tab of the product form, also for defining customer information,
+allowing to define prices per customer and product.
+
+Configuration
+=============
 
 For these prices to be used in sale prices calculations, you will have
-to create a pricelist with a rule with option "Based on" is "Supplier prices
-on the product form" (although the text is not clear enough).
+to create a pricelist with a rule with option "Based on" with the value
+"Supplier prices on the product form" (although the text is not clear enough).
+
+Usage
+=====
+
+There's a new section on *Sales* tab of the product form called "Customers",
+where you can define records for customers with the same structure of the
+suppliers.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/188/8.0
+
+Known issues / Roadmap
+======================
+
+* Product prices through this method are only guaranteed on the standard sale
+  order workflow. Other custom flows maybe don't reflect the price.
+* The product code / product name specified for the customer will not be
+  reflected on the sale orders.
+* The minimum quantity will not also be applied on sale orders.
 
 Credits
 =======

--- a/product_supplierinfo_for_customer/README.rst
+++ b/product_supplierinfo_for_customer/README.rst
@@ -35,6 +35,8 @@ Known issues / Roadmap
 * The product code / product name specified for the customer will not be
   reflected on the sale orders.
 * The minimum quantity will not also be applied on sale orders.
+* Computed fields in product.supplierinfo object won't properly work for
+  customer type
 
 Credits
 =======
@@ -43,4 +45,3 @@ Contributors
 ------------
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-

--- a/product_supplierinfo_for_customer/README.rst
+++ b/product_supplierinfo_for_customer/README.rst
@@ -1,5 +1,6 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License: AGPL-3
+    :target: http://www.gnu.org/licenses/agpl-3.0.en.html
 
 ============================================
 Use product supplier info also for customers

--- a/product_supplierinfo_for_customer/__init__.py
+++ b/product_supplierinfo_for_customer/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/product_supplierinfo_for_customer/__init__.py
+++ b/product_supplierinfo_for_customer/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify

--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -24,16 +24,9 @@
         "product",
     ],
     "author": "OdooMRP team",
-    "contributors": [
-        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
-    ],
     "category": "Sales Management",
     "website": "http://www.odoomrp.com",
     "summary": "",
-    "description": """
-This module extends product.supplierinfo object with a combo to allow using
-it for sale pricelists
-    """,
     "data": [
         "views/product_view.xml",
     ],

--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -20,7 +20,8 @@
     "version": "8.0.1.0.0",
     "author": "OdooMRP team,"
               "AvanzOSC,"
-              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
+              "Odoo Community Association (OCA)",
     "website": "http://www.odoomrp.com",
     "category": "Sales Management",
     "license": 'AGPL-3',

--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -23,7 +23,9 @@
         "base",
         "product",
     ],
-    "author": "OdooMRP team",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
     "category": "Sales Management",
     "website": "http://www.odoomrp.com",
     "summary": "",

--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -15,22 +15,24 @@
 #    along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-
 {
     "name": "Use product supplier info for customers too",
-    "version": "1.0",
+    "version": "8.0.1.0.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "website": "http://www.odoomrp.com",
+    "category": "Sales Management",
+    "license": 'AGPL-3',
     "depends": [
         "base",
         "product",
     ],
-    "author": "OdooMRP team,"
-              "AvanzOSC,"
-              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
-    "category": "Sales Management",
-    "website": "http://www.odoomrp.com",
-    "summary": "",
     "data": [
         "views/product_view.xml",
+    ],
+    "demo": [
+        "demo/product_demo.xml",
     ],
     "installable": True,
 }

--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Use product supplier info for customers too",
+    "version": "1.0",
+    "depends": [
+        "base",
+        "product",
+    ],
+    "author": "OdooMRP team",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+    ],
+    "category": "Sales Management",
+    "website": "http://www.odoomrp.com",
+    "summary": "",
+    "description": """
+This module extends product.supplierinfo object with a combo to allow using
+it for sale pricelists
+    """,
+    "data": [
+        "views/product_view.xml",
+    ],
+    "installable": True,
+}

--- a/product_supplierinfo_for_customer/demo/product_demo.xml
+++ b/product_supplierinfo_for_customer/demo/product_demo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="product_supplierinfo_customer" model="product.supplierinfo">
+            <field name="product_tmpl_id" ref="product.product_product_4_product_template"/>
+            <field name="name" ref="base.res_partner_2"/>
+            <field name="delay">1</field>
+            <field name="min_qty">1</field>
+            <field name="type">customer</field>
+            <field name="pricelist_ids"
+                   eval="[(0,0,{'name':'Customer pricelist1', 'min_quantity': 1, 'price':25}),
+                          (0,0,{'name':'Customer pricelist2', 'min_quantity': 5, 'price':20})]"/>
+        </record>
+    </data>
+</openerp>

--- a/product_supplierinfo_for_customer/i18n/es.po
+++ b/product_supplierinfo_for_customer/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 8.0rc1\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-09-05 11:46+0000\n"
-"PO-Revision-Date: 2014-09-05 11:46+0000\n"
+"POT-Creation-Date: 2015-02-05 14:08+0000\n"
+"PO-Revision-Date: 2015-02-05 14:08+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,19 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_supplierinfo_for_customer
+#: model:ir.actions.act_window,help:product_supplierinfo_for_customer.product_supplierinfo_action
+msgid "<p class=\"oe_view_nocontent_create\">\n"
+"                    Click to define a new product.supplierinfo.\n"
+"                </p>\n"
+"            "
+msgstr "<p class=\"oe_view_nocontent_create\">\n"
+"Pulse para definir una nueva definición de producto-empresa.\n"
+"</p>\n"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 #: selection:product.supplierinfo,type:0
+#: field:product.template,customer_ids:0
 msgid "Customer"
 msgstr "Cliente"
 
@@ -26,32 +38,65 @@ msgid "Customers"
 msgstr "Clientes"
 
 #. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.actions.act_window,name:product_supplierinfo_for_customer.product_supplierinfo_action
+#: model:ir.ui.menu,name:product_supplierinfo_for_customer.product_supplierinfo_sale_menu
+msgid "Information about a product"
+msgstr "Información sobre un producto"
+
+#. module: product_supplierinfo_for_customer
 #: model:ir.model,name:product_supplierinfo_for_customer.model_product_supplierinfo
 msgid "Information about a product supplier"
 msgstr "Información de un proveedor de producto"
 
 #. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_res_partner
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_tree_view
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Product Code"
+msgstr "Código de producto para la empresa"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Product Name"
+msgstr "Nombre de producto para la empresa"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Unit of Measure"
+msgstr "Unidad de medida de empresa"
+
+#. module: product_supplierinfo_for_customer
 #: model:ir.model,name:product_supplierinfo_for_customer.model_product_template
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 msgid "Product Template"
 msgstr "Plantilla de producto"
 
 #. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 #: selection:product.supplierinfo,type:0
+#: field:product.template,supplier_ids:0
 msgid "Supplier"
 msgstr "Proveedor"
 
 #. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Supplierinfo search"
+msgstr "Búsqueda de producto-empresa"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 #: field:product.supplierinfo,type:0
 msgid "Type"
 msgstr "Tipo"
-
-#. module: product_supplierinfo_for_customer
-#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
-msgid "[('type','=','supplier')]"
-msgstr "[('type','=','supplier')]"
-
-#. module: product_supplierinfo_for_customer
-#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
-msgid "{'default_search_type':'supplier','default_type':'supplier'}"
-msgstr "{'default_search_type':'supplier','default_type':'supplier'}"
 

--- a/product_supplierinfo_for_customer/i18n/es.po
+++ b/product_supplierinfo_for_customer/i18n/es.po
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_supplierinfo_for_customer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0rc1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-09-05 11:46+0000\n"
+"PO-Revision-Date: 2014-09-05 11:46+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_supplierinfo_for_customer
+#: selection:product.supplierinfo,type:0
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "Customers"
+msgstr "Clientes"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_product_supplierinfo
+msgid "Information about a product supplier"
+msgstr "Información de un proveedor de producto"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de producto"
+
+#. module: product_supplierinfo_for_customer
+#: selection:product.supplierinfo,type:0
+msgid "Supplier"
+msgstr "Proveedor"
+
+#. module: product_supplierinfo_for_customer
+#: field:product.supplierinfo,type:0
+msgid "Type"
+msgstr "Tipo"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "[('type','=','supplier')]"
+msgstr "[('type','=','supplier')]"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "{'default_search_type':'supplier','default_type':'supplier'}"
+msgstr "{'default_search_type':'supplier','default_type':'supplier'}"
+

--- a/product_supplierinfo_for_customer/i18n/product_supplierinfo_for_customer.pot
+++ b/product_supplierinfo_for_customer/i18n/product_supplierinfo_for_customer.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 8.0rc1\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-09-05 11:46+0000\n"
-"PO-Revision-Date: 2014-09-05 11:46+0000\n"
+"POT-Creation-Date: 2015-02-05 14:08+0000\n"
+"PO-Revision-Date: 2015-02-05 14:08+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,17 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_supplierinfo_for_customer
+#: model:ir.actions.act_window,help:product_supplierinfo_for_customer.product_supplierinfo_action
+msgid "<p class=\"oe_view_nocontent_create\">\n"
+"                    Click to define a new product.supplierinfo.\n"
+"                </p>\n"
+"            "
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 #: selection:product.supplierinfo,type:0
+#: field:product.template,customer_ids:0
 msgid "Customer"
 msgstr ""
 
@@ -26,32 +36,65 @@ msgid "Customers"
 msgstr ""
 
 #. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Group By"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.actions.act_window,name:product_supplierinfo_for_customer.product_supplierinfo_action
+#: model:ir.ui.menu,name:product_supplierinfo_for_customer.product_supplierinfo_sale_menu
+msgid "Information about a product"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
 #: model:ir.model,name:product_supplierinfo_for_customer.model_product_supplierinfo
 msgid "Information about a product supplier"
 msgstr ""
 
 #. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_res_partner
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_tree_view
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Partner"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Product Code"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Product Name"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Unit of Measure"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
 #: model:ir.model,name:product_supplierinfo_for_customer.model_product_template
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 msgid "Product Template"
 msgstr ""
 
 #. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 #: selection:product.supplierinfo,type:0
+#: field:product.template,supplier_ids:0
 msgid "Supplier"
 msgstr ""
 
 #. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Supplierinfo search"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
 #: field:product.supplierinfo,type:0
 msgid "Type"
-msgstr ""
-
-#. module: product_supplierinfo_for_customer
-#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
-msgid "[('type','=','supplier')]"
-msgstr ""
-
-#. module: product_supplierinfo_for_customer
-#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
-msgid "{'default_search_type':'supplier','default_type':'supplier'}"
 msgstr ""
 

--- a/product_supplierinfo_for_customer/i18n/product_supplierinfo_for_customer.pot
+++ b/product_supplierinfo_for_customer/i18n/product_supplierinfo_for_customer.pot
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_supplierinfo_for_customer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0rc1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-09-05 11:46+0000\n"
+"PO-Revision-Date: 2014-09-05 11:46+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_supplierinfo_for_customer
+#: selection:product.supplierinfo,type:0
+msgid "Customer"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "Customers"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_product_supplierinfo
+msgid "Information about a product supplier"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_product_template
+msgid "Product Template"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: selection:product.supplierinfo,type:0
+msgid "Supplier"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: field:product.supplierinfo,type:0
+msgid "Type"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "[('type','=','supplier')]"
+msgstr ""
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "{'default_search_type':'supplier','default_type':'supplier'}"
+msgstr ""
+

--- a/product_supplierinfo_for_customer/i18n/sl.po
+++ b/product_supplierinfo_for_customer/i18n/sl.po
@@ -1,0 +1,104 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* product_supplierinfo_for_customer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-02-05 14:08+0000\n"
+"PO-Revision-Date: 2015-08-15 13:06+0200\n"
+"Last-Translator: Matjaz Mozetic <m.mozetic@matmoz.si>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: sl\n"
+"X-Generator: Poedit 1.8.4\n"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.actions.act_window,help:product_supplierinfo_for_customer.product_supplierinfo_action
+msgid ""
+"<p class=\"oe_view_nocontent_create\">\n"
+"                    Click to define a new product.supplierinfo.\n"
+"                </p>\n"
+"            "
+msgstr ""
+"<p class=\"oe_view_nocontent_create\">\n"
+"                    Kliknite za nov product.supplierinfo.\n"
+"                </p>\n"
+"            "
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+#: selection:product.supplierinfo,type:0 field:product.template,customer_ids:0
+msgid "Customer"
+msgstr "Kupec"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.template:product_supplierinfo_for_customer.product_template_extended_form_view
+msgid "Customers"
+msgstr "Kupci"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Group By"
+msgstr "Združi po"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.actions.act_window,name:product_supplierinfo_for_customer.product_supplierinfo_action
+#: model:ir.ui.menu,name:product_supplierinfo_for_customer.product_supplierinfo_sale_menu
+msgid "Information about a product"
+msgstr "Podatki o proizvodu"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_product_supplierinfo
+msgid "Information about a product supplier"
+msgstr "Podatki o dobavitelju proizvoda"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_res_partner
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_tree_view
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Partner"
+msgstr "Partner"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Product Code"
+msgstr "Partnerjeva koda proizvoda"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Product Name"
+msgstr "Partnerjev naziv proizvoda"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_extended_form_view
+msgid "Partner Unit of Measure"
+msgstr "Partnerjeva EM"
+
+#. module: product_supplierinfo_for_customer
+#: model:ir.model,name:product_supplierinfo_for_customer.model_product_template
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Product Template"
+msgstr "Predloga proizvoda"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+#: selection:product.supplierinfo,type:0 field:product.template,supplier_ids:0
+msgid "Supplier"
+msgstr "Dobavitelj"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+msgid "Supplierinfo search"
+msgstr "Iskanje podatkov o dobavitelju"
+
+#. module: product_supplierinfo_for_customer
+#: view:product.supplierinfo:product_supplierinfo_for_customer.product_supplierinfo_search_view
+#: field:product.supplierinfo,type:0
+msgid "Type"
+msgstr "Tip"

--- a/product_supplierinfo_for_customer/models/__init__.py
+++ b/product_supplierinfo_for_customer/models/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -19,3 +19,4 @@
 from . import product_supplierinfo
 from . import product_template
 from . import res_partner
+from . import product_pricelist

--- a/product_supplierinfo_for_customer/models/__init__.py
+++ b/product_supplierinfo_for_customer/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import product_supplierinfo
+from . import product_template
+from . import res_partner

--- a/product_supplierinfo_for_customer/models/__init__.py
+++ b/product_supplierinfo_for_customer/models/__init__.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-
 from . import product_supplierinfo
 from . import product_template
 from . import res_partner

--- a/product_supplierinfo_for_customer/models/product_pricelist.py
+++ b/product_supplierinfo_for_customer/models/product_pricelist.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# (c) 2015 Pedro M. Baeza
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
 from openerp import models, api
 
 

--- a/product_supplierinfo_for_customer/models/product_pricelist.py
+++ b/product_supplierinfo_for_customer/models/product_pricelist.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class ProductPricelist(models.Model):
+    _inherit = 'product.pricelist'
+
+    @api.multi
+    def price_rule_get(self, prod_id, qty, partner=None):
+        """Pass context if the type of the pricelist is sale for restricting
+        on the search product.supplierinfo records of type customer."""
+        obj = (self.with_context(supplierinfo_type='customer') if
+               self.type == 'sale' else self)
+        return super(ProductPricelist, obj).price_rule_get(
+            prod_id, qty, partner=partner)

--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class ProductSupplierinfo(models.Model):
+    _inherit = 'product.supplierinfo'
+
+    type = fields.Selection([('customer', 'Customer'),
+                             ('supplier', 'Supplier')], string='Type',
+                            default='supplier')
+
+    @api.multi
+    @api.onchange('type')
+    def onchange_type(self):
+        if self.type == 'supplier':
+            return {'domain': {'name': [('supplier', '=', True)]}}
+        elif self.type == 'customer':
+            return {'domain': {'name': [('customer', '=', True)]}}
+        return {'domain': {'name': []}}

--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-
 from openerp import models, fields, api
 
 

--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -22,9 +22,10 @@ from openerp import models, fields, api
 class ProductSupplierinfo(models.Model):
     _inherit = 'product.supplierinfo'
 
-    type = fields.Selection([('customer', 'Customer'),
-                             ('supplier', 'Supplier')], string='Type',
-                            default='supplier')
+    type = fields.Selection(
+        selection=[('customer', 'Customer'),
+                   ('supplier', 'Supplier')], string='Type',
+        default='supplier')
 
     @api.multi
     @api.onchange('type')
@@ -34,3 +35,17 @@ class ProductSupplierinfo(models.Model):
         elif self.type == 'customer':
             return {'domain': {'name': [('customer', '=', True)]}}
         return {'domain': {'name': []}}
+
+    def search(self, cr, uid, args, offset=0, limit=None, order=None,
+               context=None, count=False):
+        """Add search argument for field type if the context says so. This
+        should be in old API because context argument is not the last one.
+        """
+        if context is None:
+            context = {}
+        if not any(arg[0] == 'type' for arg in args):
+            args += [('type', '=',
+                      context.get('supplierinfo_type', 'supplier'))]
+        return super(ProductSupplierinfo, self).search(
+            cr, uid, args, offset=offset, limit=limit, order=order,
+            context=context, count=count)

--- a/product_supplierinfo_for_customer/models/product_template.py
+++ b/product_supplierinfo_for_customer/models/product_template.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -22,11 +22,9 @@ from openerp import models, fields
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    customer_ids = fields.One2many(comodel_name='product.supplierinfo',
-                                   inverse_name='product_tmpl_id',
-                                   string='Customer',
-                                   domain=[('type', '=', 'customer')])
-    supplier_ids = fields.One2many(comodel_name='product.supplierinfo',
-                                   inverse_name='product_tmpl_id',
-                                   string='Supplier',
-                                   domain=[('type', '=', 'supplier')])
+    customer_ids = fields.One2many(
+        comodel_name='product.supplierinfo', inverse_name='product_tmpl_id',
+        string='Customer', domain=[('type', '=', 'customer')])
+    supplier_ids = fields.One2many(
+        comodel_name='product.supplierinfo', inverse_name='product_tmpl_id',
+        string='Supplier', domain=[('type', '=', 'supplier')])

--- a/product_supplierinfo_for_customer/models/product_template.py
+++ b/product_supplierinfo_for_customer/models/product_template.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-
 from openerp import models, fields
 
 

--- a/product_supplierinfo_for_customer/models/product_template.py
+++ b/product_supplierinfo_for_customer/models/product_template.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    customer_ids = fields.One2many(comodel_name='product.supplierinfo',
+                                   inverse_name='product_tmpl_id',
+                                   string='Customer',
+                                   domain=[('type', '=', 'customer')])
+    supplier_ids = fields.One2many(comodel_name='product.supplierinfo',
+                                   inverse_name='product_tmpl_id',
+                                   string='Supplier',
+                                   domain=[('type', '=', 'supplier')])

--- a/product_supplierinfo_for_customer/models/res_partner.py
+++ b/product_supplierinfo_for_customer/models/res_partner.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def default_get(self, fields):
+        res = super(ResPartner, self).default_get(fields)
+        select_type = self.env.context.get('select_type', False)
+        if select_type:
+            res.update({
+                'customer': select_type == 'customer',
+                'supplier': select_type == 'supplier',
+            })
+        return res

--- a/product_supplierinfo_for_customer/models/res_partner.py
+++ b/product_supplierinfo_for_customer/models/res_partner.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-
 from openerp import models, api
 
 

--- a/product_supplierinfo_for_customer/models/res_partner.py
+++ b/product_supplierinfo_for_customer/models/res_partner.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify

--- a/product_supplierinfo_for_customer/tests/__init__.py
+++ b/product_supplierinfo_for_customer/tests/__init__.py
@@ -2,4 +2,4 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from . import models
+from . import test_product_supplierinfo_for_customer

--- a/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
+++ b/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+import openerp.tests.common as common
+
+
+class TestProductSupplierinfoForCustomer(common.TransactionCase):
+
+    def setUp(self):
+        super(TestProductSupplierinfoForCustomer, self).setUp()
+        self.supplierinfo_model = self.env['product.supplierinfo']
+        self.pricelist_item_model = self.env['product.pricelist.item']
+        self.pricelist_model = self.env['product.pricelist']
+        self.customer = self.env.ref('base.res_partner_2')
+        self.product = self.env.ref('product.product_product_4')
+        self.pricelist = self.env.ref('product.list0')
+        self.pricelist_item = self.pricelist_item_model.browse(
+            self.env.ref('product.item0').id)
+        self.pricelist_item.write({'base': -2})
+
+    def test_product_supplierinfo_for_customer(self):
+        cond = [('name', '=', self.customer.id)]
+        supplierinfos = self.supplierinfo_model.search(cond)
+        self.assertEqual(len(supplierinfos), 0,
+                         "Error: Supplier found in Supplierinfo")
+        cond = [('name', '=', self.customer.id)]
+        customerinfos = self.supplierinfo_model.with_context(
+            supplierinfo_type='customer').search(cond)
+        self.assertNotEqual(len(customerinfos), 0,
+                            "Error: Supplier not found in Supplierinfo")
+        price_unit = self.pricelist_model.with_context(
+            supplierinfo_type='customer').price_rule_get(
+            self.product.id, 7, partner=self.customer.id)
+        self.assertTrue(
+            price_unit.get(self.pricelist.id, False),
+            "Error: Price unit not found for customer")
+        price = price_unit.get(self.pricelist.id, False)[0]
+        self.assertEqual(price, 20.0,
+                         "Error: Price not found for product and customer")

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -115,6 +115,7 @@
 
         <record id="product_supplierinfo_action" model="ir.actions.act_window">
             <field name="name">Information about a product (customer)</field>
+            <field name="name">Information about a product (customer)</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">product.supplierinfo</field>
             <field name="view_mode">tree,form</field>

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -21,7 +21,20 @@
                     <attribute name="string">Partner Unit of Measure</attribute>
                 </field>
                 <field name="name" position="before">
-                    <field name="type" invisible="1"/>
+                    <field name="type" invisible="1" />
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_supplierinfo_template_form_view">
+            <field name="name">product.supplierinfo.template.form</field>
+            <field name="model">product.supplierinfo</field>
+            <field name="inherit_id" ref="product_supplierinfo_extended_form_view" />
+            <field name="mode">primary</field>
+            <field name="priority" eval="20" />
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="product_tmpl_id" />
                 </field>
             </field>
         </record>
@@ -33,6 +46,19 @@
             <field name="arch" type="xml">
                 <field name="name" position="attributes">
                     <attribute name="string">Partner</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_supplierinfo_template_tree_view">
+            <field name="name">product.supplierinfo.template.tree</field>
+            <field name="model">product.supplierinfo</field>
+            <field name="inherit_id" ref="product_supplierinfo_extended_tree_view" />
+            <field name="mode">primary</field>
+            <field name="priority" eval="20" />
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field name="product_tmpl_id" />
                 </field>
             </field>
         </record>
@@ -49,13 +75,15 @@
                 </field>
                 <field name="seller_ids" position="after">
                     <field name="supplier_ids"
-                           context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
-                           domain="[('type','=','supplier')]" />
+                        context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
+                        domain="[('type','=','supplier')]" />
                 </field>
-                <xpath expr="//separator[@string='Description for Quotations']" position="before">
+                <xpath
+                    expr="//separator[@string='Description for Quotations']"
+                    position="before">
                     <separator string="Customers" />
                     <field name="customer_ids"
-                           context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
+                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
                     </field>
                 </xpath>
             </field>
@@ -68,26 +96,25 @@
                 <search string="Supplierinfo search">
                     <field name="name" />
                     <field name="product_tmpl_id" />
-                    <filter string="Customer" domain="[('type','=','customer')]" name="is_customer_filter"/>
-                    <filter string="Supplier" domain="[('type','=','supplier')]" name="is_supplier_filter"/>
+                    <filter string="Customer" domain="[('type','=','customer')]"
+                        name="is_customer_filter" />
+                    <filter string="Supplier" domain="[('type','=','supplier')]"
+                        name="is_supplier_filter" />
                     <group expand="0" string="Group By">
-                        <filter string="Partner"
-                                icon="terp-partner"
-                                domain="[]" context="{'group_by':'name'}" />
-                        <filter string="Product Template"
-                                domain="[]"
-                                context="{'group_by':'product_tmpl_id'}" />
+                        <filter string="Partner" icon="terp-partner"
+                            domain="[]" context="{'group_by':'name'}" />
+                        <filter string="Product Template" domain="[]"
+                            context="{'group_by':'product_tmpl_id'}" />
                         <separator />
-                        <filter string="Type"
-                                domain="[]"
-                                context="{'group_by':'type'}" />
+                        <filter string="Type" domain="[]"
+                            context="{'group_by':'type'}" />
                     </group>
                 </search>
             </field>
         </record>
 
         <record id="product_supplierinfo_action" model="ir.actions.act_window">
-            <field name="name">Information about a product</field>
+            <field name="name">Information about a product (customer)</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">product.supplierinfo</field>
             <field name="view_mode">tree,form</field>
@@ -103,6 +130,22 @@
                     Click to define a new product.supplierinfo.
                 </p>
             </field>
+        </record>
+
+        <record id="product_supplierinfo_customer_act_view"
+            model="ir.actions.act_window.view">
+            <field name="act_window_id" ref="product_supplierinfo_action" />
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="product_supplierinfo_template_form_view" />
+            <field name="sequence" eval="15" />
+        </record>
+
+        <record id="product_supplierinfo_customer_tree_act_view"
+            model="ir.actions.act_window.view">
+            <field name="act_window_id" ref="product_supplierinfo_action" />
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="product_supplierinfo_template_tree_view" />
+            <field name="sequence" eval="5" />
         </record>
 
         <menuitem id="product_supplierinfo_sale_menu" parent="base.menu_product"

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="product_supplierinfo_extended_form_view">
+            <field name="name">product.supplierinfo.extended.form</field>
+            <field name="model">product.supplierinfo</field>
+            <field name="inherit_id" ref="product.product_supplierinfo_form_view" />
+            <field name="arch" type="xml">
+                <field name="name" position="attributes">
+                    <attribute name="string">Partner</attribute>
+                    <attribute name="context">{'select_type': type}</attribute>
+                </field>
+                <field name="product_name" position="attributes">
+                    <attribute name="string">Partner Product Name</attribute>
+                </field>
+                <field name="product_code" position="attributes">
+                    <attribute name="string">Partner Product Code</attribute>
+                </field>
+                <field name="product_uom" position="attributes">
+                    <attribute name="string">Partner Unit of Measure</attribute>
+                </field>
+                <field name="name" position="before">
+                    <field name="type" />
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_supplierinfo_extended_tree_view">
+            <field name="name">product.supplierinfo.extended.tree</field>
+            <field name="model">product.supplierinfo</field>
+            <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="type" />
+                </field>
+                <field name="name" position="attributes">
+                    <attribute name="string">Partner</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_template_extended_form_view">
+            <field name="name">product.template.extended.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view" />
+            <field name="arch" type="xml">
+                <field name="seller_ids" position="attributes">
+                    <attribute name="context">{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}</attribute>
+                    <attribute name="domain">[('type','=','supplier')]</attribute>
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="seller_ids" position="after">
+                    <field name="supplier_ids" context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
+                        domain="[('type','=','supplier')]" />
+                </field>
+                <xpath
+                    expr="//separator[@string='Description for Quotations']"
+                    position="before">
+                    <separator string="Customers" />
+                    <field name="customer_ids"
+                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
+                    </field>
+                </xpath>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_supplierinfo_search_view">
+            <field name="name">product.supplierinfo.search</field>
+            <field name="model">product.supplierinfo</field>
+            <field name="arch" type="xml">
+                <search string="Supplierinfo search">
+                    <field name="name" />
+                    <field name="product_tmpl_id" />
+                    <filter string="Customer" domain="[('type','=','customer')]" name="is_customer_filter"/>
+                    <filter string="Supplier" domain="[('type','=','supplier')]" name="is_supplier_filter"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Partner" icon="terp-partner"
+                            domain="[]" context="{'group_by':'name'}" />
+                        <filter string="Product Template" domain="[]"
+                            context="{'group_by':'product_tmpl_id'}" />
+                        <separator />
+                        <filter string="Type" domain="[]"
+                            context="{'group_by':'type'}" />
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id="product_supplierinfo_action" model="ir.actions.act_window">
+            <field name="name">Information about a product</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">product.supplierinfo</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_type">form</field>
+            <field name="search_view_id" ref="product_supplierinfo_search_view" />
+            <field name="domain">[]</field>
+            <field name="context">{
+                    'search_default_is_customer_filter': 1
+                }
+            </field>
+            <field name="help" type="html">
+                <p class="oe_view_nocontent_create">
+                    Click to define a new product.supplierinfo.
+                </p>
+            </field>
+        </record>
+
+        <menuitem id="product_supplierinfo_sale_menu" parent="base.menu_product"
+            action="product_supplierinfo_action" />
+
+    </data>
+</openerp>

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -21,7 +21,7 @@
                     <attribute name="string">Partner Unit of Measure</attribute>
                 </field>
                 <field name="name" position="before">
-                    <field name="type" />
+                    <field name="type" invisible="1"/>
                 </field>
             </field>
         </record>
@@ -31,9 +31,6 @@
             <field name="model">product.supplierinfo</field>
             <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
             <field name="arch" type="xml">
-                <field name="name" position="before">
-                    <field name="type" />
-                </field>
                 <field name="name" position="attributes">
                     <attribute name="string">Partner</attribute>
                 </field>
@@ -51,15 +48,14 @@
                     <attribute name="invisible">1</attribute>
                 </field>
                 <field name="seller_ids" position="after">
-                    <field name="supplier_ids" context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
-                        domain="[('type','=','supplier')]" />
+                    <field name="supplier_ids"
+                           context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
+                           domain="[('type','=','supplier')]" />
                 </field>
-                <xpath
-                    expr="//separator[@string='Description for Quotations']"
-                    position="before">
+                <xpath expr="//separator[@string='Description for Quotations']" position="before">
                     <separator string="Customers" />
                     <field name="customer_ids"
-                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
+                           context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
                     </field>
                 </xpath>
             </field>
@@ -75,13 +71,16 @@
                     <filter string="Customer" domain="[('type','=','customer')]" name="is_customer_filter"/>
                     <filter string="Supplier" domain="[('type','=','supplier')]" name="is_supplier_filter"/>
                     <group expand="0" string="Group By">
-                        <filter string="Partner" icon="terp-partner"
-                            domain="[]" context="{'group_by':'name'}" />
-                        <filter string="Product Template" domain="[]"
-                            context="{'group_by':'product_tmpl_id'}" />
+                        <filter string="Partner"
+                                icon="terp-partner"
+                                domain="[]" context="{'group_by':'name'}" />
+                        <filter string="Product Template"
+                                domain="[]"
+                                context="{'group_by':'product_tmpl_id'}" />
                         <separator />
-                        <filter string="Type" domain="[]"
-                            context="{'group_by':'type'}" />
+                        <filter string="Type"
+                                domain="[]"
+                                context="{'group_by':'type'}" />
                     </group>
                 </search>
             </field>

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -21,7 +21,7 @@
                     <attribute name="string">Partner Unit of Measure</attribute>
                 </field>
                 <field name="name" position="before">
-                    <field name="type" invisible="1" />
+                    <field name="type" colspan="4" invisible="1"/>
                 </field>
             </field>
         </record>
@@ -40,7 +40,7 @@
         </record>
 
         <record model="ir.ui.view" id="product_supplierinfo_extended_tree_view">
-            <field name="name">product.supplierinfo.extended.tree</field>
+            <field name="name">product.supplierinfo.partner.tree</field>
             <field name="model">product.supplierinfo</field>
             <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
             <field name="arch" type="xml">
@@ -75,15 +75,15 @@
                 </field>
                 <field name="seller_ids" position="after">
                     <field name="supplier_ids"
-                        context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
-                        domain="[('type','=','supplier')]" />
+                           context="{'default_search_type':'supplier','default_type':'supplier','default_product_tmpl_id':id}"
+                           domain="[('type','=','supplier')]" />
                 </field>
                 <xpath
                     expr="//separator[@string='Description for Quotations']"
                     position="before">
                     <separator string="Customers" />
                     <field name="customer_ids"
-                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
+                           context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
                     </field>
                 </xpath>
             </field>
@@ -97,17 +97,17 @@
                     <field name="name" />
                     <field name="product_tmpl_id" />
                     <filter string="Customer" domain="[('type','=','customer')]"
-                        name="is_customer_filter" />
+                            name="is_customer_filter" />
                     <filter string="Supplier" domain="[('type','=','supplier')]"
-                        name="is_supplier_filter" />
+                            name="is_supplier_filter" />
                     <group expand="0" string="Group By">
                         <filter string="Partner" icon="terp-partner"
-                            domain="[]" context="{'group_by':'name'}" />
+                                domain="[]" context="{'group_by':'name'}" />
                         <filter string="Product Template" domain="[]"
-                            context="{'group_by':'product_tmpl_id'}" />
+                                context="{'group_by':'product_tmpl_id'}" />
                         <separator />
                         <filter string="Type" domain="[]"
-                            context="{'group_by':'type'}" />
+                                context="{'group_by':'type'}" />
                     </group>
                 </search>
             </field>
@@ -115,15 +115,15 @@
 
         <record id="product_supplierinfo_action" model="ir.actions.act_window">
             <field name="name">Information about a product (customer)</field>
-            <field name="name">Information about a product (customer)</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">product.supplierinfo</field>
             <field name="view_mode">tree,form</field>
             <field name="view_type">form</field>
             <field name="search_view_id" ref="product_supplierinfo_search_view" />
-            <field name="domain">[]</field>
             <field name="context">{
-                    'search_default_is_customer_filter': 1
+                    'search_default_is_customer_filter': 1,
+                    'default_type': 'customer',
+                    'supplierinfo_type': 'customer',
                 }
             </field>
             <field name="help" type="html">
@@ -134,7 +134,7 @@
         </record>
 
         <record id="product_supplierinfo_customer_act_view"
-            model="ir.actions.act_window.view">
+                model="ir.actions.act_window.view">
             <field name="act_window_id" ref="product_supplierinfo_action" />
             <field name="view_mode">form</field>
             <field name="view_id" ref="product_supplierinfo_template_form_view" />
@@ -142,7 +142,7 @@
         </record>
 
         <record id="product_supplierinfo_customer_tree_act_view"
-            model="ir.actions.act_window.view">
+                model="ir.actions.act_window.view">
             <field name="act_window_id" ref="product_supplierinfo_action" />
             <field name="view_mode">tree</field>
             <field name="view_id" ref="product_supplierinfo_template_tree_view" />
@@ -150,7 +150,7 @@
         </record>
 
         <menuitem id="product_supplierinfo_sale_menu" parent="base.menu_product"
-            action="product_supplierinfo_action" />
+                  action="product_supplierinfo_action" />
 
     </data>
 </openerp>


### PR DESCRIPTION
This modules allows to use supplier info structure, available in
_Procurements_ tab of the product form, also for defining customer information,
allowing to define prices per customer and product.
