### PR TITLE
check_upc() fails when check-digit is 0

### DIFF
--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -83,21 +83,21 @@ def check_gtinx(code):
 VALID_GTIN_LENGTHS = [8, 10, 12, 13, 14]
 
 
-def check_gtin(eancode):
-    if not eancode:
+def check_gtin(code):
+    if not code:
         return True
-    if len(eancode) not in VALID_GTIN_LENGTHS:
+    if len(code) not in VALID_GTIN_LENGTHS:
         return False
-    if len(eancode) == 10:
+    if len(code) == 10:
         # Should be an ISBN-10
-        return check_isbn(eancode)
+        return check_isbn(code)
     else:
         # SHould be GTIN-x
         try:
-            int(eancode)
+            int(code)
         except:
             return False
-        return check_gtinx(eancode)
+        return check_gtinx(code)
 
 
 class product_product(orm.Model):

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -23,8 +23,6 @@ import logging
 _logger = logging.getLogger(__name__)
 
 from openerp.osv import orm, fields
-import operator
-
 
 CONSTRAINT_MESSAGE = 'Error: Invalid EAN/GTIN code'
 HELP_MESSAGE = ("EAN8 EAN13 UPC JPC GTIN \n"
@@ -45,9 +43,8 @@ def check_eanx(code):
             total += int(code[pos])
         else:
             total += 3 * int(code[pos])
-    check = 10 - operator.mod(total, 10)
-    if check == 10:
-        check = 0
+    check = 10 - (total % 10)
+    check = check % 10
 
     return check == int(code[-1])    
 

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -33,7 +33,10 @@ def check_eanx(code):
     """
     The routine for calculating GTIN checksums is the same for all types,
     provided one starts at the end of the number (right-hand side) and works
-    backwards
+    backwards.
+
+    :param eancode: string, GTIN code
+    :return: boolean    
     """
     total = 0
     gtin_len = len(code)

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -208,7 +208,6 @@ if __name__ == '__main__':
 
         def test_upc_ending_zero(self):
             # Current check_upc() is broken if the check digit is zero
-            # (Test fails currently)
             self.assertTrue(check_upc('813922013030'))
                
             # Tweak the last digit to make it invalid   
@@ -222,7 +221,39 @@ if __name__ == '__main__':
             self.assertTrue(check_gtin14('30012345678906'))
                
             # Tweak the last digit to make it invalid   
-            self.assertFalse(check_gtin14('30012345678907'))             
+            self.assertFalse(check_gtin14('30012345678907'))
+            
+        def text_check_ean(self):
+            # Check all of the real-world GTINS via check_ean()
+
+            # EAN13
+            self.assertTrue(check_ean('5013567421497'))
+            
+            # EAN8
+            self.assertTrue(check_ean('73513537'))  
+
+            # UPC
+            self.assertTrue(check_ean('813922012941'))
+            self.assertTrue(check_upc('813922013030'))            
+            
+            # GTIN-14
+            self.assertTrue(check_ean('30012345678906'))
+            
+            # None should pass
+            self.assertTrue(check_ean(None))
+            
+            # Non-numeric string should fail
+            self.assertFalse(check_ean("ABCDEFG"))
+            
+            # Short numeric string should fail
+            self.assertFalse(check_ean("12345"))
+            
+            # GTINs with corrupted checksum should fail
+            self.assertFalse(check_ean('5013567421498'))            
+            self.assertFalse(check_ean('73513538'))            
+            self.assertTrue(check_ean('813922012941'))            
+            self.assertFalse(check_ean('813922013031'))            
+            self.assertFalse(check_ean('30012345678907'))                       
 
 
     unittest.main()

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -33,6 +33,26 @@ HELP_MESSAGE = ("EAN8 EAN13 UPC JPC GTIN \n"
 
 def is_pair(x):
     return not x % 2
+    
+def check_eanx(code):
+    """
+    The routine for calculating GTIN checksums is the same for all types,
+    provided one starts at the end of the number (right-hand side) and works
+    backwards
+    """
+    total = 0
+    gtin_len = len(code)
+    for i in range(gtin_len-1):
+        pos = int(gtin_len-2-i)
+        if is_pair(i):
+            total += 3 * int(code[pos])
+        else:
+            total += int(code[pos])
+    check = 10 - operator.mod(total, 10)
+    if check == 10:
+        check = 0
+
+    return check == int(code[-1])    
 
 
 def check_ean8(eancode):
@@ -49,18 +69,7 @@ def check_ean8(eancode):
         _logger.warn('Ean8 code has to have a length of 8 characters.')
         return False
 
-    sum = 0
-    ean_len = len(eancode)
-    for i in range(ean_len-1):
-        if is_pair(i):
-            sum += 3 * int(eancode[i])
-        else:
-            sum += int(eancode[i])
-    check = 10 - operator.mod(sum, 10)
-    if check == 10:
-        check = 0
-
-    return check == int(eancode[-1])
+    return check_eanx(eancode)
 
 
 def check_upc(upccode):
@@ -78,19 +87,7 @@ def check_upc(upccode):
         _logger.warn('UPC code has to have a length of 12 characters.')
         return False
 
-    sum_pair = 0
-    ean_len = len(upccode)
-    for i in range(ean_len-1):
-        if is_pair(i):
-            sum_pair += int(upccode[i])
-    sum = sum_pair * 3
-    for i in range(ean_len-1):
-        if not is_pair(i):
-            sum += int(upccode[i])
-    check = ((sum/10 + 1) * 10) - sum
-    check = check % 10
-
-    return check == int(upccode[-1])
+    return check_eanx(upccode)
 
 
 def check_ean13(eancode):
@@ -108,19 +105,7 @@ def check_ean13(eancode):
         _logger.warn('Ean13 code has to have a length of 13 characters.')
         return False
 
-    sum = 0
-    ean_len = len(eancode)
-    for i in range(ean_len-1):
-        pos = int(ean_len-2-i)
-        if is_pair(i):
-            sum += 3 * int(eancode[pos])
-        else:
-            sum += int(eancode[pos])
-    check = 10 - operator.mod(sum, 10)
-    if check == 10:
-        check = 0
-
-    return check == int(eancode[-1])
+    return check_eanx(eancode)
 
 
 def check_ean11(eancode):
@@ -128,7 +113,7 @@ def check_ean11(eancode):
 
 
 def check_gtin14(eancode):
-    pass
+    return check_eanx(eancode)
 
 
 DICT_CHECK_EAN = {8: check_ean8,

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -52,61 +52,7 @@ def check_eanx(code):
     return check == int(code[-1])    
 
 
-def check_ean8(eancode):
-    """Check if the given ean code answer ean8 requirements
-    For more details: http://en.wikipedia.org/wiki/EAN-8
-
-    :param eancode: string, ean-8 code
-    :return: boolean
-    """
-    if not eancode or not eancode.isdigit():
-        return False
-
-    return check_eanx(eancode)
-
-
-def check_upc(upccode):
-    """Check if the given code answers upc requirements
-    For more details:
-    http://en.wikipedia.org/wiki/Universal_Product_Code
-
-    :param upccode: string, upc code
-    :return: bool
-    """
-    if not upccode or not upccode.isdigit():
-        return False
-
-    return check_eanx(upccode)
-
-
-def check_ean13(eancode):
-    """Check if the given ean code answer ean13 requirements
-    For more details:
-    http://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29
-
-    :param eancode: string, ean-13 code
-    :return: boolean
-    """
-    if not eancode or not eancode.isdigit():
-        return False
-
-    return check_eanx(eancode)
-
-
-def check_ean11(eancode):
-    pass
-
-
-def check_gtin14(eancode):
-    return check_eanx(eancode)
-
-
-DICT_CHECK_EAN = {8: check_ean8,
-                  11: check_ean11,
-                  12: check_upc,
-                  13: check_ean13,
-                  14: check_gtin14,
-                  }
+DICT_CHECK_EAN = [8, 11, 12, 13, 14]
 
 
 def check_ean(eancode):
@@ -118,7 +64,7 @@ def check_ean(eancode):
         int(eancode)
     except:
         return False
-    return DICT_CHECK_EAN[len(eancode)](eancode)
+    return check_eanx(eancode)
 
 
 class product_product(orm.Model):
@@ -181,48 +127,6 @@ if __name__ == '__main__':
     
     class TestEANCheckers(unittest.TestCase):
     
-        def test_ean13(self):
-            # This is a valid EAN13
-            self.assertTrue(check_ean13('5013567421497'))
-               
-            # Tweak the last digit to make it invalid   
-            self.assertFalse(check_ean13('5013567421498'))
-            
-            
-        def test_ean8(self):
-            # This is a valid EAN8 from
-            # https://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29
-            self.assertTrue(check_ean8('73513537'))
-               
-            # Tweak the last digit to make it invalid   
-            self.assertFalse(check_ean8('73513538'))
-            
-            
-        def test_upc(self):
-            # This is a valid UPC from
-            self.assertTrue(check_upc('813922012941'))
-               
-            # Tweak the last digit to make it invalid   
-            self.assertFalse(check_upc('813922012942'))                      
-
-
-        def test_upc_ending_zero(self):
-            # Current check_upc() is broken if the check digit is zero
-            self.assertTrue(check_upc('813922013030'))
-               
-            # Tweak the last digit to make it invalid   
-            self.assertFalse(check_upc('813922013031'))
-            
-            
-        def test_gtin14(self):
-            # Example GTIN-14 from
-            # http://www.morovia.com/kb/Shipping-Container-Code-GS114-SCC14-GTIN14-10600.html
-            # (Test fails currently as check_gtin14() returns None)
-            self.assertTrue(check_gtin14('30012345678906'))
-               
-            # Tweak the last digit to make it invalid   
-            self.assertFalse(check_gtin14('30012345678907'))
-            
         def text_check_ean(self):
             # Check all of the real-world GTINS via check_ean()
 

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -52,13 +52,13 @@ def check_eanx(code):
     return check == int(code[-1])    
 
 
-DICT_CHECK_EAN = [8, 11, 12, 13, 14]
+VALID_GTIN_LENGTHS = [8, 11, 12, 13, 14]
 
 
 def check_ean(eancode):
     if not eancode:
         return True
-    if not len(eancode) in DICT_CHECK_EAN:
+    if not len(eancode) in VALID_GTIN_LENGTHS:
         return False
     try:
         int(eancode)

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -88,6 +88,7 @@ def check_upc(upccode):
         if not is_pair(i):
             sum += int(upccode[i])
     check = ((sum/10 + 1) * 10) - sum
+    check = check % 10
 
     return check == int(upccode[-1])
 

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -27,9 +27,17 @@ from openerp.osv import orm, fields
 CONSTRAINT_MESSAGE = 'Error: Invalid EAN/GTIN code'
 HELP_MESSAGE = ("EAN8 EAN13 UPC JPC GTIN \n"
                 "http://en.wikipedia.org/wiki/Global_Trade_Item_Number")
+                
+
+# The official names of EANs, UPCs, etc. are now GTIN-x:
+# GTIN-14 (was DUN-14, ITF)
+# GTIN-13 (was EAN-13, CIP)
+# GTIN-12 (was UCC-12, UPC)
+# GTIN-8 (was EAN-8)
+# From https://en.wikipedia.org/wiki/Global_Trade_Item_Number                
 
 
-def check_eanx(code):
+def check_gtinx(code):
     """
     The routine for calculating GTIN checksums is the same for all types,
     provided one starts at the end of the number (right-hand side) and works
@@ -52,10 +60,10 @@ def check_eanx(code):
     return check == int(code[-1])    
 
 
-VALID_GTIN_LENGTHS = [8, 11, 12, 13, 14]
+VALID_GTIN_LENGTHS = [8, 12, 13, 14]
 
 
-def check_ean(eancode):
+def check_gtin(eancode):
     if not eancode:
         return True
     if not len(eancode) in VALID_GTIN_LENGTHS:
@@ -64,7 +72,7 @@ def check_ean(eancode):
         int(eancode)
     except:
         return False
-    return check_eanx(eancode)
+    return check_gtinx(eancode)
 
 
 class product_product(orm.Model):
@@ -72,7 +80,7 @@ class product_product(orm.Model):
 
     def _check_ean_key(self, cr, uid, ids):
         for rec in self.browse(cr, uid, ids):
-            if not check_ean(rec.ean13):
+            if not check_gtin(rec.ean13):
                 return False
         return True
 
@@ -90,7 +98,7 @@ class product_packaging(orm.Model):
 
     def _check_ean_key(self, cr, uid, ids):
         for rec in self.browse(cr, uid, ids):
-            if not check_ean(rec.ean):
+            if not check_gtin(rec.ean):
                 return False
         return True
 
@@ -108,7 +116,7 @@ class res_partner(orm.Model):
 
     def _check_ean_key(self, cr, uid, ids):
         for rec in self.browse(cr, uid, ids):
-            if not check_ean(rec.ean13):
+            if not check_gtin(rec.ean13):
                 return False
         return True
 
@@ -127,37 +135,37 @@ if __name__ == '__main__':
     
     class TestEANCheckers(unittest.TestCase):
     
-        def text_check_ean(self):
-            # Check all of the real-world GTINS via check_ean()
+        def test_check_gtin(self):
+            # Check all of the real-world GTINS via check_frin()
 
             # EAN13
-            self.assertTrue(check_ean('5013567421497'))
+            self.assertTrue(check_gtin('5013567421497'))
             
             # EAN8
-            self.assertTrue(check_ean('73513537'))  
+            self.assertTrue(check_gtin('73513537'))  
 
             # UPC
-            self.assertTrue(check_ean('813922012941'))
-            self.assertTrue(check_upc('813922013030'))            
+            self.assertTrue(check_gtin('813922012941'))
+            self.assertTrue(check_gtin('813922013030'))            
             
             # GTIN-14
-            self.assertTrue(check_ean('30012345678906'))
+            self.assertTrue(check_gtin('30012345678906'))
             
             # None should pass
-            self.assertTrue(check_ean(None))
+            self.assertTrue(check_gtin(None))
             
             # Non-numeric string should fail
-            self.assertFalse(check_ean("ABCDEFG"))
+            self.assertFalse(check_gtin("ABCDEFG"))
             
             # Short numeric string should fail
-            self.assertFalse(check_ean("12345"))
+            self.assertFalse(check_gtin("12345"))
             
             # GTINs with corrupted checksum should fail
-            self.assertFalse(check_ean('5013567421498'))            
-            self.assertFalse(check_ean('73513538'))            
-            self.assertTrue(check_ean('813922012941'))            
-            self.assertFalse(check_ean('813922013031'))            
-            self.assertFalse(check_ean('30012345678907'))                       
+            self.assertFalse(check_gtin('5013567421498'))            
+            self.assertFalse(check_gtin('73513538'))            
+            self.assertTrue(check_gtin('813922012941'))            
+            self.assertFalse(check_gtin('813922013031'))            
+            self.assertFalse(check_gtin('30012345678907'))                       
 
 
     unittest.main()

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -86,7 +86,7 @@ class product_product(orm.Model):
 
     _columns = {
         'ean13': fields.char(
-            'EAN/GTIN', size=14,
+            'EAN/GTIN', size = max(VALID_GTIN_LENGTHS),
             help="Code for %s" % HELP_MESSAGE),
     }
 
@@ -104,7 +104,7 @@ class product_packaging(orm.Model):
 
     _columns = {
         'ean': fields.char(
-            'EAN', size=14,
+            'EAN', size = max(VALID_GTIN_LENGTHS),
             help='Barcode number for %s' % HELP_MESSAGE),
         }
 
@@ -122,7 +122,7 @@ class res_partner(orm.Model):
 
     _columns = {
         'ean13': fields.char(
-            'EAN', size=14,
+            'EAN', size = max(VALID_GTIN_LENGTHS),
             help="Code for %s" % HELP_MESSAGE),
         }
 

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -202,3 +202,57 @@ class res_partner(orm.Model):
         }
 
     _constraints = [(_check_ean_key, CONSTRAINT_MESSAGE, ['ean13'])]
+    
+    
+if __name__ == '__main__':
+    
+    import unittest
+    
+    class TestEANCheckers(unittest.TestCase):
+    
+        def test_ean13(self):
+            # This is a valid EAN13
+            self.assertTrue(check_ean13('5013567421497'))
+               
+            # Tweak the last digit to make it invalid   
+            self.assertFalse(check_ean13('5013567421498'))
+            
+            
+        def test_ean8(self):
+            # This is a valid EAN8 from
+            # https://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29
+            self.assertTrue(check_ean8('73513537'))
+               
+            # Tweak the last digit to make it invalid   
+            self.assertFalse(check_ean8('73513538'))
+            
+            
+        def test_upc(self):
+            # This is a valid UPC from
+            self.assertTrue(check_upc('813922012941'))
+               
+            # Tweak the last digit to make it invalid   
+            self.assertFalse(check_upc('813922012942'))                      
+
+
+        def test_upc_ending_zero(self):
+            # Current check_upc() is broken if the check digit is zero
+            # (Test fails currently)
+            self.assertTrue(check_upc('813922013030'))
+               
+            # Tweak the last digit to make it invalid   
+            self.assertFalse(check_upc('813922013031'))
+            
+            
+        def test_gtin14(self):
+            # Example GTIN-14 from
+            # http://www.morovia.com/kb/Shipping-Container-Code-GS114-SCC14-GTIN14-10600.html
+            # (Test fails currently as check_gtin14() returns None)
+            self.assertTrue(check_gtin14('30012345678906'))
+               
+            # Tweak the last digit to make it invalid   
+            self.assertFalse(check_gtin14('30012345678907'))             
+
+
+    unittest.main()
+               

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -28,7 +28,8 @@ import re
 CONSTRAINT_MESSAGE = 'Error: Invalid EAN/GTIN code'
 HELP_MESSAGE = ("EAN8 EAN13 UPC JPC GTIN \n"
                 "http://en.wikipedia.org/wiki/Global_Trade_Item_Number")
-                
+
+VALID_GTIN_LENGTHS = [8, 10, 12, 13, 14]                
 
 # The official names of EANs, UPCs, etc. are now GTIN-x:
 # GTIN-14 (was DUN-14, ITF)
@@ -78,9 +79,6 @@ def check_gtinx(code):
     check = check % 10
 
     return check == int(code[-1])    
-
-
-VALID_GTIN_LENGTHS = [8, 10, 12, 13, 14]
 
 
 def check_gtin(code):

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -50,7 +50,7 @@ def check_ean8(eancode):
         return False
 
     sum = 0
-    ean_len = int(len(eancode))
+    ean_len = len(eancode)
     for i in range(ean_len-1):
         if is_pair(i):
             sum += 3 * int(eancode[i])
@@ -79,7 +79,7 @@ def check_upc(upccode):
         return False
 
     sum_pair = 0
-    ean_len = int(len(upccode))
+    ean_len = len(upccode)
     for i in range(ean_len-1):
         if is_pair(i):
             sum_pair += int(upccode[i])
@@ -108,7 +108,7 @@ def check_ean13(eancode):
         return False
 
     sum = 0
-    ean_len = int(len(eancode))
+    ean_len = len(eancode)
     for i in range(ean_len-1):
         pos = int(ean_len-2-i)
         if is_pair(i):

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -59,10 +59,6 @@ def check_ean8(eancode):
     if not eancode or not eancode.isdigit():
         return False
 
-    if not len(eancode) == 8:
-        _logger.warn('Ean8 code has to have a length of 8 characters.')
-        return False
-
     return check_eanx(eancode)
 
 
@@ -77,10 +73,6 @@ def check_upc(upccode):
     if not upccode or not upccode.isdigit():
         return False
 
-    if not len(upccode) == 12:
-        _logger.warn('UPC code has to have a length of 12 characters.')
-        return False
-
     return check_eanx(upccode)
 
 
@@ -93,10 +85,6 @@ def check_ean13(eancode):
     :return: boolean
     """
     if not eancode or not eancode.isdigit():
-        return False
-
-    if not len(eancode) == 13:
-        _logger.warn('Ean13 code has to have a length of 13 characters.')
         return False
 
     return check_eanx(eancode)

--- a/product_gtin/product_gtin.py
+++ b/product_gtin/product_gtin.py
@@ -31,9 +31,6 @@ HELP_MESSAGE = ("EAN8 EAN13 UPC JPC GTIN \n"
                 "http://en.wikipedia.org/wiki/Global_Trade_Item_Number")
 
 
-def is_pair(x):
-    return not x % 2
-    
 def check_eanx(code):
     """
     The routine for calculating GTIN checksums is the same for all types,
@@ -44,10 +41,10 @@ def check_eanx(code):
     gtin_len = len(code)
     for i in range(gtin_len-1):
         pos = int(gtin_len-2-i)
-        if is_pair(i):
-            total += 3 * int(code[pos])
-        else:
+        if i % 2:
             total += int(code[pos])
+        else:
+            total += 3 * int(code[pos])
     check = 10 - operator.mod(total, 10)
     if check == 10:
         check = 0


### PR DESCRIPTION
I discovered that the check_upc() routine was not working when the check-digit was zero, as it was missing the:

```
if check == 10:
 check = 10
```

that the other `check_x()` routines have.

Once I started poking around the rules for GTIN checksums, I discovered that the algorithm is identical for EAN-8, EAN-13, UPC, EAN-14---you just have to start at the right hand side (ignoring the check digit).

So this has led to some major re-factoring as there was considerable duplication of the GTIN checking algorithm.

I also added some unit tests, as it was a gap that this module did not have any real-world EANs or UPCs to verify the `check_x()` routines with.

Finally, once all of the identifiers are being checked by the same function, the section to route the identifier to the appropriate check function was redundant, so I zapped that too!
