### PR TITLE
[8.0][fix] onchange method was incompletely migrated and produced a stack trace

### DIFF
--- a/product_pricelist_fixed_price/i18n/fr.po
+++ b/product_pricelist_fixed_price/i18n/fr.po
@@ -18,28 +18,28 @@ msgstr ""
 #. module: product_pricelist_fixed_price
 #: view:product.pricelist.item:product_pricelist_fixed_price.product_pricelist_item_fixedprice_form
 msgid "Base Price"
-msgstr ""
+msgstr "Prix de base"
 
 #. module: product_pricelist_fixed_price
 #: help:product.pricelist.item,base_ext:0
 msgid "Base price for computation"
-msgstr ""
+msgstr "Prix de base pour le calcul"
 
 #. module: product_pricelist_fixed_price
 #: field:product.pricelist.item,base_ext:0
 msgid "Based on"
-msgstr ""
+msgstr "Basée sur"
 
 #. module: product_pricelist_fixed_price
 #: code:addons/product_pricelist_fixed_price/model/product_pricelist_item.py:31
 #, python-format
 msgid "Fixed Price"
-msgstr ""
+msgstr "Prix fixe"
 
 #. module: product_pricelist_fixed_price
 #: model:ir.model,name:product_pricelist_fixed_price.model_product_pricelist_item
 msgid "Pricelist item"
-msgstr ""
+msgstr "Élément de la liste de prix"
 
 #. module: product_pricelist_fixed_price
 #: view:product.pricelist.item:product_pricelist_fixed_price.product_pricelist_item_fixedprice_form

--- a/product_pricelist_fixed_price/model/product_pricelist_item.py
+++ b/product_pricelist_fixed_price/model/product_pricelist_item.py
@@ -42,8 +42,9 @@ class ProductPricelistItem(models.Model):
 
     @api.onchange('base_ext')
     def change_base_ext(self):
-        if self.base_ext == -3:
-            base = self.env['product.price.type'].search(
-                [], limit=1, order='id')
-            self.base = base[0]
+        base = self.base_ext
+        if base == -3:
+            base = self._get_default_base(
+                {'type': self.price_version_id.pricelist_id.type})
             self.price_discount = -1
+        self.base = base

--- a/product_pricelist_fixed_price/tests/__init__.py
+++ b/product_pricelist_fixed_price/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_product_pricelist_fixed_price

--- a/product_pricelist_fixed_price/tests/test_product_pricelist_fixed_price.py
+++ b/product_pricelist_fixed_price/tests/test_product_pricelist_fixed_price.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# © 2016  Olivier Laurent, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import openerp.tests.common as common
+
+
+class TestProductPricelistFixedPrice(common.TransactionCase):
+
+    def test_onchange_base_ext(self):
+        """ Check for the value of 'base' field when changing the value of
+            'base_ext' field:
+            * for sale price list
+            * for purchase price list
+        """
+        item_obj = self.env['product.pricelist.item']
+        plv = self.env.ref('product.ver0')
+        base_sale = item_obj._get_default_base({'type': 'sale'})
+        vals = {
+            'price_version_id': plv.id,
+            'base_ext': base_sale,
+        }
+
+        # check for the 'base' field, it must be equal to base_ext=base_sale
+        # when base_ext != -3
+        item = item_obj.new(values=vals)
+        item.change_base_ext()
+        self.assertEqual(item.base, item.base_ext)
+        self.assertEqual(item.base, base_sale)
+
+        # force a fixed price
+        vals['base_ext'] = -3
+
+        # check again, it must be the same as default 'base' value
+        item = item_obj.new(values=vals)
+        item.change_base_ext()
+        self.assertNotEqual(item.base, item.base_ext)
+        self.assertEqual(item.base, base_sale)
+        self.assertEqual(item.price_discount, -1.0)
+
+        # change the type of the pricelist => purchase
+        plv.pricelist_id.type = 'purchase'
+        base_pur = item_obj._get_default_base({'type': 'purchase'})
+        self.assertNotEqual(base_sale, base_pur)
+
+        vals['base_ext'] = base_pur
+
+        # check for the 'base' field, it must be equal to base_ext=base_pur
+        item = item_obj.new(values=vals)
+        item.change_base_ext()
+        self.assertEqual(item.base, item.base_ext)
+        self.assertEqual(item.base, base_pur)
+
+        # force a fixed price
+        vals['base_ext'] = -3
+
+        # check again, it must be the same as default 'base' value
+        item = item_obj.new(values=vals)
+        item.change_base_ext()
+        self.assertNotEqual(item.base, item.base_ext)
+        self.assertEqual(item.base, base_pur)
+        self.assertEqual(item.price_discount, -1.0)
+
+        pass


### PR DESCRIPTION
- when changing the value of `base_ext` to `-3` (i.e. fixed price), a stack trace is produced.
- when changing this field to another value, the `base` field was not updated leaving visible and required (but most of cases irrelvant) the field related to another pricelist
