### PR TITLE
[FIX] Fix field base_pricelist_id visibility when base is fixed price

### DIFF
--- a/product_pricelist_fixed_price/view/product_pricelist_item_view.xml
+++ b/product_pricelist_fixed_price/view/product_pricelist_item_view.xml
@@ -57,6 +57,9 @@
                     <attribute name="attrs"
                         >{'invisible': [('base_ext', '=', -3)]}</attribute>
                 </field>
+                <field name="base_pricelist_id" position="attributes">
+                    <attribute name="attrs">{'invisible': [('base_ext', '=', -3)]}</attribute>
+                </field>
             </field>
         </record>
 


### PR DESCRIPTION
If you set fixed price on a pricelist item save and go back on the item you can see base_pricelist_id field.
This PR fix the problem
