### PR TITLE
FIX product_pricelist_fixed_price: creation of new fixed price list

### DIFF
--- a/product_pricelist_fixed_price/model/product_pricelist_item.py
+++ b/product_pricelist_fixed_price/model/product_pricelist_item.py
@@ -57,8 +57,9 @@ class ProductPricelistItem(models.Model):
             if base_ext != FIXED_PRICE_TYPE:
                 base = base_ext
             else:
-                base = self._get_default_base(
-                    {'type': self.price_version_id.pricelist_id.type})
+                base = self._get_default_base({
+                    'type': self.price_version_id.pricelist_id.type or 'sale'
+                })
         else:
             # getting here we are sure base is in vals
             base = vals['base']


### PR DESCRIPTION
FIX the following use case:

Install product_pricelist_fixed_price and sale
Create a new product P1
Create a new price list 'fixed' with a version and a rule linked to product P1, based on 'fixed price' and set 'new price' = 100
Save
Create a new sale order, select 'fixed' price list, add a line, select P1 product, get

No valid pricelist line found ! :Cannot find a pricelist line matching this product and quantity.
You have to change either the product, the quantity or the pricelist
