### PR TITLE
[FIX] Prevented the system from copying the field prefix_code

### DIFF
--- a/product_code_builder/models/product.py
+++ b/product_code_builder/models/product.py
@@ -20,6 +20,7 @@ class ProductTemplate(models.Model):
 
     prefix_code = fields.Char(
         string='Internal Reference',
+        copy=False,
         help="This is the code of the product model"
              "If Automatic Reference is checked, "
              "this field is used as a prefix for "


### PR DESCRIPTION
As the field prefix_code is declared as unique, through an SQL constraint, trying to duplicate a product.template (or also product.product) record would raise an error. The system should prevent the copy method from duplicating this field.
