### PR TITLE
[FIX] Extended copy method for model product.product

### DIFF
--- a/product_code_builder_sequence/models/product_product.py
+++ b/product_code_builder_sequence/models/product_product.py
@@ -46,3 +46,18 @@ class ProductTemplate(models.Model):
                     'prefix_code': self.prefix_code + _('-copy'),
                 })
         return super(ProductTemplate, self).copy(default)
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.multi
+    def copy(self, default=None):
+        for product in self:
+            if default is None:
+                default = {}
+            if product.prefix_code:
+                default.update({
+                    'prefix_code': self.prefix_code + _('-copy'),
+                })
+        return super(ProductProduct, self).copy(default)

--- a/product_code_builder_sequence/models/product_product.py
+++ b/product_code_builder_sequence/models/product_product.py
@@ -38,13 +38,13 @@ class ProductTemplate(models.Model):
 
     @api.multi
     def copy(self, default=None):
-        for product in self:
-            if default is None:
-                default = {}
-            if product.prefix_code:
-                default.update({
-                    'prefix_code': self.prefix_code + _('-copy'),
-                })
+        self.ensure_one()
+        if default is None:
+            default = {}
+        if 'prefix_code' not in default and self.prefix_code:
+            default.update({
+                'prefix_code': self.prefix_code + _('-copy'),
+            })
         return super(ProductTemplate, self).copy(default)
 
 
@@ -53,11 +53,11 @@ class ProductProduct(models.Model):
 
     @api.multi
     def copy(self, default=None):
-        for product in self:
-            if default is None:
-                default = {}
-            if product.prefix_code:
-                default.update({
-                    'prefix_code': self.prefix_code + _('-copy'),
-                })
+        self.ensure_one()
+        if default is None:
+            default = {}
+        if 'prefix_code' not in default and self.prefix_code:
+            default.update({
+                'prefix_code': self.prefix_code + _('-copy'),
+            })
         return super(ProductProduct, self).copy(default)


### PR DESCRIPTION
Currently this module only extends the copy method for the model product.template, in order to provide a non-duplicated value for the field prefix_code.
Unfortunately, when a user tries to duplicate a product (model product.product), the copy method of the product.template model is not called (only the copy method of the product.product model is called and it doesn't recall the copy method of the product.template model, only its create method). 
The result is that the system tries to duplicate the field prefix_code on the new product.template record and this raises an error, as the field prefix_code is declared to be unique.

The solution that I propose is to simply extend the copy method in the product.product model in order to prevent the system from duplicating a unique field.
