### PR TITLE
[FIX] product_attribute_priority

### DIFF
--- a/product_attribute_priority/models/product.py
+++ b/product_attribute_priority/models/product.py
@@ -4,8 +4,8 @@
 from openerp import models, fields
 
 SEQUENCE_HELP = ("Set the display order of the attributes in backoffice "
-                 "and reports"),
-SEQUENCE_ATTR_HELP = SEQUENCE_HELP, ' (defined in Product Attribute)',
+                 "and reports")
+SEQUENCE_ATTR_HELP = SEQUENCE_HELP + " (defined in Product Attribute)"
 
 
 class ProductAttribute(models.Model):


### PR DESCRIPTION
the `help` of fields  must be a string, not a tuple.
