### PR TITLE
[8.0] fix sequence for pricelist items in pricelist_per_product module

### DIFF
--- a/pricelist_per_product/pricelist.py
+++ b/pricelist_per_product/pricelist.py
@@ -72,7 +72,9 @@ class ProductPricelistItem(models.Model):
         readonly=True)
     related_sequence = fields.Integer(
         String='Sequence',
-        related="sequence")
+        related="sequence",
+        help="Allows to modify the sequence manually because "
+             "the sequence field is difficult to modify because 'handle'.")
 
     @api.multi
     def button_product(self):
@@ -91,12 +93,38 @@ class ProductPricelistItem(models.Model):
         }
 
     @api.model
+    def update_sequence_price_grid(self, vals):
+        """
+            In sale order line, we want to use as a priority
+            the product pricelist item associated with the product variant.
+            But in Odoo, it's the product pricelist item which has the
+            smallest sequence that is used.
+            That's why, we put a smaller sequence to the product pricelist item
+            of the product variant and a larger sequence to
+            the product pricelist item of the product template.
+        """
+        product_id = vals.get('product_id', self.product_id)
+        product_tmpl_id = vals.get('product_tmpl_id', self.product_tmpl_id)
+        if product_id:
+            vals['related_sequence'] = 5
+        elif product_tmpl_id:
+            vals['related_sequence'] = 10
+
+    @api.model
     def create(self, vals):
         if self.env['product.pricelist.version'].browse(
                 vals['price_version_id']).price_grid:
+            self.update_sequence_price_grid(vals)
             vals.update({
                 'price_discount': -1,
-                'sequence': 1,
                 'base': 1,
             })
         return super(ProductPricelistItem, self).create(vals)
+
+    @api.multi
+    def write(self, vals):
+        for item in self:
+            if 'product_id' in vals:
+                item.update_sequence_price_grid(vals)
+            super(ProductPricelistItem, item).write(vals)
+        return True


### PR DESCRIPTION
In sale order line, we want to use as a priority the product pricelist item associated with the product variant.But in Odoo, it's the product pricelist item which has the smallest sequence that is used.
That's why, I put a smaller sequence to the product pricelist item of the product variant and a larger sequence to the product pricelist item of the product template.