### PR TITLE
[10.0] re-introduce state field on product

### DIFF
--- a/product_state/README.rst
+++ b/product_state/README.rst
@@ -1,0 +1,69 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=============
+Product State
+=============
+
+In version 10.0 Odoo removes the state field from product. This module re-introduces it and allows simple product life cycle.
+
+Installation
+============
+
+To install this module, you need to:
+
+* Click on install button
+
+Configuration
+=============
+
+Nothing to configure.
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/135/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/product-attribute/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/product-attribute/issues/new?body=module:%20product_life_period%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Cedric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_state/__init__.py
+++ b/product_state/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/product_state/__manifest__.py
+++ b/product_state/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': "Product State",
+    'description': """
+        Module introducing a state field on product template""",
+    'author': 'ACSONE SA/NV, Odoo Community Association (OCA)',
+    'website': "http://acsone.eu",
+    'category': 'Product',
+    'version': '10.0.1.0.0',
+    'license': 'AGPL-3',
+    'depends': [
+        'product',
+    ],
+    'data': [
+        'views/product_views.xml',
+    ],
+    'application': True,
+}

--- a/product_state/models/__init__.py
+++ b/product_state/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import product_template

--- a/product_state/models/product_template.py
+++ b/product_state/models/product_template.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    state = fields.Selection(selection=[('draft', 'In Development'),
+                                        ('sellable', 'Normal'),
+                                        ('end', 'End of Lifecycle'),
+                                        ('obsolete', 'Obsolete')],
+                             string='Status',
+                             default='sellable',
+                             index=True)

--- a/product_state/views/product_views.xml
+++ b/product_state/views/product_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.common.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <sheet position="before">
+                <header>
+                    <field name="state" widget="statusbar" clickable="True"/>
+                </header>
+            </sheet>
+        </field>
+    </record>
+</odoo>

--- a/setup/product_state/odoo/__init__.py
+++ b/setup/product_state/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/product_state/odoo/addons/__init__.py
+++ b/setup/product_state/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/product_state/odoo/addons/product_state
+++ b/setup/product_state/odoo/addons/product_state
@@ -1,0 +1,1 @@
+../../../../product_state

--- a/setup/product_state/setup.py
+++ b/setup/product_state/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Since version 10.0 Odoo removed the state field on product which was really useful to manage simple product life cycle.

I suggest this module to re-introduce it.