### PR TITLE
[8.0][IMP] Replicate sale order line names behavior

### DIFF
--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -28,6 +28,7 @@
     "depends": [
         "base",
         "product",
+        "sale",
     ],
     "data": [
         "views/product_view.xml",

--- a/product_supplierinfo_for_customer/models/__init__.py
+++ b/product_supplierinfo_for_customer/models/__init__.py
@@ -4,5 +4,7 @@
 ##############################################################################
 from . import product_supplierinfo
 from . import product_template
+from . import product_product
 from . import res_partner
 from . import product_pricelist
+from . import sale_order_line

--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.model
+    def _name_get(self, dict_data):
+        name = dict_data.get('name', '')
+        code = (
+            self.env.context.get('display_default_code', True) and
+            dict_data.get('default_code', False) or
+            False
+        )
+        if code:
+            name = '[%s] %s' % (code, name)
+        return (dict_data['id'], name)
+
+    @api.multi
+    def name_get(self):
+        ResPartner = self.env['res.partner']
+        result = super(ProductProduct, self).name_get()
+
+        partner_id = self.env.context.get('sale_partner_id', False)
+        if partner_id:
+            partner_ids = [
+                partner_id,
+                ResPartner.browse(partner_id).commercial_partner_id.id,
+            ]
+            last_result = result
+            result = []
+            for product in self:
+                customers = ResPartner
+                result_tuple = filter(lambda r: r[0] == product.id, last_result)
+                if partner_ids:
+                    customers = product.customer_ids.filtered(
+                        lambda pr: pr.name.id in partner_ids)
+                if not customers:
+                    result += [result_tuple and result_tuple[0]]
+                    continue
+                name = result_tuple and result_tuple[0][1] or ""
+                variant = ", ".join(product.attribute_value_ids.mapped("name"))
+                for customer in customers:
+                    customer_variant = (
+                        customer.product_name and (
+                            variant and "%s (%s)" % (customer.product_name, variant) or
+                            customer.product_name
+                        ) or False)
+                    mydict = {
+                        'id': product.id,
+                        'name': customer_variant or name,
+                        'default_code': customer.product_code or product.default_code,
+                    }
+                    result += [self._name_get(mydict)]
+        return result

--- a/product_supplierinfo_for_customer/models/sale_order_line.py
+++ b/product_supplierinfo_for_customer/models/sale_order_line.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.multi
+    def product_id_change(
+            self, pricelist, product, qty=0,
+            uom=False, qty_uos=0, uos=False, name='', partner_id=False,
+            lang=False, update_tax=True, date_order=False, packaging=False,
+            fiscal_position=False, flag=False):
+
+        ProductProduct = self.env["product.product"]
+        product_id = product
+
+        res = super(SaleOrderLine, self).product_id_change(
+            pricelist, product, qty=qty, uom=uom, qty_uos=qty_uos, uos=uos,
+            name=name, partner_id=partner_id, lang=lang, update_tax=update_tax,
+            date_order=date_order, packaging=packaging,
+            fiscal_position=fiscal_position, flag=flag)
+
+        res.setdefault("value", {})
+        if "name" in res["value"]:
+            del res["value"]["name"]
+
+        if product_id:
+            if partner_id:
+                ProductProduct = ProductProduct.with_context(sale_partner_id=partner_id)
+            product = ProductProduct.browse(product_id)
+            # Call name_get() with partner in the context to eventually match
+            # name and description in the seller_ids field
+            if not name:
+                dummy, name = product.name_get()[0]
+                if product.description_sale:
+                    name += '\n' + product.description_sale
+                res['value'].update({'name': name})
+        return res


### PR DESCRIPTION
Replicate behavior of *sale.order.line:name* field, set to customer product code + name instead of product code + name.