### PR TITLE
[9.0][ADD] module product_variant_exclusion

### DIFF
--- a/product_variant_exclusion/README.rst
+++ b/product_variant_exclusion/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Product Variant Exclusion
+=========================
+
+This module extends the functionality of product variants to allow you to
+select which combination of product attribute values you want to exclude
+from the product variants.
+
+It's build with a focus on performance using lots of attribute values, as
+it avoids creating unnecessary product.product should the combination of
+attribute values be part of an exclusion.
+
+Installation
+============
+
+Just install it
+
+Usage
+=====
+
+To use this module, you need to activate Product variants.
+On product template's form, under the variants tab will appear a new tree view
+allowing you to add variant exclusions.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/135/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/product-attribute/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Akim Juillerat <akim.juillerat@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_variant_exclusion/__init__.py
+++ b/product_variant_exclusion/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_variant_exclusion/__openerp__.py
+++ b/product_variant_exclusion/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{'name': 'Product Variant Exclusion',
+ 'description': "Allows to exclude Product variants based on attribute value",
+ 'version': '9.0.1.0.0',
+ 'author': 'Camptocamp SA, Odoo Community Association (OCA)',
+ 'license': 'AGPL-3',
+ 'category': 'Product',
+ 'depends': [
+     'product',
+ ],
+ 'website': 'http://www.camptocamp.com',
+ 'data': [
+     'views/product.xml',
+     'security/ir.model.access.csv'
+ ],
+ 'installable': True,
+ }

--- a/product_variant_exclusion/__openerp__.py
+++ b/product_variant_exclusion/__openerp__.py
@@ -2,7 +2,6 @@
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Product Variant Exclusion',
- 'description': "Allows to exclude Product variants based on attribute value",
  'version': '9.0.1.0.0',
  'author': 'Camptocamp SA, Odoo Community Association (OCA)',
  'license': 'AGPL-3',

--- a/product_variant_exclusion/models/__init__.py
+++ b/product_variant_exclusion/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/product_variant_exclusion/models/product.py
+++ b/product_variant_exclusion/models/product.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import models, fields, api, _
+from openerp.exceptions import ValidationError, UserError
+import psycopg2
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = 'product.template'
+
+    variant_exclusion_ids = fields.One2many(
+        'product.variant.exclusion', 'product_tmpl_id', 'Variants exlcusion'
+    )
+
+    allowed_value_ids = fields.Many2many('product.attribute.value',
+                                         compute='_compute_allowed_values')
+
+    @api.depends('attribute_line_ids.value_ids')
+    def _compute_allowed_values(self):
+        for template in self:
+            template.allowed_value_ids = template.attribute_line_ids.mapped(
+                'value_ids')
+
+    @api.multi
+    def write(self, vals):
+        res = super(ProductTemplate, self).write(vals)
+        if 'variant_exclusion_ids' in vals:
+            self.create_variant_ids()
+            self.delete_variant_ids()
+        return res
+
+    @api.multi
+    def delete_variant_ids(self):
+        exclusions = self.env['product.variant.exclusion'].search(
+            [('product_tmpl_id', '=', self.id)])
+        for template in self:
+            for product in template.product_variant_ids:
+                for excl in exclusions:
+                    if set(excl.attribute_value_ids.ids) <= set(
+                            product.attribute_value_ids.ids):
+                        try:
+                            with self.env.cr.savepoint():
+                                product.unlink()
+                        except (psycopg2.Error, ValidationError):
+                            product.write({'active': False})
+                        break
+
+
+class ProductAttributeLine(models.Model):
+
+    _inherit = 'product.attribute.line'
+
+    @api.multi
+    def write(self, vals):
+        attr_values = vals.get('value_ids')[0][2]
+        if len(attr_values) <= 1:
+            for line in self:
+                for exclusion in line.product_tmpl_id.variant_exclusion_ids:
+                    if set(attr_values) <= set(
+                            exclusion.attribute_value_ids.ids):
+                        raise UserError(_(
+                            'You cannot leave only one value on a line '
+                            'if this value is part of an exclusion'))
+        return super(ProductAttributeLine, self).write(vals)
+
+    @api.multi
+    def unlink(self):
+        for line in self:
+            for val_id in line.value_ids.ids:
+                if val_id in line.product_tmpl_id.variant_exclusion_ids.mapped(
+                        'attribute_value_ids').ids:
+                    raise UserError(_(
+                        'You cannot delete an attribute line, when '
+                        'one of its values is part of an exclusion'))
+
+
+class ProductVariantExclusion(models.Model):
+
+    _name = 'product.variant.exclusion'
+
+    product_tmpl_id = fields.Many2one('product.template', required=True)
+    attribute_value_ids = fields.Many2many('product.attribute.value',
+                                           required=True)
+
+    @api.model
+    def create(self, vals):
+        value_ids = vals.get('attribute_value_ids')[0][2]
+        if len(value_ids) <= 1:
+            raise UserError(_(
+                'You cannot create an exclusion with only one value !'))
+        template_lines = self.env['product.attribute.line'].search([
+            ('product_tmpl_id', '=', vals.get('product_tmpl_id')),
+            ('value_ids', 'in', value_ids)])
+        for line in template_lines:
+            if len(line.value_ids) <= 1 and set(line.value_ids.ids) <= set(
+                    value_ids):
+                raise UserError(_(
+                    'You cannot create an exclusion for '
+                    'a unique attribute line value !'))
+        return super(ProductVariantExclusion, self).create(vals)
+
+    @api.multi
+    def write(self, vals):
+        value_ids = vals.get('attribute_value_ids')[0][2]
+        if len(value_ids) <= 1:
+            raise UserError(_(
+                'You cannot modify an exclusion to have only one value !'))
+        return super(ProductVariantExclusion, self).write(vals)
+
+
+class ProductProduct(models.Model):
+
+    _inherit = 'product.product'
+
+    @api.multi
+    def write(self, vals):
+        if self._context.get('create_product_variant'):
+            products_to_write = self.env['product.product']
+            # Case 1: Adding new attribute value
+            if vals.get('attribute_value_ids'):
+                return super(ProductProduct, self).write(vals)
+            # Case 2: Setting active to True
+            if vals.get('active'):
+                for product in self:
+                    product_value_ids = product.attribute_value_ids.ids
+                    if product.product_tmpl_id.variant_exclusion_ids:
+                        for excl in product.product_tmpl_id.\
+                                variant_exclusion_ids:
+                            if not set(excl.attribute_value_ids.ids) <= set(
+                                    product_value_ids):
+                                products_to_write += product
+                    else:
+                        products_to_write += product
+                return super(ProductProduct, products_to_write).write(vals)
+            # Case 3: Setting active to False
+            elif not vals.get('active', True):
+                return super(ProductProduct, self).write(vals)
+            else:
+                raise UserError(_('Something went wrong'))
+        else:
+            return super(ProductProduct, self).write(vals)
+
+    @api.model
+    def create(self, vals):
+        # Case 4: Creating new product variant
+        if self._context.get('create_product_variant'):
+            template_id = vals.get('product_tmpl_id')
+            value_ids = vals.get('attribute_value_ids')[0][2]
+
+            template_exclusions = self.env['product.variant.exclusion'].search(
+                [('product_tmpl_id', '=', template_id)])
+
+            for excl in template_exclusions:
+                if set(excl.attribute_value_ids.ids) <= set(value_ids):
+                    return self
+
+        return super(ProductProduct, self).create(vals)

--- a/product_variant_exclusion/models/product.py
+++ b/product_variant_exclusion/models/product.py
@@ -54,8 +54,9 @@ class ProductAttributeLine(models.Model):
 
     @api.multi
     def write(self, vals):
-        attr_values = vals.get('value_ids')[0][2]
-        if len(attr_values) <= 1:
+        attr_values = vals.get('value_ids', False) and vals.get(
+            'value_ids')[0][2]
+        if attr_values and len(attr_values) <= 1:
             for line in self:
                 for exclusion in line.product_tmpl_id.variant_exclusion_ids:
                     if set(attr_values) <= set(

--- a/product_variant_exclusion/security/ir.model.access.csv
+++ b/product_variant_exclusion/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_variant_exclusion_user,access_product_variant_exclusion_user,model_product_variant_exclusion,base.group_user,1,0,0,0
+access_product_variant_exclusion_manager,access_product_variant_exclusion_manager,model_product_variant_exclusion,base.group_sale_manager,1,1,1,1

--- a/product_variant_exclusion/tests/__init__.py
+++ b/product_variant_exclusion/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/product_variant_exclusion/tests/test_product_variant_exclusion.py
+++ b/product_variant_exclusion/tests/test_product_variant_exclusion.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestProductVariantExclusion(TransactionCase):
+
+    def setUp(self):
+        super(TestProductVariantExclusion, self).setUp()
+        sizes = [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47]
+        colours = ['Green', 'Black', 'Blue', 'Yellow']
+        genders = ['Women', 'Men']
+
+        ProductAttribute = self.env['product.attribute']
+
+        self.attribute_size = ProductAttribute.create({
+            'name': 'size',
+            'value_ids': [(0, False, {'name': s}) for s in sizes],
+        })
+        self.attribute_colour = ProductAttribute.create({
+            'name': 'Colour',
+            'value_ids': [(0, False, {'name': c}) for c in colours],
+        })
+        self.attribute_gender = ProductAttribute.create({
+            'name': 'Gender',
+            'value_ids': [(0, False, {'name': g}) for g in genders],
+        })
+
+
+    def test_create_product_template(self):
+
+        ProductTemplate = self.env['product.template']
+
+        self.women_value = self.env['product.attribute.value'].search([
+            ('name', '=', 'Women')])
+
+        self.product_template = ProductTemplate.create({
+            'name': 'Test shoes',
+            'type': 'consu',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'attribute_line_ids': [(0, False, {
+                'attribute_id': self.attribute_size.id,
+                'value_ids': [(6, False, self.attribute_size.value_ids.ids)],
+            }), (0, False, {
+                'attribute_id': self.attribute_colour.id,
+                'value_ids': [(6, False, self.attribute_colour.value_ids.ids)],
+            }), (0, False, {
+                'attribute_id': self.attribute_gender.id,
+                'value_ids': [(6, False, self.attribute_gender.value_ids.ids)],
+            })],
+            'variant_exclusion_ids': [(0, False, {
+                'attribute_value_ids': [(6, False, [v.id,
+                                                    self.women_value.id])]})
+                                      for v in self.attribute_size.value_ids
+                                      if int(v.name) > 40],
+        })
+        self.assertEqual(self.product_template.product_variant_count, 92)

--- a/product_variant_exclusion/tests/test_product_variant_exclusion.py
+++ b/product_variant_exclusion/tests/test_product_variant_exclusion.py
@@ -28,7 +28,6 @@ class TestProductVariantExclusion(TransactionCase):
             'value_ids': [(0, False, {'name': g}) for g in genders],
         })
 
-
     def test_create_product_template(self):
 
         ProductTemplate = self.env['product.template']

--- a/product_variant_exclusion/views/product.xml
+++ b/product_variant_exclusion/views/product.xml
@@ -8,9 +8,9 @@
             <xpath expr="//page[@name='variants']//field[@name='attribute_line_ids']" position="after">
                 <group>
                     <field name="allowed_value_ids" invisible="1"/>
-                    <field name="variant_exclusion_ids" widget="one2many_list" context="{'show_attribute': False}">
+                    <field name="variant_exclusion_ids" widget="one2many_list" context="{'show_attribute': True}" nolabel="1">
                         <tree string="Exclusions" editable="bottom">
-                            <field name="attribute_value_ids" widget="many2many_tags" options="{'no_create_edit': True}" domain="[('id', 'in', parent.allowed_value_ids and parent.allowed_value_ids[0][2] or [])]"/>
+                            <field name="attribute_value_ids" string="Variants exclusions" widget="many2many_tags" options="{'no_create_edit': True}" domain="[('id', 'in', parent.allowed_value_ids and parent.allowed_value_ids[0][2] or [])]"/>
                         </tree>
                     </field>
                 </group>

--- a/product_variant_exclusion/views/product.xml
+++ b/product_variant_exclusion/views/product.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_only_form_view" model="ir.ui.view">
+        <field name="name">product.template.product.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='variants']//field[@name='attribute_line_ids']" position="after">
+                <group>
+                    <field name="allowed_value_ids" invisible="1"/>
+                    <field name="variant_exclusion_ids" widget="one2many_list" context="{'show_attribute': False}">
+                        <tree string="Exclusions" editable="bottom">
+                            <field name="attribute_value_ids" widget="many2many_tags" options="{'no_create_edit': True}" domain="[('id', 'in', parent.allowed_value_ids and parent.allowed_value_ids[0][2] or [])]"/>
+                        </tree>
+                    </field>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Product Variant Exclusion
=========================

This module extends the functionality of product variants to allow you to
select which combination of product attribute values you want to exclude
from the product variants.

It's build with a focus on performance using lots of attribute values, as
it avoids creating unnecessary product.product should the combination of
attribute values be part of an exclusion.