### PR TITLE
[FIX] product_sequence: Fix testing results

### DIFF
--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -74,7 +74,7 @@ class ProductProduct(models.Model):
             super(ProductProduct, product).write(vals)
         return True
 
-    @api.one
+    @api.multi
     def copy(self, default=None):
         if default is None:
             default = {}


### PR DESCRIPTION
Currently the [travis stable 8.0 build is red](https://travis-ci.org/OCA/product-attribute/builds/241438080) because test's `product_sequence`
This PR avoid recompute product values when the followers are added and mute a expected error.