### PR TITLE
[IMP] product_brand: update form view for 10.0

### DIFF
--- a/product_brand/README.rst
+++ b/product_brand/README.rst
@@ -68,6 +68,7 @@ Contributors
 * Leonardo Donelli <donelli@webmonks.it>
 * Serpent Consulting Services Pvt. Ltd. <jay.vora@serpentcs.com>
 * Marcelo Pickler <loxamir@gmail.com>
+* Andrius Laukavičius <ala@boolit.eu> (Boolit)
 
 Maintainer
 ----------

--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -32,28 +32,25 @@
         <field name="name">product.brand.form</field>
         <field name="model">product.brand</field>
         <field name="arch" type="xml">
-            <form string="Product Brand" version="7.0">
+            <form>
                 <sheet>
-                    <field name="logo" widget="image" class="oe_avatar oe_left"/>
-                    <div class="oe_title">
-                        <div class="oe_edit_only">
-                            <label for="name" string="Brand Name"/>
-                        </div>
-                        <h1>
-                            <field name="name"/>
-                        </h1>
-                    </div>
-                    <div class="oe_right oe_button_box">
-                        <button
-                            class="oe_inline oe_stat_button"
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(action_open_brand_products)d"
                             type="action"
-                            name="%(action_open_brand_products)d"
+                            class="oe_stat_button"
                             icon="fa-cubes">
-                            <field name="products_count" string="Products" widget="statinfo" />
+                            <field name="products_count" widget="statinfo" string="Products"/>
                         </button>
                     </div>
+                    <field name="logo" widget="image" class="oe_avatar"/>
+                    <div class="oe_title">
+                            <label for="name" string="Brand Name" class="oe_edit_only"/>
+                            <h1><field name="name"/></h1>
+                    </div>
                     <group>
-                        <field name="partner_id"/>
+                        <group>
+                            <field name="partner_id"/>
+                        </group>
                     </group>
                     <group string="Description">
                         <field name="description" nolabel="1"/>


### PR DESCRIPTION
Old form view was out of order: form blocks misaligned, because it was
not using Odoo 10 views styling and layout.

Before change form looks like this: 

![before-form](https://user-images.githubusercontent.com/7812986/27580108-5d120f56-5b32-11e7-8a09-bafb5891e5c9.png)

After change:

![after-form](https://user-images.githubusercontent.com/7812986/27580135-69254344-5b32-11e7-9757-9221e526fa30.png)

New form better use empty space in a view and form blocks are aligned properly.