### PR TITLE
[8.0][product_dimension][FIX] Fix volume being incorrectly calculated due to rounding issues.

### DIFF
--- a/product_dimension/__openerp__.py
+++ b/product_dimension/__openerp__.py
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {
     'name': 'Product Dimension',
-    'version': '8.0.3.0.0',
+    'version': '8.0.2.0.1',
     'category': 'Product',
     'author':  'ADHOC SA,Camptocamp,Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/product_dimension/__openerp__.py
+++ b/product_dimension/__openerp__.py
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 {
     'name': 'Product Dimension',
-    'version': '8.0.2.0.0',
+    'version': '8.0.3.0.0',
     'category': 'Product',
     'author':  'ADHOC SA,Camptocamp,Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/product_dimension/product.py
+++ b/product_dimension/product.py
@@ -85,7 +85,8 @@ class ProductTemplate(models.Model):
             from_unit=dimensional_uom,
             qty=measure,
             to_unit=uom_meters,
-            round=False)
+            round=False,
+            )
 
     length = fields.Float(related='product_variant_ids.length')
     height = fields.Float(related='product_variant_ids.height')

--- a/product_dimension/product.py
+++ b/product_dimension/product.py
@@ -42,7 +42,8 @@ class ProductProduct(models.Model):
         return self.env['product.uom']._compute_qty_obj(
             from_unit=dimensional_uom,
             qty=measure,
-            to_unit=uom_meters)
+            to_unit=uom_meters,
+            round=False)
 
     @api.model
     def _get_dimension_uom_domain(self):
@@ -83,7 +84,8 @@ class ProductTemplate(models.Model):
         return self.env['product.uom']._compute_qty_obj(
             from_unit=dimensional_uom,
             qty=measure,
-            to_unit=uom_meters)
+            to_unit=uom_meters,
+            round=False)
 
     length = fields.Float(related='product_variant_ids.length')
     height = fields.Float(related='product_variant_ids.height')


### PR DESCRIPTION
Without this fix, volume was being incorrectly calculated in some cases.

For instance,

UOM: cm
Length: 57.00
Height: 8.00
Width: 19.50

Resulting volume: 0.005 when it should be 0.009 (0.008892, if not rounded)