### PR TITLE
[8.0][IMP] product_supplierinfo_for_customer add hook

### DIFF
--- a/product_profile/README.rst
+++ b/product_profile/README.rst
@@ -1,13 +1,15 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
 
+===============
 Product Profile
 ===============
 
 This module provides easier products configuration (in one click).
 It allows to configure a product template with only one field.
 
-.. image:: static/description/field.png
+.. figure:: static/description/field.png
 
 **Main use case**: a lot of modules are installed (mrp, purchase, sale, pos)
 and products configuration becomes harder for end users: too many fields to take care of.
@@ -26,68 +28,62 @@ Additional feature: a default value can be attached to a profile (see § Configu
 Configuration
 =============
 
-1. Create your own profile here: Sales > Configuration > Product Categories and Attributes > Product Profiles
+#. Create your own profile here: Sales > Configuration > Product Categories and Attributes > Product Profiles
 
-.. image:: static/description/list.png
+.. figure:: static/description/list.png
 
 
-2. To have more fields available to attach to this profile you must define
+#. To have more fields available to attach to this profile you must define
    these fields in the model 'product.profile' in your own module
    If the field name (and its type) is the same than those in 'product.template'
    then values of these will be populated automatically
    in 'product.template'
-   Example of fields declaration in your own module:
+   Example of fields declaration in your own module::
 
-```python
+    class ProductProfile(models.Model):
+        """ Require dependency on sale, purchase and point_of_sale modules
+        """
 
-class ProductProfile(models.Model):
-    """ Require dependency on sale, purchase and point_of_sale modules
-    """
+        _inherit = 'product.profile'
 
-    _inherit = 'product.profile'
+        def _get_types(self):
+            return [('product', 'Stockable Product'),
+                    ('consu', 'Consumable'),
+                    ('service', 'Service')]
 
-    def _get_types(self):
-        return [('product', 'Stockable Product'),
-                ('consu', 'Consumable'),
-                ('service', 'Service')]
+        sale_ok = fields.Boolean(
+            string='Can be Sold',
+            help="Specify if the product can be selected in a sales order line.")
+        purchase_ok = fields.Boolean(
+            string='Can be Purchased')
+        available_in_pos = fields.Boolean()
 
-    sale_ok = fields.Boolean(
-        string='Can be Sold',
-        help="Specify if the product can be selected in a sales order line.")
-    purchase_ok = fields.Boolean(
-        string='Can be Purchased')
-    available_in_pos = fields.Boolean()
 
-```
-
-3. Second behavior: you might want to add a default behavior to these fields:
+#. Second behavior: you might want to add a default behavior to these fields:
    in this case use prefix 'profile_default\_' for your field name
-   in 'product.profile' model.
+   in 'product.profile' model::
 
-```python
-
-class ProductProfile(models.Model):
-    ...
-    profile_default_categ_id = fields.Many2one(
-        'product.category',
-        string='Default category')
-    profile_default_route_ids = fields.Many2many(
-        'stock.location.route',
-        string=u'Default Routes',
-        domain="[('product_selectable', '=', True)]",
-        help="Depending on the modules installed, this will allow "
-             "you to define the route of the product: "
-             "whether it will be bought, manufactured, MTO/MTS,...")
-
-```
-
-   In this case 'categ_id' field (from product.template) is populated
-   with 'profile_default_categ_id' value but can be updated manually by the user.
-   Careful: each time you change profile, the default value is also populated
-   whatever the previous value. Custom value is only keep if don't change the profile.
+    class ProductProfile(models.Model):
+        ...
+        profile_default_categ_id = fields.Many2one(
+            'product.category',
+            string='Default category')
+        profile_default_route_ids = fields.Many2many(
+            'stock.location.route',
+            string=u'Default Routes',
+            domain="[('product_selectable', '=', True)]",
+            help="Depending on the modules installed, this will allow "
+                 "you to define the route of the product: "
+                 "whether it will be bought, manufactured, MTO/MTS,...")
 
 
-4. Insert data (xml or csv) and define values for each field defined above
+In this case 'categ_id' field (from product.template) is populated
+with 'profile_default_categ_id' value but can be updated manually by the user.
+Careful: each time you change profile, the default value is also populated
+whatever the previous value. Custom value is only keep if don't change the profile.
+
+
+#. Insert data (xml or csv) and define values for each field defined above
    for each configuration scenario
 
 
@@ -107,10 +103,10 @@ Profiles are also defined as search filter and group.
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/product-attribute/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/product-attribute/issues/new?body=module:%20product_profile%0Aversion:%201.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/product-attribute/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
 
 
 Credits
@@ -126,15 +122,15 @@ Contributors
 Iconography
 -----------
 
-https://www.iconfinder.com/icondesigner
+* https://www.iconfinder.com/icondesigner
 
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -142,4 +138,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_supplierinfo_for_customer/__init__.py
+++ b/product_supplierinfo_for_customer/__init__.py
@@ -3,3 +3,4 @@
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from . import models
+from .post_init_hook import post_init_hook

--- a/product_supplierinfo_for_customer/__openerp__.py
+++ b/product_supplierinfo_for_customer/__openerp__.py
@@ -36,4 +36,5 @@
         "demo/product_demo.xml",
     ],
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }

--- a/product_supplierinfo_for_customer/post_init_hook.py
+++ b/product_supplierinfo_for_customer/post_init_hook.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+from openerp.api import Environment
+from openerp import SUPERUSER_ID
+
+
+def import_customer_code(env):
+    env.cr.execute("""SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name='product_customer_code'""")
+    if env.cr.fetchone():
+        env.cr.execute("""
+            select product_id,
+            product_code, partner_id, company_id, product_name
+            from product_customer_code
+        """)
+        for product_id, product_code, partner_id, company_id, product_name in \
+                env.cr.fetchall():
+            pt_id = env['product.product'].browse(
+                product_id).product_tmpl_id.id
+            vals = {'name': partner_id,
+                    'product_tmpl_id': pt_id,
+                    'product_code': product_code,
+                    'type': 'customer',
+                    'pricelist_ids': [(
+                        0, 0, {'price': 0.0, 'min_quantity': 0.0})],
+                    }
+            env['product.supplierinfo'].create(vals)
+
+
+def post_init_hook(cr, registry):
+    env = Environment(cr, SUPERUSER_ID, {})
+    import_customer_code(env)


### PR DESCRIPTION
`product_customer_code `is deprecated. The hook passes the information to `product_supplierinfo` table