### PR TITLE
Don't format the ID

### DIFF
--- a/product_brand/__manifest__.py
+++ b/product_brand/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Product Brand Manager',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Product',
     'summary': "Product Brand Manager",
     'author': 'NetAndCo, Akretion, Prisnet Telecommunications SA'

--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -85,7 +85,7 @@
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override">
                             <a type="open">
-                                <img t-att-src="kanban_image('product.brand', 'logo', record.id.value)"
+                                <img t-att-src="kanban_image('product.brand', 'logo', record.id.raw_value)"
                                      class="oe_kanban_image"/>
                             </a>
                             <div class="oe_kanban_details">


### PR DESCRIPTION
Lookup fails when the ID is formatted. The unformatted version of the
data is located under `raw_value`.

Closes #354