### PR TITLE
Make the kanban card of product.brand consistent with other odoo apps.

### DIFF
--- a/product_brand/__manifest__.py
+++ b/product_brand/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Product Brand Manager',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.2.0',
     'category': 'Product',
     'summary': "Product Brand Manager",
     'author': 'NetAndCo, Akretion, Prisnet Telecommunications SA, '

--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -83,29 +83,19 @@
                 <field name="description"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="oe_kanban_vignette oe_semantic_html_override">
-                            <a type="open">
-                                <img t-att-src="kanban_image('product.brand', 'logo', record.id.raw_value)"
-                                     class="oe_kanban_image"/>
-                            </a>
+                        <div class="oe_kanban_global_click">
+                            <div class="o_kanban_image">
+                                <img t-att-src="kanban_image('product.brand', 'logo', record.id.raw_value)"/>
+                            </div>
                             <div class="oe_kanban_details">
                                 <h4>
-                                    <a type="open">
-                                        <field name="name"/>
-                                    </a>
+                                    <field name="name"/>
                                 </h4>
                                 <div>
-                                    <a name="%(product_brand.action_open_brand_products)d"
-                                       type="action">
+                                    <a name="%(product_brand.action_open_brand_products)d" type="action">
                                         <t t-esc="record.products_count.value"/> Products
                                     </a>
                                 </div>
-                                <span>
-                                    <t t-esc="record.description.value.substr(0,200)"/>
-                                    <t t-if="record.description.value.length > 200">
-                                        <a type="open"><b>...</b></a>
-                                    </t>
-                                </span>
                             </div>
                         </div>
                     </t>


### PR DESCRIPTION
* Make the logo always the same width (64px).
* Remove the description (200 first caracters). Not relevant for a configuration model.
* Move the brand name and product count beside the image. This is the way it is displayed in partners and products kanban views.