### PR TITLE
remove post_install

### DIFF
--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -6,8 +6,6 @@ from odoo.tests import common
 
 
 class TestProductSupplierinfo(common.SavepointCase):
-    at_install = False
-    post_install = True
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
post_install are not required for travis on OCA repos. Tests are green without post_install.