### PR TITLE
[FIX] 10.0 product_profile : do not customize product easy form view

### DIFF
--- a/product_profile/models/product.py
+++ b/product_profile/models/product.py
@@ -267,7 +267,11 @@ class ProductProduct(models.Model):
     @api.model
     def fields_view_get(self, view_id=None, view_type='form',
                         toolbar=False, submenu=False):
+        view = self.env['ir.ui.view'].browse(view_id)
         res = super(ProductProduct, self).fields_view_get(
             view_id=view_id, view_type=view_type, toolbar=toolbar,
             submenu=submenu)
+        # This is a simplified view for which the customization do not apply
+        if view.name == 'product.product.view.form.easy':
+            return res
         return self._customize_view(res, view_type)


### PR DESCRIPTION
Before this fix:
Product.product.easy.form view does not work (odoo tries to use the field product_id which is not loaded)

After this fix:
The view works as expected and isn't customized by the product_profile module.
It woul be complex to implement the profile customization into the easy form view while being of little interest. There is already a view with every fields that handle it properly.