### PR TITLE
11.0][IMP] product_template_tags: No create edit tags

### DIFF
--- a/product_template_tags/views/product_template.xml
+++ b/product_template_tags/views/product_template.xml
@@ -12,7 +12,7 @@
 
             <xpath expr="//page[@name='general_information']" position="inside">
                 <group>
-                    <field name="tag_ids" widget="many2many_tags"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
                 </group>
             </xpath>
 
@@ -51,4 +51,3 @@
     </record>
 
 </odoo>
-


### PR DESCRIPTION
Added the no_create_edit option to the tags in order to do not allow to create duplicates.