### PR TITLE
[FIX][10.0] product_weight travis warnings

### DIFF
--- a/product_weight/views/product_view.xml
+++ b/product_weight/views/product_view.xml
@@ -5,9 +5,9 @@
       <field name="model">product.template</field>
       <field name="inherit_id" ref="stock.view_template_property_form"/>
       <field name="arch" type="xml">
-	    <field name="weight" position="after">
-	            <button name="%(action_view_product_weight_update)d" type="action" string="update weights" class="oe_link" />
-	    </field>
+        <field name="weight" position="after">
+                <button name="%(action_view_product_weight_update)d" type="action" string="update weights" class="oe_link" />
+        </field>
       </field>
     </record>
 

--- a/product_weight/wizard/product_weight_update_view.xml
+++ b/product_weight/wizard/product_weight_update_view.xml
@@ -5,18 +5,18 @@
       <field name="name">Update Product Weight</field>
       <field name="model">product.weight.update</field>
       <field name="arch" type="xml">
-	    <form string="Update Product Weight">
-	      <group>
-	        <field name="product_tmpl_id" invisible="1" />
-	        <field name="product_id" invisible="1" />
-	        <field name="bom_id" required="1"/>
-	      </group>
-	      <footer>
-	        <button name="update_single_weight" string="_Apply" type="object" class="oe_highlight"/>
-	        or
-	        <button string="Cancel" class="oe_link" special="cancel" />
-	      </footer>
-	    </form>
+        <form string="Update Product Weight">
+          <group>
+            <field name="product_tmpl_id" invisible="1" />
+            <field name="product_id" invisible="1" />
+            <field name="bom_id" required="1"/>
+          </group>
+          <footer>
+            <button name="update_single_weight" string="_Apply" type="object" class="oe_highlight"/>
+            or
+            <button string="Cancel" class="oe_link" special="cancel" />
+          </footer>
+        </form>
       </field>
     </record>
 
@@ -25,11 +25,11 @@
       <field name="name">Update Product Weights</field>
       <field name="model">product.weight.update</field>
       <field name="arch" type="xml">
-	<form string="Update Product Weight">
-	    <button name="update_multi_product_weight" string="_Apply" type="object" class="oe_highlight"/>
-	    or
-	    <button string="Cancel" class="oe_link" special="cancel" />
-	</form>
+    <form string="Update Product Weight">
+        <button name="update_multi_product_weight" string="_Apply" type="object" class="oe_highlight"/>
+        or
+        <button string="Cancel" class="oe_link" special="cancel" />
+    </form>
       </field>
     </record>
 


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/452 :
fix of:
************* Module product_weight
product_weight/wizard/product_weight_update_view.xml:8: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:9: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:10: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:11: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:12: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:13: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:14: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:15: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:16: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:17: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:18: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:19: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:28: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:29: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:30: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:31: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/wizard/product_weight_update_view.xml:32: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/views/product_view.xml:8: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/views/product_view.xml:9: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight/views/product_view.xml:10: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces