### PR TITLE
[FIX][10.0] product_default_image travis warning

### DIFF
--- a/product_default_image/tests/setup.py
+++ b/product_default_image/tests/setup.py
@@ -47,9 +47,9 @@ class Setup(TransactionCase):
 
     def create_test_image(self, color):
         # color arg should be (r, g, b)
-        file = BytesIO()
+        file_data = BytesIO()
         image = Image.new('RGBA', size=(4, 4), color=(color))
-        image.save(file, 'png')
-        file.name = 'test.png'
-        file.seek(0)
-        return file.read().encode('base64')
+        image.save(file_data, 'png')
+        file_data.name = 'test.png'
+        file_data.seek(0)
+        return file_data.read().encode('base64')


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/452 :
fix of:
************* Module product_default_image.tests.setup
product_default_image/tests/setup.py:50: [W0622(redefined-builtin), Setup.create_test_image] Redefining built-in 'file'