### PR TITLE
[FIX][10.0] product_brand travis warnings

### DIFF
--- a/product_brand/models/product_brand.py
+++ b/product_brand/models/product_brand.py
@@ -28,13 +28,14 @@ class ProductBrand(models.Model):
     )
     products_count = fields.Integer(
         string='Number of products',
-        compute='_get_products_count',
+        compute='_compute_products_count',
     )
 
-    @api.one
+    @api.multi
     @api.depends('product_ids')
-    def _get_products_count(self):
-        self.products_count = len(self.product_ids)
+    def _compute_products_count(self):
+        for this in self:
+            this.products_count = len(this.product_ids)
 
 
 class ProductTemplate(models.Model):


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/452 :
fix of:
************* Module product_brand.models.product_brand
product_brand/models/product_brand.py:31: [C8108(method-compute), ProductBrand] Name of compute method should start with "compute"
product_brand/models/product_brand.py:36: [W8104(api-one-deprecated), ProductBrand._get_products_count] api.one deprecated