### PR TITLE
[FIX][11.0] product_pricelist_direct_print travis warning

### DIFF
--- a/product_pricelist_direct_print/tests/__init__.py
+++ b/product_pricelist_direct_print/tests/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import test_product_pricelist_direct_print


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/453 :
fix of:
************ Module product_pricelist_direct_print.tests.init
product_pricelist_direct_print/tests/init.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary