### PR TITLE
[FIX][11.0] product_weight_through_uom travis warn

### DIFF
--- a/product_weight_through_uom/views/product_views.xml
+++ b/product_weight_through_uom/views/product_views.xml
@@ -5,14 +5,14 @@
       <field name="model">product.template</field>
       <field name="inherit_id" ref="stock.view_template_property_form"/>
       <field name="arch" type="xml">
-	    <xpath expr="//div[@name='weight']" position="after">
+        <xpath expr="//div[@name='weight']" position="after">
             <field name="is_weight_uom" invisible="1"/>
             <label for="extra_weight"/>
             <div class="o_row" name="extra_weight" attrs="{'invisible':[('is_weight_uom', '=', True)]}">
                 <field name="extra_weight"/>
                 <span>kg</span>
             </div>
-	    </xpath>
+        </xpath>
         <field name="weight" position="attributes">
             <attribute name="attrs">
                 {'readonly':[('is_weight_uom', '=', True)]}


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/453 :
fix off:
************* Module product_weight_through_uom
product_weight_through_uom/views/product_views.xml:8: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_weight_through_uom/views/product_views.xml:15: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces