### PR TITLE
[FIX][11.0] product_multi_category travis warning

### DIFF
--- a/product_multi_category/__init__.py
+++ b/product_multi_category/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 Akretion,Guewen Baconnier,Camptocamp,Avanzosc,Sharoon Thomas,Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/product_multi_category/__manifest__.py
+++ b/product_multi_category/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 Akretion,Guewen Baconnier,Camptocamp,Avanzosc,Sharoon Thomas,Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/product_multi_category/models/__init__.py
+++ b/product_multi_category/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 Akretion,Guewen Baconnier,Camptocamp,Avanzosc,Sharoon Thomas,Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/product_multi_category/models/product.py
+++ b/product_multi_category/models/product.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 Akretion,Guewen Baconnier,Camptocamp,Avanzosc,Sharoon Thomas,Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/453 :
fix of:
************* Module product_multi_category
product_multi_category/init.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module product_multi_category.manifest
product_multi_category/manifest.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module product_multi_category.models.init
product_multi_category/models/init.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module product_multi_category.models.product
product_multi_category/models/product.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary