### PR TITLE
[FIX][11.0] 11.0-fix-product-sequence  travis warnings

### DIFF
--- a/product_sequence/__manifest__.py
+++ b/product_sequence/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2004 Tiny SPRL
 # Copyright 2016 Sodexis
 # Copyright 2018 Eficent Business and IT Consulting Services S.L.

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -41,8 +40,8 @@ class TestProductSequence(TransactionCase):
             default_code='PROD03'
         ))
         self.cr.execute(
-            "update product_product set default_code='/' where id=%s"
-            % (product_3.id,))
+            "update product_product set default_code='/' where id=%s",
+            (product_3.id,))
         product_3.invalidate_cache()
         self.assertEqual(product_3.default_code, '/')
         pre_init_hook(self.cr)


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/453 :
fix of:
************* Module product_sequence.tests.test_product_sequence
product_sequence/tests/test_product_sequence.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
product_sequence/tests/test_product_sequence.py:43: [E8103(sql-injection), TestProductSequence.test_pre_init_hook] SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection