### PR TITLE
[FIX][11.0] product_state travis warning

### DIFF
--- a/product_state/__manifest__.py
+++ b/product_state/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     'name': "Product State",
-    'description': """
+    'summary': """
         Module introducing a state field on product template""",
     'author': 'ACSONE SA/NV, Odoo Community Association (OCA)',
     'website': "https://github.com/OCA/product-attribute",


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/453 : 
fix of:
************* Module product_state.manifest
product_state/manifest.py:3: [C8103(manifest-deprecated-key), ] Deprecated key "description" in manifest file