### PR TITLE
[FIX][11.0] product_end_of_life travis warnings

### DIFF
--- a/product_end_of_life/models/res_config_settings.py
+++ b/product_end_of_life/models/res_config_settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 

--- a/product_end_of_life/tests/test_product_eol.py
+++ b/product_end_of_life/tests/test_product_eol.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 

--- a/product_end_of_life/views/res_config_settings_view.xml
+++ b/product_end_of_life/views/res_config_settings_view.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0"?>
 <odoo>
-	<record id="res_config_settings_view_form" model="ir.ui.view">
-		<field name="name">res.config.settings.view.form.inherit.product_end_of_life</field>
-		<field name="model">res.config.settings</field>
-		<field name="inherit_id" ref="stock.res_config_settings_view_form"/>
-		<field name="arch" type="xml">
-			<xpath expr="//div[@data-key='stock']" position="inside">
-				<h2>Product End of Life</h2>
-				<div class="row mt16 o_settings_container">
-					<div class="col-xs-12 col-md-6 o_setting_box" title="Define the window of the product EoL notifications">
-						<div class="o_setting_right_pane">
-							<label string="Notification Window" />
-							<div class="text-muted">
-								Define the window value
-							</div>
-							<div class="content-group">
-								<div class="mt16_row">
-									<label for="product_eol_approaching_number" string="Interval" class="col-xs-3 col-md-3 o_light_label" />
-									<field name="product_eol_approaching_number" class="oe_inline" required="True" />
-								</div>
-								<div class="mt16_row">
-									<label for="product_eol_approaching_type" string="Unit" class="col-xs-3 col-md-3 o_light_label" />
-									<field name="product_eol_approaching_type" class="oe_inline" required="True" />
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</xpath>
-		</field>
-	</record>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.product_end_of_life</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='stock']" position="inside">
+                <h2>Product End of Life</h2>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-xs-12 col-md-6 o_setting_box" title="Define the window of the product EoL notifications">
+                        <div class="o_setting_right_pane">
+                            <label string="Notification Window" />
+                            <div class="text-muted">
+                                Define the window value
+                            </div>
+                            <div class="content-group">
+                                <div class="mt16_row">
+                                    <label for="product_eol_approaching_number" string="Interval" class="col-xs-3 col-md-3 o_light_label" />
+                                    <field name="product_eol_approaching_number" class="oe_inline" required="True" />
+                                </div>
+                                <div class="mt16_row">
+                                    <label for="product_eol_approaching_type" string="Unit" class="col-xs-3 col-md-3 o_light_label" />
+                                    <field name="product_eol_approaching_type" class="oe_inline" required="True" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
issue https://github.com/OCA/product-attribute/issues/453 : 
fix of:
************* Module product_end_of_life
product_end_of_life/views/res_config_settings_view.xml:1: [W7908(missing-newline-extrafiles), ] Missing newline
product_end_of_life/views/res_config_settings_view.xml:3: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:4: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:5: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:6: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:7: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:8: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:9: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:10: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:11: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:12: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:13: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:14: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:15: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:16: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:17: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:18: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:19: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:20: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:21: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:22: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:23: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:24: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:25: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:26: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:27: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:28: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:29: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:30: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:31: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
product_end_of_life/views/res_config_settings_view.xml:32: [W7910(wrong-tabs-instead-of-spaces), ] Use wrong tabs indentation instead of four spaces
************* Module product_end_of_life.models.res_config_settings
product_end_of_life/models/res_config_settings.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary
************* Module product_end_of_life.tests.test_product_eol
product_end_of_life/tests/test_product_eol.py:1: [C8202(unnecessary-utf8-coding-comment), ] UTF-8 coding is not necessary