### PR TITLE
[FIX] [11.0] product_state app false

### DIFF
--- a/product_state/__manifest__.py
+++ b/product_state/__manifest__.py
@@ -15,5 +15,4 @@
     'data': [
         'views/product_views.xml',
     ],
-    'application': True,
 }


### PR DESCRIPTION
Fix for issue: https://github.com/OCA/product-attribute/issues/476
As the default for application is false, I removed it from the manifest.
