### PR TITLE
[FIX] product_pricelist_direct_print: empty categ. in last ordered products

### DIFF
--- a/product_pricelist_direct_print/views/report_product_pricelist.xml
+++ b/product_pricelist_direct_print/views/report_product_pricelist.xml
@@ -80,7 +80,7 @@
                            t-as="category">
                             <t t-set="category_products"
                                t-value="products and products.with_context(categ_id=category.id).filtered(lambda x: x.categ_id.id == x.env.context['categ_id']) or
-                                        ((not o.last_ordered_products) and products.search([('sale_ok','=',True), ('categ_id','=',category.id)]) or [])"/>
+                                        ((not o.last_ordered_products) and products.search([('sale_ok','=',True), ('categ_id','=',category.id)]) or products.browse())"/>
                             <t t-if="o.order_field == 'name'">
                                 <t t-set="category_products"
                                    t-value="category_products.sorted(lambda x: x.name)"/>


### PR DESCRIPTION
When categories are set on the filter and and last ordered products is
checked, if one of the categories was empty it causes an error due to
the t-value returning an empty dict instead of an empty recordset.

The fix returns an empty recordset of either product.template o
product.product model.

cc @Tecnativa