### PR TITLE
FIX remove README instructions

### DIFF
--- a/product_template_tags/readme/CONFIGURE.rst
+++ b/product_template_tags/readme/CONFIGURE.rst
@@ -1,5 +1,3 @@
-[ This file is optional, it should explain how to configure
-  the module before using it; it is aimed at advanced users. ]
 
 To configure this module, you need to:
 

--- a/product_template_tags/readme/DESCRIPTION.rst
+++ b/product_template_tags/readme/DESCRIPTION.rst
@@ -1,3 +1,2 @@
-[ This file must be max 2-3 paragraphs, and is required. ]
 
 This addon allows to add tags on products.

--- a/product_template_tags/readme/USAGE.rst
+++ b/product_template_tags/readme/USAGE.rst
@@ -1,10 +1,3 @@
-[ This file must be present and contains the usage instructions
-  for end-users. As all other rst files included in the README,
-  it MUST NOT contain reStructuredText sections
-  only body text (paragraphs, lists, tables, etc). Should you need
-  a more elaborate structure to explain the addon, please create a
-  Sphinx documentation (which may include this file as a "quick start"
-  section). ]
 
 To use this module, you need to:
 


### PR DESCRIPTION
instrucions for writing README were still present in files, making reading difficult.