### PR TITLE
[FIX] product_supplierinfo_for_customer: catch price type

### DIFF
--- a/product_supplierinfo_for_customer/__manifest__.py
+++ b/product_supplierinfo_for_customer/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Product Supplierinfo for Customers",
     "summary": "Allows to define prices for customers in the products",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "AvanzOSC, "
               "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/product_supplierinfo_for_customer/models/product_template.py
+++ b/product_supplierinfo_for_customer/models/product_template.py
@@ -21,3 +21,14 @@ class ProductTemplate(models.Model):
     variant_supplier_ids = fields.One2many(
         comodel_name='product.supplierinfo', inverse_name='product_tmpl_id',
         string='Supplier', domain=[('supplierinfo_type', '=', 'supplier')])
+
+    def price_compute(self, price_type, uom=False, currency=False,
+                      company=False):
+        """Return dummy not falsy prices when computation is done from supplier
+        info for avoiding error on super method. We will later fill these with
+        correct values.
+        """
+        if price_type == 'partner':
+            return dict.fromkeys(self.ids, 1.0)
+        return super().price_compute(
+            price_type, uom=uom, currency=currency, company=company)

--- a/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
+++ b/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
@@ -112,3 +112,11 @@ class TestProductSupplierinfoForCustomer(SavepointCase):
         self.assertEqual(
             res[self.product.id], 750.0,
             "Error: price does not match list price")
+
+    def test_product_supplierinfo_partner(self):
+        self.pricelist_item.base = 'partner'
+        self.assertAlmostEqual(
+            self.pricelist.get_product_price(
+                self.product.product_tmpl_id, 5, False, False,
+            ), 100,
+        )


### PR DESCRIPTION
Module `product_supplierinfo_for_customer` adds a new price type: `partner`

If we use this module with other modules, i.e. [sale_variant_configurator](https://github.com/OCA/product-variant/tree/11.0/sale_variant_configurator) that adds `product_template` to sale order line, an error is raised because we have to avoid check price type in product template.