### PR TITLE
[12.0][FIX] product_sequence: Keep default_code when copy products if dictionary contains the default_code key.

### DIFF
--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -65,7 +65,7 @@ class ProductProduct(models.Model):
     def copy(self, default=None):
         if default is None:
             default = {}
-        if self.default_code:
+        if self.default_code and 'default_code' not in default:
             default.update({
                 'default_code': self.default_code + _('-copy'),
             })

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -103,3 +103,13 @@ class TestProductSequence(TransactionCase):
         categ_car.sequence_id = False
         categ_car.write({'code_prefix': 'KIA'})
         self.assertEqual(categ_car.sequence_id.prefix, "KIA")
+
+    def test_product_copy_with_default_values(self):
+        product_2 = self.product_product.create(dict(
+            name="Apple",
+            default_code='PROD02'
+        ))
+        copy_product_2 = product_2.copy({
+            'default_code': 'product test sequence',
+        })
+        self.assertEqual(copy_product_2.default_code, 'product test sequence')


### PR DESCRIPTION
cc @Tecnativa