### PR TITLE
Fix position of field product_tag_ids

### DIFF
--- a/product_template_tags/views/product_template.xml
+++ b/product_template_tags/views/product_template.xml
@@ -7,13 +7,11 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='general_information']" position="inside">
-                <group>
-                    <field name="tag_ids"
-                           widget="many2many_tags"
-                           options="{'color_field': 'color'}"/>
-                </group>
-            </xpath>
+            <group name="group_general" position="inside">
+                <field name="tag_ids"
+                       widget="many2many_tags"
+                       options="{'color_field': 'color'}"/>
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
The current position of the field is a bit odd.

Before
![image](https://user-images.githubusercontent.com/27902736/73877418-9d1b7180-4826-11ea-8c36-ddea578ac09b.png)

After
![image](https://user-images.githubusercontent.com/27902736/73877426-a1e02580-4826-11ea-9b01-bcf63a12817c.png)

