### PR TITLE
[12.0] FIX product_pricelist_supplierinfo: no_supplierinfo_min_quantity should not influence supplierinfo order + Supplier filter

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -44,3 +44,6 @@ class ProductPricelistItem(models.Model):
     no_supplierinfo_min_quantity = fields.Boolean(
         string='Ignore Supplier Info Min. Quantity',
     )
+    filter_supplier_id = fields.Many2one(
+        "res.partner", "Supplier filter", domain=[('supplier', '=', True)],
+        help="Only match prices from the selected supplier")

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -23,6 +23,10 @@ class ProductTemplate(models.Model):
             domain = [
                 ('product_tmpl_id', '=', self.id),
             ]
+        if rule.filter_supplier_id:
+            domain += [
+                ('name', '=', rule.filter_supplier_id.id)
+            ]
         if not rule.no_supplierinfo_min_quantity and quantity:
             domain += [
                 '|',

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -38,15 +38,8 @@ class ProductTemplate(models.Model):
                 ('date_end', '=', False),
                 ('date_end', '>=', date),
             ]
-        # We use a different default order because we are interested in getting
-        # the price for lowest minimum quantity if no_supplierinfo_min_quantity
-        supplierinfos = self.env['product.supplierinfo'].search(
-            domain, order='min_qty,sequence,price',
-        )
-        if rule.no_supplierinfo_min_quantity:
-            price = supplierinfos[:1].price
-        else:
-            price = supplierinfos[-1:].price
+        supplierinfos = self.env['product.supplierinfo'].search(domain)
+        price = supplierinfos[:1].price
         if price:
             # We have to replicate this logic in this method as pricelist
             # method are atomic and we can't hack inside.

--- a/product_pricelist_supplierinfo/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_supplierinfo/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
   * Pedro M. Baeza
 
 * Nikul Chaudhary <nikulchaudhary2112@gmail.com>
+
+* `TAKOBI <https://takobi.online/>`_:
+
+  * Lorenzo Battistini

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -38,7 +38,6 @@ class TestProductSupplierinfo(common.SavepointCase):
         })
         cls.pricelist = cls.env['product.pricelist'].create({
             'name': 'Supplierinfo Pricelist',
-            'discount_policy': 'without_discount',
             'item_ids': [
                 (0, 0, {
                     'compute_price': 'formula',
@@ -98,6 +97,15 @@ class TestProductSupplierinfo(common.SavepointCase):
         self.pricelist.item_ids[0].no_supplierinfo_min_quantity = True
         self.assertAlmostEqual(
             self.pricelist.get_product_price(self.product, 1, False), 50,
+        )
+
+    def test_pricelist_supplier_filter(self):
+        self.assertAlmostEqual(
+            self.pricelist.get_product_price(self.product, 5, False), 50,
+        )
+        self.pricelist.item_ids[0].filter_supplier_id = self.supplier2.id
+        self.assertAlmostEqual(
+            self.pricelist.get_product_price(self.product, 5, False), 10,
         )
 
     def test_pricelist_dates(self):

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -26,26 +26,16 @@ class TestProductSupplierinfo(common.SavepointCase):
                     'name': cls.supplier1.id,
                     'min_qty': 5,
                     'price': 50,
+                    'sequence': 1,
                 }),
                 (0, 0, {
                     'name': cls.supplier2.id,
                     'min_qty': 1,
                     'price': 10,
+                    'sequence': 2,
                 }),
             ],
         })
-        cls.product.write({'seller_ids': [
-            (0, 0, {
-                'name': cls.supplier1.id,
-                'min_qty': 5,
-                'price': 50,
-            }),
-            (0, 0, {
-                'name': cls.supplier2.id,
-                'min_qty': 1,
-                'price': 10,
-            }),
-        ]})
         cls.pricelist = cls.env['product.pricelist'].create({
             'name': 'Supplierinfo Pricelist',
             'discount_policy': 'without_discount',
@@ -107,7 +97,7 @@ class TestProductSupplierinfo(common.SavepointCase):
         )
         self.pricelist.item_ids[0].no_supplierinfo_min_quantity = True
         self.assertAlmostEqual(
-            self.pricelist.get_product_price(self.product, 5, False), 10,
+            self.pricelist.get_product_price(self.product, 1, False), 50,
         )
 
     def test_pricelist_dates(self):

--- a/product_pricelist_supplierinfo/views/product_pricelist_item_views.xml
+++ b/product_pricelist_supplierinfo/views/product_pricelist_item_views.xml
@@ -11,6 +11,7 @@
             </xpath>
             <field name="price_max_margin" position="after">
                 <field name="no_supplierinfo_min_quantity" attrs="{'invisible':[('base', '!=', 'supplierinfo')]}"/>
+                <field name="filter_supplier_id" attrs="{'invisible':[('base', '!=', 'supplierinfo')]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Steps:

 - Create 2 supplierinfo for 1 product, only setting their price
 - Create a pricelist "based on supplier info"
 - Create a sale order using that pricelist and selecting that product

The last supplierinfo is used, instead of the first one.

In general, no_supplierinfo_min_quantity should only influence the domain, because the correct order is already handled by default: 'sequence, min_qty desc, price'

**New funzionality**

Allow to only match prices from selected supplier