### PR TITLE
[FIX][12.0] product_dimension rename length to product_length

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Product Dimension',
-    'version': '12.0.1.0.0',
+    'version': '12.0.2.0.0',
     'category': 'Product',
     'author': 'brain-tec AG, ADHOC SA, Camptocamp SA, '
               'Odoo Community Association (OCA)',

--- a/product_dimension/migrations/12.0.2.0.0/pre-migration.py
+++ b/product_dimension/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2019 C2i Change 2 improve - Eduardo Magdalena <emagdalena@c2i.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+field_renames = [
+    ('product.template', 'product_template', 'length', 'product_length'),
+    ('product.template', 'product_template', 'heigth', 'product_heigth'),
+    ('product.template', 'product_template', 'width', 'product_width'),
+]
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_fields(env, field_renames)

--- a/product_dimension/models/product.py
+++ b/product_dimension/models/product.py
@@ -8,10 +8,12 @@ from odoo import models, fields, api
 class Product(models.Model):
     _inherit = 'product.product'
 
-    @api.onchange('length', 'height', 'width', 'dimensional_uom_id')
+    @api.onchange(
+        'product_length', 'product_height', 'product_width', 'dimensional_uom_id')
     def onchange_calculate_volume(self):
         self.volume = self.env['product.template']._calc_volume(
-            self.length, self.height, self.width, self.dimensional_uom_id)
+            self.product_length, self.product_height,
+            self.product_width, self.dimensional_uom_id)
 
     @api.model
     def _get_dimension_uom_domain(self):
@@ -19,9 +21,9 @@ class Product(models.Model):
             ('category_id', '=', self.env.ref('uom.uom_categ_length').id)
         ]
 
-    length = fields.Float()
-    height = fields.Float()
-    width = fields.Float()
+    product_length = fields.Float('length')
+    product_height = fields.Float('height')
+    product_width = fields.Float('width')
     dimensional_uom_id = fields.Many2one(
         'uom.uom',
         'Dimensional UoM',
@@ -35,20 +37,22 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     @api.model
-    def _calc_volume(self, length, height, width, uom_id):
+    def _calc_volume(self, product_length, product_height, product_width, uom_id):
         volume = 0
-        if length and height and width and uom_id:
-            length_m = self.convert_to_meters(length, uom_id)
-            height_m = self.convert_to_meters(height, uom_id)
-            width_m = self.convert_to_meters(width, uom_id)
+        if product_length and product_height and product_width and uom_id:
+            length_m = self.convert_to_meters(product_length, uom_id)
+            height_m = self.convert_to_meters(product_height, uom_id)
+            width_m = self.convert_to_meters(product_width, uom_id)
             volume = length_m * height_m * width_m
 
         return volume
 
-    @api.onchange('length', 'height', 'width', 'dimensional_uom_id')
+    @api.onchange(
+        'product_length', 'product_height', 'product_width', 'dimensional_uom_id')
     def onchange_calculate_volume(self):
         self.volume = self._calc_volume(
-            self.length, self.height, self.width, self.dimensional_uom_id)
+            self.product_length, self.product_height, self.product_width,
+            self.dimensional_uom_id)
 
     def convert_to_meters(self, measure, dimensional_uom):
         uom_meters = self.env.ref('uom.product_uom_meter')
@@ -69,6 +73,9 @@ class ProductTemplate(models.Model):
         readonly=False,
     )
 
-    length = fields.Float(related='product_variant_ids.length', readonly=False)
-    height = fields.Float(related='product_variant_ids.height', readonly=False)
-    width = fields.Float(related='product_variant_ids.width', readonly=False)
+    product_length = fields.Float(
+        related='product_variant_ids.product_length', readonly=False)
+    product_height = fields.Float(
+        related='product_variant_ids.product_height', readonly=False)
+    product_width = fields.Float(
+        related='product_variant_ids.product_width', readonly=False)

--- a/product_dimension/readme/CONTRIBUTORS.rst
+++ b/product_dimension/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 * Leonardo Pistone <leonardo.pistone@camptocamp.com>
 * Denis Leemann <denis.leemann@camptocamp.com>
 * Kumar Aberer <kumar.aberer@braintec-group.com>
+* `C2i Change 2 improve <https://www.c2i.es>`_:
+
+  * Eduardo Magdalena <emagdalena@c2i.es>

--- a/product_dimension/tests/test_compute_volume.py
+++ b/product_dimension/tests/test_compute_volume.py
@@ -6,9 +6,9 @@ from odoo.tests.common import TransactionCase
 class TestComputeVolumeOnProduct(TransactionCase):
 
     def test_it_computes_volume_in_cm(self):
-        self.product.length = 10.
-        self.product.height = 200.
-        self.product.width = 100.
+        self.product.product_length = 10.
+        self.product.product_height = 200.
+        self.product.product_width = 100.
         self.product.dimensional_uom_id = self.uom_cm
         self.product.onchange_calculate_volume()
         self.assertAlmostEqual(
@@ -17,9 +17,9 @@ class TestComputeVolumeOnProduct(TransactionCase):
         )
 
     def test_it_computes_volume_in_meters(self):
-        self.product.length = 6.
-        self.product.height = 2.
-        self.product.width = 10.
+        self.product.product_length = 6.
+        self.product.product_height = 2.
+        self.product.product_width = 10.
         self.product.dimensional_uom_id = self.uom_m
         self.product.onchange_calculate_volume()
         self.assertAlmostEqual(
@@ -38,9 +38,9 @@ class TestComputeVolumeOnProduct(TransactionCase):
 class TestComputeVolumeOnTemplate(TransactionCase):
 
     def test_it_computes_volume_in_cm(self):
-        self.template.length = 10.
-        self.template.height = 200.
-        self.template.width = 100.
+        self.template.product_length = 10.
+        self.template.product_height = 200.
+        self.template.product_width = 100.
         self.template.dimensional_uom_id = self.uom_cm
         self.template.onchange_calculate_volume()
         self.assertAlmostEqual(
@@ -49,9 +49,9 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         )
 
     def test_it_computes_volume_in_meters(self):
-        self.template.length = 6.
-        self.template.height = 2.
-        self.template.width = 10.
+        self.template.product_length = 6.
+        self.template.product_height = 2.
+        self.template.product_width = 10.
         self.template.dimensional_uom_id = self.uom_m
         self.template.onchange_calculate_volume()
         self.assertAlmostEqual(

--- a/product_dimension/views/product_view.xml
+++ b/product_dimension/views/product_view.xml
@@ -9,9 +9,9 @@
         <xpath expr="//group[@name='inventory']" position="inside">
           <group name="dimensions" string="Dimensions" colspan="2">
             <field name="dimensional_uom_id"/>
-            <field name="length"/>
-            <field name="height"/>
-            <field name="width"/>
+            <field name="product_length" string="Length"/>
+            <field name="product_height" string="Height"/>
+            <field name="product_width" string="Width"/>
           </group>
         </xpath>
       </field>
@@ -26,9 +26,9 @@
           <group string="Dimensions" name="dimensions" colspan="2"
                 attrs="{'invisible': [('product_variant_count', '&gt;', 1)]}">
             <field name="dimensional_uom_id"/>
-            <field name="length"/>
-            <field name="height"/>
-            <field name="width"/>
+            <field name="product_length" string="Length"/>
+            <field name="product_height" string="Height"/>
+            <field name="product_width" string="Width"/>
           </group>
         </xpath>
       </field>


### PR DESCRIPTION
Fix travis warning
************* Module product_dimension.models.product
product_dimension/models/product.py:22: [W8105(attribute-deprecated), Product] attribute "length" deprecated
product_dimension/models/product.py:72: [W8105(attribute-deprecated), ProductTemplate] attribute "length" deprecated