### PR TITLE
[FIX][12.0] product_pricelist_direct_print test

### DIFF
--- a/product_pricelist_direct_print/tests/test_product_pricelist_direct_print.py
+++ b/product_pricelist_direct_print/tests/test_product_pricelist_direct_print.py
@@ -13,7 +13,6 @@ class TestProductPricelistDirectPrint(SavepointCase):
         cls.pricelist = cls.env.ref('product.list0')
         cls.category = cls.env['product.category'].create({
             'name': 'Test category',
-            'type': 'normal',
         })
         cls.product = cls.env['product.product'].create({
             'name': 'Product for test',


### PR DESCRIPTION
Fix travis warning 
2020-03-09 19:52:16,359 5814 WARNING openerp_test odoo.models: product.category.create() with unknown fields: type
2020-03-09 19:52:16,713 5814 INFO openerp_test odoo.addons.product_pricelist_direct_print.tests.test_product_pricelist_direct_print: test_action_pricelist_send_multiple_partner (odoo.addons.product_pricelist_direct_print.tests.test_product_pricelist_direct_print.TestProductPricelistDirectPrint)