### PR TITLE
[12.0] Move state on the same header - product_state 

### DIFF
--- a/product_state/views/product_views.xml
+++ b/product_state/views/product_views.xml
@@ -6,11 +6,9 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <sheet position="before">
-                <header>
-                    <field name="state" widget="statusbar" clickable="True"/>
-                </header>
-            </sheet>
+            <header position="inside">
+                <field name="state" widget="statusbar" clickable="True"/>
+            </header>
         </field>
     </record>
 


### PR DESCRIPTION
This module add a second header in the product form view.
I propose to move the state field in the existing header.