### PR TITLE
[12.0] Add product_packaging_dimension

### DIFF
--- a/product_packaging_dimension/__init__.py
+++ b/product_packaging_dimension/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_packaging_dimension/__manifest__.py
+++ b/product_packaging_dimension/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    'name': 'Product Packaging Dimension',
+    'summary': 'Manage packaging dimensions and weight',
+    'version': '12.0.1.0.0',
+    'category': 'Product',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'depends': [
+        'product',
+    ],
+    'website': 'https://github.com/OCA/product-attribute',
+    'data': [
+        'views/product_packaging.xml',
+    ],
+    'installable': True,
+}

--- a/product_packaging_dimension/models/__init__.py
+++ b/product_packaging_dimension/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_packaging

--- a/product_packaging_dimension/models/product_packaging.py
+++ b/product_packaging_dimension/models/product_packaging.py
@@ -1,0 +1,28 @@
+# Copyright 2019-2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class ProductPackaging(models.Model):
+    _inherit = "product.packaging"
+
+    max_weight = fields.Float("Weight (kg)")
+    # lngth IS NOT A TYPO https://github.com/odoo/odoo/issues/41353
+    lngth = fields.Integer("Length (mm)", help="length in millimeters")
+    # Although it feels weird to use Integer in millimeters, we use Int to
+    # override the fields from delivery module instead of defining new ones
+    width = fields.Integer("Width (mm)", help="width in millimeters")
+    height = fields.Integer("Height (mm)", help="height in millimeters")
+    volume = fields.Float(
+        "Volume (m³)",
+        digits=(8, 4),
+        compute="_compute_volume",
+        readonly=True,
+        store=False,
+        help="volume in cubic meters",
+    )
+
+    @api.depends("lngth", "width", "height")
+    def _compute_volume(self):
+        for pack in self:
+            pack.volume = (pack.lngth * pack.width * pack.height) / 1000.0 ** 3

--- a/product_packaging_dimension/readme/CONTRIBUTORS.rst
+++ b/product_packaging_dimension/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Patrick Tombez <patrick.tombez@camptocamp.com>
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/product_packaging_dimension/readme/DESCRIPTION.rst
+++ b/product_packaging_dimension/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows to store dimensions (length, width, height), weight and
+volume of product packagings.
+

--- a/product_packaging_dimension/readme/ROADMAP.rst
+++ b/product_packaging_dimension/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* Resolve conflict with delivery module

--- a/product_packaging_dimension/views/product_packaging.xml
+++ b/product_packaging_dimension/views/product_packaging.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_packaging_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.packaging.form.view.inherit</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_form_view" />
+        <field name="arch" type="xml">
+            <group name="qty" position="after">
+                <group name="dimensions">
+                    <field name="lngth" />
+                    <field name="width" />
+                    <field name="height" />
+                    <field name="max_weight" />
+                    <field name="volume" />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Re-opening #531 with the preventive fix made in the relative #551 forward port, using `lngth` variable instead of `length` to avoid conflicts with JS functions. (cf https://github.com/odoo/odoo/issues/41353 )

The #531 works even so, but it might be more secure to merge this one... do you agree @grindtildeath @p-tombez ?

Thank you!
Cc @rvalyi 