### PR TITLE
product_secondary_unit: Unit factor decimal precision

### DIFF
--- a/product_secondary_unit/models/product_second_unit.py
+++ b/product_secondary_unit/models/product_second_unit.py
@@ -22,7 +22,10 @@ class ProductSecondaryUnit(models.Model):
         help="Default Secondary Unit of Measure.",
     )
     factor = fields.Float(
-        string="Secondary Unit Factor", default=1.0, digits=0, required=True
+        string="Secondary Unit Factor",
+        default=1.0,
+        digits="Secondary Unit Factor",
+        required=True,
     )
 
     def name_get(self):


### PR DESCRIPTION
Make factor field's decimal precision optionally configurable
by creating a Decimal Precision called "Secondary Unit Factor"

**Before this PR**
* `digits` attribute is not correct according to documentation (must be tuple of `(int, int)` or `str`)
* Factor field precision is non-configurable which by default ends-up being 2 decimal places

**After this PR**
* `digits` attribute is used correctly
* Factor field is **optionally** configurable with Decimal Precision _"Secondary Unit Factor"_:
  - If not set - nothing changes (defaults to 2 decimal places)
  - If set - field will display configured number decimal places where it is visible
