### PR TITLE
[FIX] product_multi_price: portal and public user error

### DIFF
--- a/product_multi_price/models/product_product.py
+++ b/product_multi_price/models/product_product.py
@@ -16,7 +16,7 @@ class ProductProduct(models.Model):
         """Method for getting the price from multi price."""
         self.ensure_one()
         company = rule.company_id or self.env.user.company_id
-        price = self.env['product.multi.price'].search([
+        price = self.env['product.multi.price'].sudo().search([
             ('company_id', '=', company.id),
             ('name', '=', rule.multi_price_name.id),
             ('product_id', '=', self.id),


### PR DESCRIPTION
When a not internal user (portal/public) with a pricelist that
contains multi price rules tries to see a page with a product affected
for such rules, an exception raises due to lack of permissions over
product.multi.price model.

cc @Tecnativa TT20979