### PR TITLE
Fix product_brand wrong dependency

### DIFF
--- a/product_brand/__manifest__.py
+++ b/product_brand/__manifest__.py
@@ -19,7 +19,7 @@
     'website': 'https://github.com/OCA/product-attribute',
     'license': 'AGPL-3',
     'depends': [
-        'sale',
+        'sale_management',
         ],
     'data': [
         'security/ir.model.access.csv',


### PR DESCRIPTION
Add sale_management as dependency because it is needed to manage brands. This fix also dependencies chaining for website_sale_product_brand (before this, website_sale didn't install automaticaly).

Curently product_brand depends on sale module, which contains only common functions between sale_management and website_sale. It doesn't allow to manage Products Brands.
