### PR TITLE
[13.0][ADD] product_packaging_unit_price_calculator

### DIFF
--- a/product_packaging_unit_price_calculator/__init__.py
+++ b/product_packaging_unit_price_calculator/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/product_packaging_unit_price_calculator/__manifest__.py
+++ b/product_packaging_unit_price_calculator/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Product Packaging Unit Price Calculator",
+    "summary": "",
+    "version": "13.0.1.0.0",
+    "category": "Product",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["product"],
+    "website": "https://www.camptocamp.com",
+    "data": [
+        "views/product_view.xml",
+        "views/product_supplierinfo.xml",
+        "views/product_packaging.xml",
+        "views/product_pricelist.xml",
+        "wizards/product_package_price.xml",
+    ],
+    "installable": True,
+}

--- a/product_packaging_unit_price_calculator/__manifest__.py
+++ b/product_packaging_unit_price_calculator/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Product Packaging Unit Price Calculator",
-    "summary": "",
+    "summary": "Wizard to calculate a unit price from a packaging price",
     "version": "13.0.1.0.0",
     "category": "Product",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/product_packaging_unit_price_calculator/models/__init__.py
+++ b/product_packaging_unit_price_calculator/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product
+from . import product_packaging
+from . import product_pricelist
+from . import product_supplierinfo

--- a/product_packaging_unit_price_calculator/models/product.py
+++ b/product_packaging_unit_price_calculator/models/product.py
@@ -4,7 +4,7 @@
 from odoo import models
 
 
-class ProductTempalte(models.Model):
+class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     def open_packaging_price(self):

--- a/product_packaging_unit_price_calculator/models/product.py
+++ b/product_packaging_unit_price_calculator/models/product.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class ProductTempalte(models.Model):
+    _inherit = "product.template"
+
+    def open_packaging_price(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "product_packaging_unit_price_calculator.action_unit_price_wizard"
+        ).read()[0]
+        action["context"] = {"product_tmpl_id": self.id}
+        return action

--- a/product_packaging_unit_price_calculator/models/product_packaging.py
+++ b/product_packaging_unit_price_calculator/models/product_packaging.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class ProductPackaging(models.Model):
+    _inherit = "product.packaging"
+
+    unit_price = fields.Float(related="product_id.list_price")
+    sale_price = fields.Float(compute="_compute_sale_price")
+    # Only used by the wizard to display the computed price in the treeview
+    packaging_wizard_price = fields.Float(store=False)
+
+    @api.depends("unit_price", "qty")
+    def _compute_sale_price(self):
+        for record in self:
+            record.sale_price = record.unit_price * record.qty

--- a/product_packaging_unit_price_calculator/models/product_pricelist.py
+++ b/product_packaging_unit_price_calculator/models/product_pricelist.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class PricelistItem(models.Model):
+    _inherit = "product.pricelist.item"
+
+    def open_packaging_price(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "product_packaging_unit_price_calculator.action_unit_price_wizard"
+        ).read()[0]
+        action["context"] = {"product_tmpl_id": self.product_tmpl_id.id}
+        return action

--- a/product_packaging_unit_price_calculator/models/product_supplierinfo.py
+++ b/product_packaging_unit_price_calculator/models/product_supplierinfo.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class ProductSupplierInfo(models.Model):
+    _inherit = "product.supplierinfo"
+
+    def open_packaging_price(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "product_packaging_unit_price_calculator.action_unit_price_wizard"
+        ).read()[0]
+        action["context"] = {"product_tmpl_id": self.product_tmpl_id.id}
+        return action

--- a/product_packaging_unit_price_calculator/readme/CONTRIBUTORS.rst
+++ b/product_packaging_unit_price_calculator/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/product_packaging_unit_price_calculator/readme/DESCRIPTION.rst
+++ b/product_packaging_unit_price_calculator/readme/DESCRIPTION.rst
@@ -1,0 +1,17 @@
+This module adds a wizard that allow the user to compute a unit price by
+selecting a specific `product.packaging` related to the product and the
+price of that package. The compuation is done based on the quantity `qty`
+of product set on the packaging.
+
+The wizard is accesible by buttons located in a few different places in the UI
+
+* Next to the sale price of the product on the product form
+* Next to the price of a product supplier info  form
+* Next to the price of price list item in the tree view
+* Below the fixed price of a price list item
+
+When the wizard is saved the value of the unit price located next to the button
+is updated by the computed unit price of the wizard.
+
+The sale price of a `product.packaging` is displayed in the packaging list on
+the Inventory page of the product form.

--- a/product_packaging_unit_price_calculator/readme/DESCRIPTION.rst
+++ b/product_packaging_unit_price_calculator/readme/DESCRIPTION.rst
@@ -1,9 +1,9 @@
 This module adds a wizard that allow the user to compute a unit price by
 selecting a specific `product.packaging` related to the product and the
-price of that package. The compuation is done based on the quantity `qty`
+price of that package. The computation is done based on the quantity `qty`
 of product set on the packaging.
 
-The wizard is accesible by buttons located in a few different places in the UI
+The wizard is accessible by buttons located in a few different places in the UI
 
 * Next to the sale price of the product on the product form
 * Next to the price of a product supplier info  form

--- a/product_packaging_unit_price_calculator/readme/DESCRIPTION.rst
+++ b/product_packaging_unit_price_calculator/readme/DESCRIPTION.rst
@@ -1,9 +1,9 @@
-This module adds a wizard that allow the user to compute a unit price by
+This module adds a wizard that allows the user to compute a unit price by
 selecting a specific `product.packaging` related to the product and the
 price of that package. The computation is done based on the quantity `qty`
 of product set on the packaging.
 
-The wizard is accessible by buttons located in a few different places in the UI
+The wizard is accessible via buttons located in a few different places in the UI
 
 * Next to the sale price of the product on the product form
 * Next to the price of a product supplier info  form

--- a/product_packaging_unit_price_calculator/readme/USAGE.rst
+++ b/product_packaging_unit_price_calculator/readme/USAGE.rst
@@ -1,0 +1,1 @@
+Just click on the `Packaging price` buttons to use the wizard

--- a/product_packaging_unit_price_calculator/readme/USAGE.rst
+++ b/product_packaging_unit_price_calculator/readme/USAGE.rst
@@ -1,1 +1,1 @@
-Just click on the `Packaging price` buttons to use the wizard
+Click on the `Packaging price` buttons to use the wizard

--- a/product_packaging_unit_price_calculator/tests/__init__.py
+++ b/product_packaging_unit_price_calculator/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_price_packaging_qty

--- a/product_packaging_unit_price_calculator/tests/test_product_price_packaging_qty.py
+++ b/product_packaging_unit_price_calculator/tests/test_product_price_packaging_qty.py
@@ -5,6 +5,7 @@ class TestProductPricePackagingQty(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.product = cls.env.ref("product.product_product_1")
         cls.wizard = cls.env["product.package.price.wizard"]
         cls.pkg_box = cls.env["product.packaging"].create(
@@ -21,8 +22,10 @@ class TestProductPricePackagingQty(SavepointCase):
             {"name": "Pallet", "product_id": cls.product.id}
         )
         cls.pkg_pallet.qty = 2000
-        cls.wizard_1 = cls.wizard.create({"product_id": cls.product.product_tmpl_id.id})
-        cls.supplier = cls.env["res.partner"].create({"name": "Good Supplier"})
+        cls.wizard_1 = cls.wizard.with_context(
+            product_tmpl_id=cls.product.product_tmpl_id.id
+        ).create({})
+        cls.supplier = cls.env.ref("base.res_partner_1")
         cls.supplier_info = cls.env["product.supplierinfo"].create(
             {
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
@@ -36,7 +39,7 @@ class TestProductPricePackagingQty(SavepointCase):
         form.selected_packaging_id = self.pkg_box
         self.assertEqual(form.unit_price, 4)
         form.save()
-        self.wizard_1.save()
+        self.wizard_1.action_set_price()
         self.assertEqual(self.product.list_price, 4)
 
     def test_set_purchase_pacakge_price(self):
@@ -46,5 +49,5 @@ class TestProductPricePackagingQty(SavepointCase):
         form.selected_packaging_id = self.pkg_big_box
         self.assertEqual(form.unit_price, 1)
         form.save()
-        self.wizard_1.save()
+        self.wizard_1.action_set_price()
         self.assertEqual(self.supplier_info.price, 1)

--- a/product_packaging_unit_price_calculator/views/product_packaging.xml
+++ b/product_packaging_unit_price_calculator/views/product_packaging.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp SA
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_packaging_tree_view2" model="ir.ui.view">
+        <field name="name">product.packaging.tree.view2</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_tree_view2" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <field name="sale_price" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_packaging_unit_price_calculator/views/product_pricelist.xml
+++ b/product_packaging_unit_price_calculator/views/product_pricelist.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp SA
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_pricelist_item_form_view" model="ir.ui.view">
+        <field name="name">product.pricelist.item.form.inherit</field>
+        <field name="model">product.pricelist.item</field>
+        <field name="inherit_id" ref="product.product_pricelist_item_form_view" />
+        <field name="arch" type="xml">
+            <group name="pricelist_rule_base" position="inside">
+                <div attrs="{'invisible':[('compute_price', '!=', 'fixed')]}">
+                    <button
+                        name="open_packaging_price"
+                        icon="fa-calculator"
+                        type="object"
+                        class="oe_inline"
+                    >Packaging Prices</button>
+                </div>
+            </group>
+        </field>
+    </record>
+    <record id="product_pricelist_item_tree__view_from_product" model="ir.ui.view">
+        <field name="name">product.pricelist.item.tree.inherit</field>
+        <field name="model">product.pricelist.item</field>
+        <field
+            name="inherit_id"
+            ref="product.product_pricelist_item_tree_view_from_product"
+        />
+        <field name="arch" type="xml">
+            <field name="fixed_price" position="after">
+                <button
+                    name="open_packaging_price"
+                    string="Packaging Prices"
+                    icon="fa-calculator"
+                    type="object"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_packaging_unit_price_calculator/views/product_supplierinfo.xml
+++ b/product_packaging_unit_price_calculator/views/product_supplierinfo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_supplierinfo_form_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.form.inherit</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_form_view" />
+        <field name="arch" type="xml">
+            <field name="price" position="after">
+                <button
+                    name="open_packaging_price"
+                    icon="fa-calculator"
+                    type="object"
+                    class="oe_inline"
+                >Packaging Prices</button>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_packaging_unit_price_calculator/views/product_view.xml
+++ b/product_packaging_unit_price_calculator/views/product_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <button name="open_pricelist_rules" position="after">
+                <button
+                    name="open_packaging_price"
+                    icon="fa-calculator"
+                    type="object"
+                    class="oe_inline"
+                >Packaging Prices</button>
+            </button>
+        </field>
+    </record>
+</odoo>

--- a/product_packaging_unit_price_calculator/wizards/__init__.py
+++ b/product_packaging_unit_price_calculator/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import product_package_price

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.py
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.py
@@ -1,0 +1,100 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class ProductPackagePrice(models.TransientModel):
+    _name = "product.package.price.wizard"
+    _description = "Wizard to compute unit price from packaging price"
+
+    def _default_product_tmpl_id(self):
+        return self.env["product.template"].browse(self._context.get("product_tmpl_id"))
+
+    def _default_product_pricelist_item_id(self):
+        if self._context.get("active_model") != "product.pricelist.item":
+            return False
+        return self.env["product.pricelist.item"].browse(self._context.get("active_id"))
+
+    def _default_product_supplierinfo_id(self):
+        if self._context.get("active_model") != "product.supplierinfo":
+            return False
+        return self.env["product.supplierinfo"].browse(self._context.get("active_id"))
+
+    product_id = fields.Many2one("product.template", default=_default_product_tmpl_id)
+    product_pricelist_item_id = fields.Many2one(
+        "product.pricelist.item", default=_default_product_pricelist_item_id
+    )
+    product_supplierinfo_id = fields.Many2one(
+        "product.supplierinfo", default=_default_product_supplierinfo_id
+    )
+    product_variant_ids = fields.One2many(
+        "product.product", "product_tmpl_id", related="product_id.product_variant_ids",
+    )
+    selected_packaging_id = fields.Many2one(
+        "product.packaging", domain="[('product_id', 'in', product_variant_ids)]",
+    )
+    packaging_price = fields.Float("Package Price", default=0.0, digits="Product Price")
+    unit_price = fields.Float(
+        "Unit Price", compute="_compute_unit_price", readonly=True
+    )
+    packaging_ids = fields.One2many(
+        "product.packaging",
+        string="Product Packages",
+        compute="_compute_packaging_ids",
+    )
+    warning_message = fields.Char(readonly=True, default=" ")
+
+    @api.depends("packaging_price", "selected_packaging_id")
+    def _compute_unit_price(self):
+        if not self.selected_packaging_id:
+            self.unit_price = 0.0
+        elif not self.selected_packaging_id.qty:
+            self.unit_price = 0.0
+            self.warning_message = _(
+                "Unit price can not be computed because the selected"
+                "packaging as no quantity set."
+            )
+        else:
+            self.unit_price = self.packaging_price / self.selected_packaging_id.qty
+            self.warning_message = " "
+            self._compute_package_prices()
+
+    @api.depends("unit_price")
+    def _compute_package_prices(self):
+        if not self.packaging_price or not self.selected_packaging_id:
+            return
+        if not self.selected_packaging_id.qty:
+            raise UserError(
+                _(
+                    "Unit price can not be computed because the selected"
+                    "packaging as no quantity set."
+                )
+            )
+        for pack in self.packaging_ids:
+            pack.packaging_wizard_price = self.unit_price * pack.qty
+
+    @api.depends("product_id")
+    def _compute_packaging_ids(self):
+        if len(self.product_id.product_variant_ids) == 1:
+            self.packaging_ids = self.product_id.product_variant_ids.packaging_ids
+        else:
+            self.packaging_ids = False
+
+    def save(self):
+        if not self.packaging_price:
+            return
+        if not self.selected_packaging_id.qty:
+            raise UserError(
+                _(
+                    "Unit price can not be computed because the selected"
+                    "packaging as no quantity set."
+                )
+            )
+        if self.product_pricelist_item_id:
+            self.product_pricelist_item_id.fixed_price = self.unit_price
+        elif self.product_supplierinfo_id:
+            self.product_supplierinfo_id.price = self.unit_price
+        else:
+            self.product_id.list_price = self.unit_price

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.py
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.py
@@ -54,7 +54,7 @@ class ProductPackagePrice(models.TransientModel):
             self.unit_price = 0.0
             self.warning_message = _(
                 "Unit price can not be computed because the selected"
-                "packaging as no quantity set."
+                "packaging has no quantity set."
             )
         else:
             self.unit_price = self.packaging_price / self.selected_packaging_id.qty
@@ -69,7 +69,7 @@ class ProductPackagePrice(models.TransientModel):
             raise UserError(
                 _(
                     "Unit price can not be computed because the selected"
-                    "packaging as no quantity set."
+                    "packaging has no quantity set."
                 )
             )
         for pack in self.packaging_ids:
@@ -89,7 +89,7 @@ class ProductPackagePrice(models.TransientModel):
             raise UserError(
                 _(
                     "Unit price can not be computed because the selected"
-                    "packaging as no quantity set."
+                    "packaging has no quantity set."
                 )
             )
         if self.product_pricelist_item_id:

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.xml
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.xml
@@ -7,15 +7,15 @@
             <form string="Product Packaging Price">
                 <field name="product_id" invisible="1" />
                 <field name="product_variant_ids" invisible="1" />
-                <group>
-                    <group>
+                <group name="main">
+                    <group name="package_price_group">
                         <field name="packaging_price" />
                         <field
                             name="selected_packaging_id"
                             options="{'no_open': True, 'no_create': True, 'no_edit': True}"
                         />
                     </group>
-                    <group>
+                    <group name="unit_price_group">
                         <field name="unit_price" />
                     </group>
                 </group>
@@ -39,7 +39,7 @@
                 </field>
                 <footer>
                     <button
-                        name="save"
+                        name="action_set_price"
                         string="Save"
                         type="object"
                         class="btn-primary"

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.xml
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_product_package_price_form" model="ir.ui.view">
+        <field name="name">Product Package Price</field>
+        <field name="model">product.package.price.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Product Packaging Price">
+                <field name="product_id" invisible="1" />
+                <field name="product_variant_ids" invisible="1" />
+                <group>
+                    <group>
+                        <field name="packaging_price" />
+                        <field
+                            name="selected_packaging_id"
+                            options="{'no_open': True, 'no_create': True, 'no_edit': True}"
+                        />
+                    </group>
+                    <group>
+                        <field name="unit_price" />
+                    </group>
+                </group>
+                <div class="text-warning">
+                    <field name="warning_message" />
+                </div>
+                <field name="packaging_ids">
+                    <tree>
+                        <field name="name" />
+                        <field name="qty" />
+                        <field
+                            name="packaging_wizard_price"
+                            string="Total Price"
+                            class="font-weight-bold"
+                        />
+                        <field
+                            name="product_uom_id"
+                            options="{'no_open': True, 'no_create': True}"
+                        />
+                    </tree>
+                </field>
+                <footer>
+                    <button
+                        name="save"
+                        string="Save"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="action_unit_price_wizard" model="ir.actions.act_window">
+        <field name="name">Product Package Price</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">product.package.price.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Here is a description of the module from the readme description file:

This module adds a wizard that allow the user to compute a unit price by
selecting a specific `product.packaging` related to the product and the
price of that package. The compuation is done based on the quantity `qty`
of product set on the packaging.

The wizard is accesible by buttons located in a few different places in the UI

* Next to the sale price of the product on the product form
* Next to the price of a product supplier info  form
* Next to the price of price list item in the tree view
* Below the fixed price of a price list item

When the wizard is saved the value of the price located next to the button is
updated by the computed unit price of the wizard.

The sale price of a `product.packaging` is displayed in the packaging list on
the Inventory page of the product form.