### PR TITLE
[13.0] packaging_uom: Fix xmlid of product packaging tree view

### DIFF
--- a/packaging_uom/views/product_packaging_views.xml
+++ b/packaging_uom/views/product_packaging_views.xml
@@ -10,7 +10,7 @@
             <field name="packaging_ids" position="attributes">
                 <attribute name="context">{
                     'get_uom_categ_from_uom': uom_id,
-                    'tree_view_ref':'product.product.product_packaging_tree_view2',
+                    'tree_view_ref': 'product.product_packaging_tree_view2',
                     'form_view_ref': 'product.product_packaging_form_view2'}
                 </attribute>
             </field>


### PR DESCRIPTION
The erroneous xmlid is not found, so the wrong list view is shown.
