### PR TITLE
[13.0][IMP] product_packaging_unit_price_calculator

### DIFF
--- a/product_packaging_unit_price_calculator/models/product.py
+++ b/product_packaging_unit_price_calculator/models/product.py
@@ -14,3 +14,15 @@ class ProductTemplate(models.Model):
         ).read()[0]
         action["context"] = {"product_tmpl_id": self.id}
         return action
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def open_packaging_price(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "product_packaging_unit_price_calculator.action_unit_price_wizard"
+        ).read()[0]
+        action["context"] = {"product_tmpl_id": self.product_tmpl_id.id}
+        return action

--- a/product_packaging_unit_price_calculator/models/product_packaging.py
+++ b/product_packaging_unit_price_calculator/models/product_packaging.py
@@ -8,9 +8,9 @@ class ProductPackaging(models.Model):
     _inherit = "product.packaging"
 
     unit_price = fields.Float(related="product_id.list_price")
-    sale_price = fields.Float(compute="_compute_sale_price")
+    sale_price = fields.Float(compute="_compute_sale_price", digits="Product Price")
     # Only used by the wizard to display the computed price in the treeview
-    packaging_wizard_price = fields.Float(store=False)
+    packaging_wizard_price = fields.Float(store=False, digits="Product Price")
 
     @api.depends("unit_price", "qty")
     def _compute_sale_price(self):

--- a/product_packaging_unit_price_calculator/tests/test_product_price_packaging_qty.py
+++ b/product_packaging_unit_price_calculator/tests/test_product_price_packaging_qty.py
@@ -7,6 +7,7 @@ class TestProductPricePackagingQty(SavepointCase):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.product = cls.env.ref("product.product_product_1")
+        cls.product.list_price = 222
         cls.wizard = cls.env["product.package.price.wizard"]
         cls.pkg_box = cls.env["product.packaging"].create(
             {"name": "Box", "product_id": cls.product.id}
@@ -30,6 +31,7 @@ class TestProductPricePackagingQty(SavepointCase):
             {
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
                 "name": cls.supplier.id,
+                "price": 333,
             }
         )
 
@@ -37,6 +39,7 @@ class TestProductPricePackagingQty(SavepointCase):
         form = Form(self.wizard_1)
         form.packaging_price = 200
         form.selected_packaging_id = self.pkg_box
+        self.assertEqual(self.wizard_1.current_unit_price, 222)
         self.assertEqual(form.unit_price, 4)
         form.save()
         self.wizard_1.action_set_price()
@@ -45,6 +48,7 @@ class TestProductPricePackagingQty(SavepointCase):
     def test_set_purchase_pacakge_price(self):
         self.wizard_1.product_supplierinfo_id = self.supplier_info
         form = Form(self.wizard_1)
+        self.assertEqual(self.wizard_1.current_unit_price, 333)
         form.packaging_price = 200
         form.selected_packaging_id = self.pkg_big_box
         self.assertEqual(form.unit_price, 1)

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.py
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.py
@@ -41,7 +41,13 @@ class ProductPackagePrice(models.TransientModel):
     )
     packaging_price = fields.Float("Package Price", default=0.0, digits="Product Price")
     unit_price = fields.Float(
-        "Unit Price", compute="_compute_unit_price", readonly=True
+        "Unit Price",
+        compute="_compute_unit_price",
+        readonly=True,
+        digits="Product Price",
+    )
+    current_unit_price = fields.Float(
+        compute="_compute_current_unit_price", digits="Product Price"
     )
     packaging_ids = fields.One2many(
         "product.packaging",
@@ -53,9 +59,9 @@ class ProductPackagePrice(models.TransientModel):
     @api.depends("packaging_price", "selected_packaging_id")
     def _compute_unit_price(self):
         if not self.selected_packaging_id:
-            self.unit_price = 0.0
+            self.unit_price = self.current_unit_price
         elif not self.selected_packaging_id.qty:
-            self.unit_price = 0.0
+            self.unit_price = self.current_unit_price
             self.warning_message = _(
                 "Unit price cannot be computed because the selected"
                 "packaging has no quantity set."
@@ -63,19 +69,20 @@ class ProductPackagePrice(models.TransientModel):
         else:
             self.unit_price = self.packaging_price / self.selected_packaging_id.qty
             self.warning_message = " "
-            self._compute_package_prices()
+        self._compute_package_prices()
+
+    @api.depends("product_pricelist_item_id", "product_supplierinfo_id", "product_id")
+    def _compute_current_unit_price(self):
+        """Compute the original unit price, the one  that the calculator will change."""
+        if self.product_pricelist_item_id:
+            self.current_unit_price = self.product_pricelist_item_id.fixed_price
+        elif self.product_supplierinfo_id:
+            self.current_unit_price = self.product_supplierinfo_id.price
+        else:
+            self.current_unit_price = self.product_id.list_price
 
     @api.depends("unit_price")
     def _compute_package_prices(self):
-        if not self.packaging_price or not self.selected_packaging_id:
-            return
-        if not self.selected_packaging_id.qty:
-            raise UserError(
-                _(
-                    "Unit price cannot be computed because the selected"
-                    "packaging has no quantity set."
-                )
-            )
         for pack in self.packaging_ids:
             pack.packaging_wizard_price = self.unit_price * pack.qty
 
@@ -99,3 +106,14 @@ class ProductPackagePrice(models.TransientModel):
             self.product_supplierinfo_id.price = self.unit_price
         else:
             self.product_id.list_price = self.unit_price
+
+    def reset_unit_price(self):
+        action = self.env.ref(
+            "product_packaging_unit_price_calculator.action_unit_price_wizard"
+        ).read()[0]
+        action["context"] = {
+            "product_tmpl_id": self._context.get("product_tmpl_id"),
+            "active_model": self._context.get("active_model"),
+            "active_id": self._context.get("active_id"),
+        }
+        return action

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.xml
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.xml
@@ -5,7 +5,7 @@
         <field name="model">product.package.price.wizard</field>
         <field name="arch" type="xml">
             <form string="Product Packaging Price">
-                <field name="product_id" invisible="1" />
+                <field name="product_tmpl_id" invisible="1" />
                 <field name="product_variant_ids" invisible="1" />
                 <group name="main">
                     <group name="package_price_group">

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.xml
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.xml
@@ -17,6 +17,10 @@
                     </group>
                     <group name="unit_price_group">
                         <field name="unit_price" />
+                        <button
+                            name="reset_unit_price"
+                            type="object"
+                        >Reset unit price</button>
                     </group>
                 </group>
                 <div class="text-warning">
@@ -24,7 +28,7 @@
                 </div>
                 <field name="packaging_ids">
                     <tree>
-                        <field name="name" />
+                        <field name="display_name" />
                         <field name="qty" />
                         <field
                             name="packaging_wizard_price"


### PR DESCRIPTION
Use the display name for the packaging in the list of packages.
Set all prices to use the Product Price digits configuration.
On load set the current unit price so package prices are displayed.
Add a button to reset the calculator.