### PR TITLE
[IMP][product_packaging_type] Specific UNECE product packaging naming.

### DIFF
--- a/product_packaging_type/models/product_packaging_type.py
+++ b/product_packaging_type/models/product_packaging_type.py
@@ -29,6 +29,12 @@ class ProductPackagingType(models.Model):
         if msg:
             raise ValidationError(msg)
 
+    def name_get(self):
+        result = []
+        for record in self:
+            result.append((record.id, "{} ({})".format(record.name, record.code)))
+        return result
+
 
 class ProductPackaging(models.Model):
     _inherit = "product.packaging"
@@ -90,3 +96,17 @@ class ProductPackaging(models.Model):
                 )
             res.append("{} {}".format(new_qty, code))
         return "; ".join(res)
+
+    @api.onchange("packaging_type_id")
+    def _onchange_name(self):
+        if self.packaging_type_id:
+            self.name = self.packaging_type_id.name
+
+    def name_get(self):
+        result = []
+        for record in self:
+            if record.product_id and record.packaging_type_id:
+                result.append((record.id, record.packaging_type_id.display_name))
+            else:
+                result.append((record.id, record.name))
+        return result

--- a/product_packaging_type/views/product_packaging_view.xml
+++ b/product_packaging_type/views/product_packaging_view.xml
@@ -16,6 +16,12 @@
                     name="attrs"
                 >{'required': [('type_has_gtin', '=', True)]}</attribute>
             </xpath>
+            <field name="name" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="name" position="after">
+                <field name="packaging_type_id" position="move" />
+            </field>
         </field>
     </record>
     <record id="product_packaging_tree_view_inherit" model="ir.ui.view">
@@ -25,7 +31,12 @@
         <field name="arch" type="xml">
             <field name="product_uom_id" position="after">
                 <field name="qty_per_type" />
-                <field name="packaging_type_id" />
+            </field>
+            <field name="name" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="name" position="before">
+                <field name="display_name" string="Packaging" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
**Context**

* Manage UNECE codes on packaging
* Be able to express a packaging qty in smallest packaging qty
* Simplify packaging name management to ease translation and avoid people to write a name every time they add a packaging on a product

**Usage**

When I open a product form, in the inventory tab I want to see the product packaging and its related code I can quickly see the Qty per packaging to know how much of a given packaging is contain in another

 

**TODO**

* Update (Improve) the module "product_packaging_type" from product-attribute (I think ) to:
    * in the product "Inventory" tab form (Packaging list view)
        * Hide the name of the packaging
        * Move the "Packaging type" in the first position
    * When opening the packaging form view from  "Inventory" tab of the product
        * Replace the name by packaging type at the top
        * Hide name field, but populate it with on_change of packaging with the packaging type name
    * Name of the packaging type:
        * name_get should be: "NAME + ' ' + (CODE)" -> e.g. Retail box (HV)
        * name_get of the product packaging should be overridden:

```python
            if product_id is set:
                return packaging_type name (e.g. Transport box)
            else:
                return the recorded packaging name on the packaging (e.g. DHL box)
```



replace #642 


![image](https://user-images.githubusercontent.com/32262135/86367383-27ec8500-bc7c-11ea-9245-551dbe4002f8.png)
![image](https://user-images.githubusercontent.com/32262135/86367396-2cb13900-bc7c-11ea-90c7-184a0110946e.png)
![image](https://user-images.githubusercontent.com/32262135/86367407-3175ed00-bc7c-11ea-814a-a99325f7450b.png)
