### PR TITLE
[13.0] Create module product_total_weight_from_packaging

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+stock-logistics-warehouse

--- a/packaging_uom/models/product_packaging.py
+++ b/packaging_uom/models/product_packaging.py
@@ -34,7 +34,7 @@ class ProductPackaging(models.Model):
         comodel_name="uom.category",
     )
     qty = fields.Float(
-        compute="_compute_qty", inverse="_inverse_qty", store=True, readonly=True
+        compute="_compute_qty", inverse="_inverse_qty", store=True, readonly=False
     )
 
     @api.depends("uom_id", "product_id.uom_id")

--- a/product_total_weight_from_packaging/__init__.py
+++ b/product_total_weight_from_packaging/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_total_weight_from_packaging/__manifest__.py
+++ b/product_total_weight_from_packaging/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Product Total Weight From Packaging",
+    "summary": "Compute estimated weight based on product's packaging weights",
+    "version": "13.0.1.3.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/stock-logistics-warehouse",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["stock_packaging_calculator", "product_packaging_dimension"],
+}

--- a/product_total_weight_from_packaging/models/__init__.py
+++ b/product_total_weight_from_packaging/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/product_total_weight_from_packaging/models/product.py
+++ b/product_total_weight_from_packaging/models/product.py
@@ -1,0 +1,34 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class ProductProduct(models.Model):
+
+    _inherit = "product.product"
+
+    def get_total_weight_from_packaging(self, qty):
+        self.ensure_one()
+        qty_by_packaging_with_weight = self.with_context(
+            **{
+                "_packaging_filter": lambda p: p.max_weight,
+                "_with_packaging_weight": True,
+            }
+        ).product_qty_by_packaging(qty)
+        total_weight = sum(
+            [
+                pck.get("qty", 0) * pck.get("weight", 0)
+                for pck in qty_by_packaging_with_weight
+            ]
+        )
+        return total_weight
+
+    def _prepare_qty_by_packaging_values(self, packaging_tuple, qty_per_pkg):
+        res = super()._prepare_qty_by_packaging_values(packaging_tuple, qty_per_pkg)
+        if self.env.context.get("_with_packaging_weight"):
+            if packaging_tuple.is_unit:
+                res["weight"] = self.weight
+            else:
+                packaging = self.env["product.packaging"].browse(packaging_tuple.id)
+                res["weight"] = packaging.max_weight
+        return res

--- a/product_total_weight_from_packaging/readme/CONTRIBUTORS.rst
+++ b/product_total_weight_from_packaging/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/product_total_weight_from_packaging/readme/DESCRIPTION.rst
+++ b/product_total_weight_from_packaging/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module provides a a function to estimate the weight
+of a given quantity of a product, taking into account the product
+packaging's weights.
+
+It uses module `stock_packaging_calculator` to get weight from product packagings
+having a weight defined first and fallback on product weight field if no
+weight is defined on any of the packagings.

--- a/product_total_weight_from_packaging/tests/__init__.py
+++ b/product_total_weight_from_packaging/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_total_weight_from_packaging

--- a/product_total_weight_from_packaging/tests/test_product_total_weight_from_packaging.py
+++ b/product_total_weight_from_packaging/tests/test_product_total_weight_from_packaging.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestProductTotalWeightFromPackaging(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env.ref("product.product_product_20")
+        cls.product.weight = 5
+        cls.env["product.packaging"].create(
+            {"name": "pair", "product_id": cls.product.id, "qty": 2, "max_weight": 12.5}
+        )
+        cls.env["product.packaging"].create(
+            {
+                "name": "cardbox",
+                "product_id": cls.product.id,
+                "qty": 10,
+                "max_weight": 55,
+            }
+        )
+        cls.env["product.packaging"].create(
+            {"name": "pallet", "product_id": cls.product.id, "qty": 200}
+        )
+
+    def test_weight_from_packaging(self):
+        weight = self.product.get_total_weight_from_packaging(259)
+        self.assertEqual(weight, 25 * 55 + 4 * 12.5 + 5)

--- a/setup/product_total_weight_from_packaging/odoo/addons/product_total_weight_from_packaging
+++ b/setup/product_total_weight_from_packaging/odoo/addons/product_total_weight_from_packaging
@@ -1,0 +1,1 @@
+../../../../product_total_weight_from_packaging

--- a/setup/product_total_weight_from_packaging/setup.py
+++ b/setup/product_total_weight_from_packaging/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Depends on:
 - [x] https://github.com/OCA/stock-logistics-warehouse/pull/939
 - [x] https://github.com/Tonow-c2c/stock-logistics-warehouse/pull/1


This module provides a weight calculation function for products based on their
packagings weight.

It uses module `stock_packaging_calculator` to get weight from packagings
having a weight defined first and fallback on product weight field if no
weight is defined on the packagings.