### PR TITLE
[12.0][FIX] packaging_uom: use factor 1.0 if packaging quantity equals 0

### DIFF
--- a/packaging_uom/models/product_packaging.py
+++ b/packaging_uom/models/product_packaging.py
@@ -67,8 +67,9 @@ class ProductPackaging(models.Model):
         """
         for packaging in self:
             category_id = packaging.product_id.uom_id.category_id
+            factor = 1.0 / packaging.qty if packaging.qty else 1.0
             uom_id = packaging.uom_id.search([
-                ("factor", "=", 1.0 / packaging.qty),
+                ("factor", "=", factor),
                 ('category_id', '=', category_id.id)])
             if not uom_id:
                 uom_id = packaging.uom_id.create({


### PR DESCRIPTION
This PR is intended to fix a small issue that appeared when running tests here [stock-logistics-warehouse/pull/938](https://github.com/OCA/stock-logistics-warehouse/pull/938).

When a packaging has qty equal to 0, there was a division by zero which raised the following error:
![image](https://user-images.githubusercontent.com/44768500/87927018-d23d1880-ca82-11ea-9827-ca12f4e68908.png)

The fix consists on default the value of factor to 1.0 if the quantity of the package is 0.

cc ~ @ForgeFlow