### PR TITLE
[13.0] Add unique constraint on Packaging Type

### DIFF
--- a/product_packaging_type/data/product_packaging_type.xml
+++ b/product_packaging_type/data/product_packaging_type.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<odoo>
+<odoo noupdate="1">
     <record id="product_packaging_type_default" model="product.packaging.type">
         <field name="name">Default Type</field>
         <field name="code">DEFAULT</field>


### PR DESCRIPTION
The constraint was added by module
OCA/stock-logistics-warehouse::stock_cubiscan, which makes no sense, see:
https://github.com/OCA/stock-logistics-warehouse/blob/95cc85c470dcdf6f41cec828e39beac4a9786c80/stock_cubiscan/models/stock.py#L15-L26

The constraint is removed from `stock_cubiscan` in https://github.com/OCA/stock-logistics-warehouse/pull/944

We should have only one type of packaging per product, but there is a
twist for the default packaging.

As the packaging type is required on a package, to be a good player with
other modules and existing data, a default packaging type is created,
and is used as a default value.

An existing database with 4 packaging per product will have the default
on all the packagings. So the unique constraint ignores the default
type, allowing users to transition to the proper types.