### PR TITLE
[IMP] add sale_price basond on sale_margin to supplierinfo

### DIFF
--- a/product_pricelist_supplierinfo/__manifest__.py
+++ b/product_pricelist_supplierinfo/__manifest__.py
@@ -14,7 +14,9 @@
         "product",
     ],
     "data": [
+        "security/res_groups.xml",
         "views/product_pricelist_item_views.xml",
+        "views/product_supplierinfo_view.xml",
     ],
     "installable": True,
 }

--- a/product_pricelist_supplierinfo/models/__init__.py
+++ b/product_pricelist_supplierinfo/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import product_supplierinfo
 from . import product_pricelist
 from . import product_product
 from . import product_template

--- a/product_pricelist_supplierinfo/models/product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/models/product_supplierinfo.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Akretion - Mourad EL HADJ MIMOUNE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class ProductSupplierinfo(models.Model):
+    _inherit = 'product.supplierinfo'
+
+    sale_margin = fields.Float(
+        'Sale Margin', default=0, digits=(16, 2),
+        help="Margin to apply on price to obtain sale price")
+
+    @api.multi
+    def _get_supplierinfo_pricelist_price(self):
+        self.ensure_one()
+        sale_price = self.price
+        if self.sale_margin:
+            sale_price = (
+                (self.price + (self.price * (self.sale_margin / 100)))
+                or 0.0)
+        return sale_price

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -44,9 +44,10 @@ class ProductTemplate(models.Model):
             domain, order='min_qty,sequence,price',
         )
         if rule.no_supplierinfo_min_quantity:
-            price = supplierinfos[:1].price
+            selected_supplierinfo = supplierinfos[:1]
         else:
-            price = supplierinfos[-1:].price
+            selected_supplierinfo = supplierinfos[-1:]
+        price = selected_supplierinfo._get_supplierinfo_pricelist_price()
         if price:
             # We have to replicate this logic in this method as pricelist
             # method are atomic and we can't hack inside.

--- a/product_pricelist_supplierinfo/readme/DESCRIPTION.rst
+++ b/product_pricelist_supplierinfo/readme/DESCRIPTION.rst
@@ -1,3 +1,6 @@
 This module allows you to create a sales pricelist based on product
 supplierinfo prices. If you want, you can bypass minimum quantity in pricelist
 item.
+
+We can also define sale marging applied on purchase price directly on supplier info.
+For this, you must add users to "Show sale margin on Product Supplierinfo" group.

--- a/product_pricelist_supplierinfo/security/res_groups.xml
+++ b/product_pricelist_supplierinfo/security/res_groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="group_supplierinfo_pricelist_sale_margin" model="res.groups">
+        <field name="name">Show sale margin on Product Supplierinfo</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
+</odoo>

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -133,3 +133,21 @@ class TestProductSupplierinfo(common.SavepointCase):
         self.assertAlmostEqual(
             self.pricelist.get_product_price(self.product, 1, False), 20.0,
         )
+
+    def test_pricelist_based_on_sale_margin(self):
+        self.pricelist.item_ids[0].write({
+            'applied_on': '1_product',
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+        })
+        self.product.seller_ids[1].sale_margin = 50
+        self.assertAlmostEqual(
+            self.product.seller_ids[1]._get_supplierinfo_pricelist_price(), 75.0,
+        )
+
+        self.assertAlmostEqual(
+            self.pricelist.get_product_price(self.product, 6, False), 75.0,
+        )
+        self.assertAlmostEqual(
+            self.product.product_tmpl_id.with_context(
+                pricelist=self.pricelist.id, quantity=6).price, 75.0,
+        )

--- a/product_pricelist_supplierinfo/views/product_supplierinfo_view.xml
+++ b/product_pricelist_supplierinfo/views/product_supplierinfo_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_supplierinfo_tree_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.tree.view.pricelist</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_tree_view"/>
+        <field name="groups_id" eval="[(4,ref('product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin'))]"/>
+        <field name="arch" type="xml">
+            <field name="price" position="after">
+                <field name="sale_margin" string="Sale margin"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_supplierinfo_form_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.form.view.pricelist</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_form_view"/>
+        <field name="groups_id" eval="[(4,ref('product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin'))]"/>
+        <field name="arch" type="xml">
+            <xpath expr="//label[@for='date_start']" position="before">
+                <label for="sale_margin"/>
+                <div>
+                    <field name="sale_margin" class="oe_inline"/>
+                </div>
+           </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Improve pricelist_supplierinfo. Add sale price based on sale_margin on product supplier info.
Its allows to simply manage several price list without redefine  sale price on each pricelist (only add discount for example). 