### PR TITLE
[FIX] product_pricelist_supplierinfo: variant domain

### DIFF
--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -2,6 +2,8 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from datetime import date
+
 from odoo.tests import common
 
 
@@ -34,18 +36,6 @@ class TestProductSupplierinfo(common.SavepointCase):
                 }),
             ],
         })
-        cls.product.write({'seller_ids': [
-            (0, 0, {
-                'name': cls.supplier1.id,
-                'min_qty': 5,
-                'price': 50,
-            }),
-            (0, 0, {
-                'name': cls.supplier2.id,
-                'min_qty': 1,
-                'price': 10,
-            }),
-        ]})
         cls.pricelist = cls.env['product.pricelist'].create({
             'name': 'Supplierinfo Pricelist',
             'discount_policy': 'without_discount',
@@ -117,7 +107,7 @@ class TestProductSupplierinfo(common.SavepointCase):
         )[0].date_start = '2018-12-31'
         self.assertAlmostEqual(
             self.pricelist.get_product_price(
-                self.product, 5, False, date='2019-01-01',
+                self.product, 5, False, date=date(2019, 1, 1),
             ), 50,
         )
 
@@ -139,15 +129,47 @@ class TestProductSupplierinfo(common.SavepointCase):
             'applied_on': '1_product',
             'product_tmpl_id': self.product.product_tmpl_id.id,
         })
-        self.product.seller_ids[1].sale_margin = 50
+        seller = self.product.seller_ids[0]
+        seller.sale_margin = 50
         self.assertAlmostEqual(
-            self.product.seller_ids[1]._get_supplierinfo_pricelist_price(), 75.0,
+            seller._get_supplierinfo_pricelist_price(), 75.0,
         )
-
         self.assertAlmostEqual(
             self.pricelist.get_product_price(self.product, 6, False), 75.0,
         )
         self.assertAlmostEqual(
             self.product.product_tmpl_id.with_context(
                 pricelist=self.pricelist.id, quantity=6).price, 75.0,
+        )
+
+    def test_supplierinfo_per_variant(self):
+        tmpl = self.env['product.template'].create({
+            'name': 'Test Product',
+            'attribute_line_ids': [[0, 0, {
+                'attribute_id': self.env.ref('product.product_attribute_1').id,
+                'value_ids': [
+                    (4, self.env.ref('product.product_attribute_value_1').id),
+                    (4, self.env.ref('product.product_attribute_value_2').id),
+                ],
+            }]]
+        })
+        variant1 = tmpl.product_variant_ids[0]
+        variant2 = tmpl.product_variant_ids[1]
+        tmpl.write({'seller_ids': [
+            (0, 0, {
+                'name': self.supplier1.id,
+                'product_id': variant1.id,
+                'price': 15,
+            }),
+            (0, 0, {
+                'name': self.supplier1.id,
+                'product_id': variant2.id,
+                'price': 25,
+            }),
+        ]})
+        self.assertAlmostEqual(
+            self.pricelist.get_product_price(variant1, 1, False), 15.0,
+        )
+        self.assertAlmostEqual(
+            self.pricelist.get_product_price(variant2, 1, False), 25.0,
         )


### PR DESCRIPTION
Before this commit, all supplierinfo records with product_tmpl_id set,
were considered as possible price for all product variants, even if
product_id was set also. That resulted in same price for all variants
even if supplierinfo records had different price for all variants.

Now, if product variant is set on a supplier record, only that is taken
into consideration for respective variant. If only template is set, it
will still be considered.

Maybe worth to mention, that it removing template relation from supplierinfo record sort of fixed the issue, but Odoo UI does not even allow selecting variant relation without template set, because of the filter domain on variant field. Also, doing that introduced permission issues down the line, resulting in all prices being 0 for non internal users.