### PR TITLE
[12.0][ADD] product_pricelist_supplierinfo: Partner to get pricelist price

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -28,6 +28,7 @@ class ProductPricelist(models.Model):
                         rule,
                         date=date or context.get('date', fields.Date.today()),
                         quantity=qty,
+                        partner_id=products_qty_partner[0][2],
                     ), rule.id,
                 )
         return result

--- a/product_pricelist_supplierinfo/models/product_product.py
+++ b/product_pricelist_supplierinfo/models/product_product.py
@@ -10,9 +10,10 @@ class ProductProduct(models.Model):
     _inherit = 'product.product'
 
     def _get_supplierinfo_pricelist_price(
-            self, rule, date=None, quantity=None):
+            self, rule, date=None, quantity=None, partner_id=False):
         return self.product_tmpl_id._get_supplierinfo_pricelist_price(
-            rule, date=date, quantity=quantity, product_id=self.id)
+            rule, date=date, quantity=quantity,
+            product_id=self.id, partner_id=partner_id)
 
     def price_compute(self, price_type, uom=False, currency=False,
                       company=False):

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -10,8 +10,8 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     def _get_supplierinfo_pricelist_price(
-            self, rule, date=None, quantity=None, product_id=None):
-        """Method for getting the price from supplier info."""
+            self, rule, date=None, quantity=None, product_id=None, partner_id=False):
+
         self.ensure_one()
         price = 0.0
         product = self.product_variant_id
@@ -19,7 +19,8 @@ class ProductTemplate(models.Model):
             product = product.browse(product_id)
         if rule.no_supplierinfo_min_quantity:
             quantity = 1.0
-        seller = product._select_seller(quantity=quantity, date=date)
+        seller = product._select_seller(
+            quantity=quantity, date=date, partner_id=partner_id)
         if seller:
             price = seller._get_supplierinfo_pricelist_price()
         if price:


### PR DESCRIPTION
Adding the option to send a `partner_id` to get the pricelist price of a product and obtaining the `partner_id` of the customer to whom the price is being computed.