### PR TITLE
[12.0][IMP] product_code_unique: Allow to use inactive products

### DIFF
--- a/product_code_unique/models/product.py
+++ b/product_code_unique/models/product.py
@@ -8,5 +8,5 @@ class ProductProduct(models.Model):
     _inherit = 'product.product'
 
     _sql_constraints = [
-        ('default_code_uniq', 'unique(default_code)',
+        ('default_code_uniq', 'EXCLUDE (default_code WITH =) WHERE (active = True)',
             'Internal Reference must be unique across the database!'), ]

--- a/product_code_unique/tests/__init__.py
+++ b/product_code_unique/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_code_unique

--- a/product_code_unique/tests/test_code_unique.py
+++ b/product_code_unique/tests/test_code_unique.py
@@ -1,0 +1,49 @@
+# Copyright 2019 DynApps <https://www.dynapps.be/>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import psycopg2
+from odoo.tests.common import SavepointCase
+from odoo.tools.misc import mute_logger
+
+
+class TestCodeUnique(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_obj = cls.env['product.product']
+        cls.product1 = cls.product_obj.create({
+            'name': 'Test Product 1',
+            'default_code': 'TSTP1',
+        })
+
+    def test_01_check_code_other(self):
+        self.product2 = self.product_obj.create({
+            'name': 'Test Product 2',
+            'default_code': 'TSTP2',
+        })
+
+    def test_02_check_code_unique(self):
+        with self.assertRaises(psycopg2.IntegrityError):
+            with mute_logger('odoo.sql_db'), self.cr.savepoint():
+                self.product2 = self.product_obj.create({
+                    'name': 'Test Product 2',
+                    'default_code': 'TSTP1',
+                })
+
+    def test_03_check_code_inactive(self):
+        self.product2 = self.product_obj.create({
+            'name': 'Test Product 2',
+            'default_code': 'TSTP2',
+        })
+        self.product2.write({'active': False})
+        self.product3 = self.product_obj.create({
+            'name': 'Test Product 3',
+            'default_code': 'TSTP2',
+        })
+        with self.assertRaises(psycopg2.IntegrityError):
+            with mute_logger('odoo.sql_db'), self.cr.savepoint():
+                self.product_obj.create({
+                    'name': 'Test Product 4',
+                    'default_code': 'TSTP2',
+                })


### PR DESCRIPTION
Module limitation was it was impossible to create a new product with the same default code as an archived one.

@max3903 @rven @agyamuta Can you confirm this use case is correct ?