### PR TITLE
[FIX] product_pricelist_direct_print: archived ordered products

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -207,7 +207,8 @@ class ProductPricelistPrint(models.TransientModel):
         orders = partner.sale_order_ids.filtered(
             lambda r: r.state not in ['draft', 'sent', 'cancel'])
         orders = orders.sorted(key=lambda r: r.confirmation_date, reverse=True)
-        products = orders.mapped('order_line').mapped('product_id')
+        products = orders.mapped(
+            'order_line').mapped('product_id').filtered('active')
         return products[:self.last_ordered_products]
 
     @api.multi


### PR DESCRIPTION
We could print an archived product if we get it from the last ordered
ones. Filter those as we don't want to show them to the user.

cc @Tecnativa TT25601