### PR TITLE
[IMP] product_template_tags: speed up tag.products_count compute

### DIFF
--- a/product_template_tags/models/product_template_tag.py
+++ b/product_template_tags/models/product_template_tag.py
@@ -16,7 +16,7 @@ class ProductTemplateTag(models.Model):
         relation='product_template_product_tag_rel',
         column1='tag_id', column2='product_tmpl_id')
     products_count = fields.Integer(
-        string="# of Products", compute='_compute_products_count', store=True)
+        string="# of Products", compute='_compute_products_count')
     company_id = fields.Many2one(
         comodel_name='res.company', string="Company",
         default=lambda self: self._default_company())
@@ -28,5 +28,12 @@ class ProductTemplateTag(models.Model):
     @api.multi
     @api.depends('product_tmpl_ids')
     def _compute_products_count(self):
+        if not self.ids:
+            return
+        self.env.cr.execute("""SELECT tag_id, COUNT(*)
+            FROM product_template_product_tag_rel
+            WHERE tag_id IN %s
+            GROUP BY tag_id""", (tuple(self.ids),))
+        tag_id_product_count = dict(self.env.cr.fetchall())
         for rec in self:
-            rec.products_count = len(rec.product_tmpl_ids)
+            rec.products_count = tag_id_product_count.get(rec.id, 0)


### PR DESCRIPTION
The tag.products_count field was store=True
If more than one user is adding/removing the same tag to different products
at the same time it will raise concurrencies issues

In fact, if you are configuring/importing your products
this compute could be so slow
Since that each tag will be updated for each product

It was changed to store=False in order to avoid these issues.

The tag.products_count field is displayed in tree view
So it needs to be so faster
Then the compute was changed using a query directly with "group by"
in order to process it faster

Note: Only this compute spend 3 hours in our importation/configuration process

![image](https://user-images.githubusercontent.com/6644187/94448254-4d503880-0170-11eb-9cc1-9459a7d9bd8c.png)
