### PR TITLE
[12.0][IMP] product_pricelist_show_product_ref: display product code in pricelists for templates

### DIFF
--- a/product_pricelist_show_product_ref/README.rst
+++ b/product_pricelist_show_product_ref/README.rst
@@ -48,7 +48,6 @@ To use this module, you need to:
 
 #. Go to *Sales > Products > Pricelists* and create a new Price List.
 #. Add a Pricelist Items to that Price List.
-   Make sure it is a 'Product Variant' and not a 'Product'.
 #. Save your changes.
 #. Verify that the Product is displayed with the full name (including the Internal code)
 

--- a/product_pricelist_show_product_ref/__manifest__.py
+++ b/product_pricelist_show_product_ref/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Show Product Ref on Product Pricelist",
     "summary": "Show Product Ref on Product Pricelist",
-    "version": "12.0.1.0.0",
+    "version": "12.0.2.0.0",
     "development_status": "Beta",
     "category": "Product",
     "website": "https://www.github.com/OCA/product-attribute",

--- a/product_pricelist_show_product_ref/models/product_pricelist.py
+++ b/product_pricelist_show_product_ref/models/product_pricelist.py
@@ -11,4 +11,6 @@ class ProductPricelistItem(models.Model):
         res = super(). _get_pricelist_item_name_price()
         for record in self.filtered("product_id"):
             record.name = record.product_id.display_name
+        for record in self.filtered("product_tmpl_id"):
+            record.name = record.product_tmpl_id.display_name
         return res

--- a/product_pricelist_show_product_ref/readme/USAGE.rst
+++ b/product_pricelist_show_product_ref/readme/USAGE.rst
@@ -2,6 +2,5 @@ To use this module, you need to:
 
 #. Go to *Sales > Products > Pricelists* and create a new Price List.
 #. Add a Pricelist Items to that Price List.
-   Make sure it is a 'Product Variant' and not a 'Product'.
 #. Save your changes.
 #. Verify that the Product is displayed with the full name (including the Internal code)

--- a/product_pricelist_show_product_ref/static/description/index.html
+++ b/product_pricelist_show_product_ref/static/description/index.html
@@ -397,8 +397,7 @@ ul.auto-toc {
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to <em>Sales &gt; Products &gt; Pricelists</em> and create a new Price List.</li>
-<li>Add a Pricelist Items to that Price List.
-Make sure it is a ‘Product Variant’ and not a ‘Product’.</li>
+<li>Add a Pricelist Items to that Price List.</li>
 <li>Save your changes.</li>
 <li>Verify that the Product is displayed with the full name (including the Internal code)</li>
 </ol>

--- a/product_pricelist_show_product_ref/tests/test_product_pricelist_show_product_ref.py
+++ b/product_pricelist_show_product_ref/tests/test_product_pricelist_show_product_ref.py
@@ -44,40 +44,60 @@ class TestProductPricelistShowProductRef(SavepointCase):
             'fixed_price': 100,
         })
 
-    def test_code_in_display_name_in_product(self):
+    def test_code_in_display_name_in_product_variant(self):
         """Test product item has code in display_name
         """
         self.assertTrue(
             "[{}]".format(
                 self.pricelist_item_product_product.product_id.default_code
-            ) in self.pricelist_item_product_product.display_name
+            ) in self.pricelist_item_product_product.name
         )
 
-    def test_code_not_in_display_name_in_product_template(self):
+    def test_code_in_display_name_in_product_template(self):
         """Test product template item has no code in display_name
         """
-        self.assertFalse(
+        self.assertTrue(
             "[{}]".format(
-                self.pricelist_item_product_template.product_id.default_code
-            ) in self.pricelist_item_product_template.display_name
+                self.pricelist_item_product_template.product_tmpl_id.default_code
+            ) in self.pricelist_item_product_template.name
         )
 
-    def test_display_name_rewritten(self):
-        """Test the display_name is rewritten
+    def test_display_name_rewritten_in_product_variant(self):
+        """Test the display_name is rewritten in variant
         """
         product_name = self.product.display_name.replace(
             "[{}]".format(self.product.default_code),
             ""
         )
-        self.pricelist_item_product_product.display_name = product_name
+        self.pricelist_item_product_product.name = product_name
         self.assertFalse(
             "[{}]".format(
                 self.pricelist_item_product_product.product_id.default_code
-            ) in self.pricelist_item_product_product.display_name
+            ) in self.pricelist_item_product_product.name
         )
         self.pricelist_item_product_product._get_pricelist_item_name_price()
         self.assertTrue(
             "[{}]".format(
                 self.pricelist_item_product_product.product_id.default_code
-            ) in self.pricelist_item_product_product.display_name
+            ) in self.pricelist_item_product_product.name
+        )
+
+    def test_display_name_rewritten_in_product_template(self):
+        """Test the display_name is rewritten in template
+        """
+        product_template_name = self.product_template.display_name.replace(
+            "[{}]".format(self.product_template.default_code),
+            ""
+        )
+        self.pricelist_item_product_template.name = product_template_name
+        self.assertFalse(
+            "[{}]".format(
+                self.pricelist_item_product_template.product_tmpl_id.default_code
+            ) in self.pricelist_item_product_template.name
+        )
+        self.pricelist_item_product_template._get_pricelist_item_name_price()
+        self.assertTrue(
+            "[{}]".format(
+                self.pricelist_item_product_template.product_tmpl_id.default_code
+            ) in self.pricelist_item_product_template.name
         )


### PR DESCRIPTION
In the preovious version, the product code was only added for product
variants.
It is now added to product templates as well.

@Tecnativa 
TT26296