### PR TITLE
product_barcode_required: fix required on template form

### DIFF
--- a/product_barcode_required/models/product_barcode_mixin.py
+++ b/product_barcode_required/models/product_barcode_mixin.py
@@ -20,9 +20,10 @@ class BarcodeRequiredMixin(models.AbstractModel):
     @api.depends("type", "barcode")
     def _compute_is_barcode_required(self):
         for rec in self:
-            rec.is_barcode_required = (
-                rec._is_barcode_required_enabled() and rec._is_barcode_missing()
-            )
+            rec.is_barcode_required = rec._is_barcode_required()
+
+    def _is_barcode_required(self):
+        return self._is_barcode_required_enabled() and self._is_barcode_missing()
 
     def _is_barcode_missing(self):
         self.ensure_one()
@@ -32,7 +33,7 @@ class BarcodeRequiredMixin(models.AbstractModel):
         return self.env.company.product_variant_barcode_required
 
     def _check_barcode_required(self):
-        """Check if barcode required, to be used in your own contraint."""
+        """Check if barcode required, to be used in your own constraint."""
         if self.env.context.get("_bypass_barcode_required_check"):
             return
         # Make error nicer up to 30 records.

--- a/product_barcode_required/models/product_template.py
+++ b/product_barcode_required/models/product_template.py
@@ -13,3 +13,8 @@ class ProductTemplate(models.Model):
         return super(
             ProductTemplate, self.with_context(_bypass_barcode_required_check=True)
         )._create_variant_ids()
+
+    def _is_barcode_required(self):
+        if self.product_variant_count > 1:
+            return False
+        return super()._is_barcode_required()

--- a/product_barcode_required/tests/test_barcode.py
+++ b/product_barcode_required/tests/test_barcode.py
@@ -59,6 +59,21 @@ class TestBarcodeTemplateRequired(TestBarcodeBase):
         record = form.save()
         self.assertEqual(record.barcode, "PROD-A")
 
+    def test_required_template(self):
+        """Requirement enabled, template needs it only if 1 variant is there."""
+        tmpl = self.env["product.template"].create({"name": "Foo"})
+        self.assertTrue(tmpl.is_barcode_required)
+        # Add a variantc
+        self.env["product.product"].create(
+            {
+                "name": "another test variant",
+                "barcode": "baz",
+                "default_code": "yeah",
+                "product_tmpl_id": tmpl.id,
+            }
+        )
+        self.assertFalse(tmpl.is_barcode_required)
+
     def test_onchange_required_variant(self):
         """Requirement enabled, default barcode to default_code."""
         form = Form(self.env["product.product"])


### PR DESCRIPTION
Barcode on product template should not be required
if you have more than 1 variant.

When more than 1 variant is generated the field is hidden
and you cannot populate it anyway.

This, for instance, prevents duplicating products with more than one variant.