### PR TITLE
[12.0][IMP] product_sequence: Use parent categories to determine the prefix …

### DIFF
--- a/product_sequence/__manifest__.py
+++ b/product_sequence/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Product Sequence',
-    'version': '12.0.1.0.1',
+    'version': '12.0.2.0.1',
     'author': "Zikzakmedia SL,Sodexis,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/product-attribute',
     'license': 'AGPL-3',
@@ -18,6 +18,7 @@
     'data': [
         'data/product_sequence.xml',
         'views/product_category.xml',
+        'views/res_config_settings_views.xml',
     ],
     'pre_init_hook': 'pre_init_hook',
     'installable': True,

--- a/product_sequence/models/__init__.py
+++ b/product_sequence/models/__init__.py
@@ -1,2 +1,5 @@
+from . import res_company
+from . import res_config_settings
+from . import ir_sequence
 from . import product_product
 from . import product_category

--- a/product_sequence/models/ir_sequence.py
+++ b/product_sequence/models/ir_sequence.py
@@ -1,0 +1,16 @@
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IrSequence(models.Model):
+    _inherit = 'ir.sequence'
+
+    @api.model
+    def get_category_sequence_id(self, category=False):
+        if self.env.user.company_id.use_parent_categories_to_determine_prefix:
+            while not category.sequence_id and category.parent_id:
+                category = category.parent_id
+        return category.sequence_id or self.env.ref('product_sequence.seq_product_auto')

--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -23,18 +23,15 @@ class ProductProduct(models.Model):
         if 'default_code' not in vals or vals['default_code'] == '/':
             categ_id = vals.get("categ_id")
             template_id = vals.get("product_tmpl_id")
-            categ = sequence = False
+            category = self.env['product.category']
             if categ_id:
                 # Created as a product.product
-                categ = self.env['product.category'].browse(categ_id)
+                category = category.browse(categ_id)
             elif template_id:
                 # Created from a product.template
                 template = self.env["product.template"].browse(template_id)
-                categ = template.categ_id
-            if categ:
-                sequence = categ.sequence_id
-            if not sequence:
-                sequence = self.env.ref('product_sequence.seq_product_auto')
+                category = template.categ_id
+            sequence = self.env["ir.sequence"].get_category_sequence_id(category)
             vals['default_code'] = sequence.next_by_id()
         return super().create(vals)
 
@@ -49,10 +46,7 @@ class ProductProduct(models.Model):
             for product in self:
                 category_id = vals.get('categ_id', product.categ_id.id)
                 category = product_category_obj.browse(category_id)
-                sequence = category.exists() and category.sequence_id
-                if not sequence:
-                    sequence = self.env.ref(
-                        'product_sequence.seq_product_auto')
+                sequence = self.env["ir.sequence"].get_category_sequence_id(category)
                 ref = sequence.next_by_id()
                 vals['default_code'] = ref
                 if len(product.product_tmpl_id.product_variant_ids) == 1:

--- a/product_sequence/models/res_company.py
+++ b/product_sequence/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2004 Tiny SPRL
+# Copyright 2016 Sodexis
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Company(models.Model):
+    _inherit = 'res.company'
+
+    use_parent_categories_to_determine_prefix = fields.Boolean(
+        string="Use parent categories to determine the prefix",
+        help="Use parent categories to determine the prefix "
+             "if the category has no settings for the prefix.",
+    )

--- a/product_sequence/models/res_config_settings.py
+++ b/product_sequence/models/res_config_settings.py
@@ -1,0 +1,16 @@
+# Copyright 2004 Tiny SPRL
+# Copyright 2016 Sodexis
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    use_parent_categories_to_determine_prefix = fields.Boolean(
+        related="company_id.use_parent_categories_to_determine_prefix",
+        readonly=False,
+    )

--- a/product_sequence/readme/USAGE.rst
+++ b/product_sequence/readme/USAGE.rst
@@ -5,6 +5,9 @@ To specify a different sequence for a product category proceed as follows:
    the form view, *Inventory > Configuration > Products > Products Categories*;
    or create a menuitem manually).
 #. Fill the *Prefix for Product Internal Reference* as desired.
+#. Under the settings (Settings -> General Settings -> Products), you can specify
+   whether the prefix of the parent category should be used if no prefix has been
+   specified for the category.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -47,9 +47,8 @@ class TestProductSequence(TransactionCase):
             name="Apple",
             default_code='PROD03'
         ))
-        self.cr.execute(
-            "update product_product set default_code='/' where id=%s"
-            % (product_3.id,))
+        sql = "update product_product set default_code='/' where id=%s"
+        self.cr.execute(sql, (product_3.id,))
         product_3.invalidate_cache()
         self.assertEqual(product_3.default_code, '/')
         pre_init_hook(self.cr)

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -103,6 +103,32 @@ class TestProductSequence(TransactionCase):
         categ_car.write({'code_prefix': 'KIA'})
         self.assertEqual(categ_car.sequence_id.prefix, "KIA")
 
+    def test_product_parent_category_sequence(self):
+        parent_categ = self.product_category.create(dict(
+            name="Parents",
+            code_prefix="PAR",
+        ))
+        categ = self.product_category.create(dict(
+            name="Child",
+            parent_id=parent_categ.id,
+        ))
+
+        product_anna = self.product_product.create(dict(
+            name="Anna",
+            categ_id=categ.id,
+        ))
+        self.assertEqual(product_anna.default_code[:2], "PR")
+        self.assertEqual(product_anna.product_tmpl_id.default_code[:2], "PR")
+
+        self.env.user.company_id.use_parent_categories_to_determine_prefix = True
+
+        product_claudia = self.product_product.create(dict(
+            name="Claudia",
+            categ_id=categ.id,
+        ))
+        self.assertEqual(product_claudia.default_code[:3], "PAR")
+        self.assertEqual(product_claudia.product_tmpl_id.default_code[:3], "PAR")
+
     def test_product_copy_with_default_values(self):
         product_2 = self.product_product.create(dict(
             name="Apple",

--- a/product_sequence/views/res_config_settings_views.xml
+++ b/product_sequence/views/res_config_settings_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.product</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="product.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div id="product_general_settings" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="use_parent_categories_to_determine_prefix" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="use_parent_categories_to_determine_prefix"
+                               string="Use parent categories to determine the prefix" />
+                        <div class="text-muted">
+                            Use parent categories to determine the prefix if the category
+                            has no settings for the prefix.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
… if the category has no settings for the prefix.

We have implemented a small improvement for determining the prefix.

Currently only the prefix from the selected category or a standard prefix is used.
With this change you can set in the settings whether the prefix of a parent category should be used if no prefix is defined for the selected category.