### PR TITLE
[REF] product_order_noname: Change product.template order

### DIFF
--- a/product_order_noname/models/__init__.py
+++ b/product_order_noname/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product
+from . import product_template

--- a/product_order_noname/models/product_template.py
+++ b/product_order_noname/models/product_template.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+    _order = 'default_code, id'
+
+    default_code = fields.Char(index=True)


### PR DESCRIPTION
product.template has `_order='name'`
even if the `name` field has an `index=True`
This index is not used because of this field has a
`translate=True` parameter

So, it is in the same situation like product.product

So, it is changed using `_order='default_code, id'` instead.
For a faster sort it requires an index so the field `default_code`
is redefined to `index=True`