### PR TITLE
[FIX] product_state: Compare recordsets

### DIFF
--- a/product_state/__init__.py
+++ b/product_state/__init__.py
@@ -2,3 +2,4 @@
 
 from . import models
 from .hooks import post_init_hook
+from . import tests

--- a/product_state/models/product_template.py
+++ b/product_state/models/product_template.py
@@ -74,6 +74,6 @@ class ProductTemplate(models.Model):
                         "code": product_tmpl.state,
                     })
                 state_mapping[product_tmpl.state] = product_state
-            if product_tmpl.product_state_id != product_state.id:
+            if product_tmpl.product_state_id != product_state:
                 product_tmpl.product_state_id = product_state.id
         self.filtered(lambda x: not x.state).write({'product_state_id': False})

--- a/product_state/tests/__init__.py
+++ b/product_state/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2020 Hunki Enterprises BV (<https://hunki-enterprises.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import test_product_state

--- a/product_state/tests/test_product_state.py
+++ b/product_state/tests/test_product_state.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Hunki Enterprises BV (<https://hunki-enterprises.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import TransactionCase
+
+
+class TestProductState(TransactionCase):
+    def test_product_state(self):
+        product = self.env['product.product'].search([], limit=1)
+        product.state = 'end'
+        self.assertEqual(
+            product.product_state_id,
+            self.env.ref('product_state.product_state_end'),
+        )
+        product.product_state_id = False
+        self.assertFalse(product.state)


### PR DESCRIPTION
this avoids log warnings like

```
Comparing apples and oranges: product.state() == 42
```