### PR TITLE
[13.0] Fix barcode required error on variants creation

### DIFF
--- a/product_barcode_required/models/product_template.py
+++ b/product_barcode_required/models/product_template.py
@@ -2,17 +2,23 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl)
 
-from odoo import models
+from odoo import api, models
 
 
 class ProductTemplate(models.Model):
     _name = "product.template"
     _inherit = ["product.template", "product.barcode.required.mixin"]
 
-    def _create_variant_ids(self):
+    @api.model_create_multi
+    def create(self, vals_list):
         return super(
             ProductTemplate, self.with_context(_bypass_barcode_required_check=True)
-        )._create_variant_ids()
+        ).create(vals_list)
+
+    def write(self, vals):
+        return super(
+            ProductTemplate, self.with_context(_bypass_barcode_required_check=True)
+        ).write(vals)
 
     def _is_barcode_required(self):
         if self.product_variant_count > 1:


### PR DESCRIPTION
When we create a product template and select variant attributes, it
creates variants under the hood. The context key in
`_create_variant_ids` allows to bypass the check on the barcode, which
would be blocking.

If we have a related or computed field triggered by a create/write on a
product.template (`@api.depends('product_tmpl_id.foo')`), the check is
triggered and blocks the creation/write on the template.

We have then to ignore the check on variants on any create/write on
templates.