### PR TITLE
[FIX] product_secondary_unit: Avoid to recompute secondary_uom_qty when secondary uom changes

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -75,7 +75,15 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
         """Set the target qty field defined in model"""
         for rec in self:
             if not rec.secondary_uom_id:
+                rec[rec._secondary_unit_fields["qty_field"]] = rec._origin[
+                    rec._secondary_unit_fields["qty_field"]
+                ]
                 continue
+            # To avoid recompute secondary_uom_qty field when
+            # secondary_uom_id changes.
+            rec.env.remove_to_compute(
+                field=rec._fields["secondary_uom_qty"], records=rec
+            )
             factor = rec._get_factor_line()
             qty = float_round(
                 rec.secondary_uom_qty * factor,

--- a/product_secondary_unit/tests/test_secondary_unit_mixin.py
+++ b/product_secondary_unit/tests/test_secondary_unit_mixin.py
@@ -100,3 +100,15 @@ class TestProductSecondaryUnitMixin(SavepointCase, FakeModelLoader):
         fake_model = self.secondary_unit_fake
         fake_model._onchange_helper_product_uom_for_secondary()
         self.assertEqual(fake_model.secondary_uom_qty, 0)
+
+    def test_chained_compute_field(self):
+        """Secondary_uom_qty has not been computed when secondary_uom_id changes
+        """
+        fake_model = self.secondary_unit_fake
+        fake_model.secondary_uom_qty = 2.0
+        fake_model.secondary_uom_id = self.secondary_unit_box_5
+        self.assertEqual(fake_model.product_uom_qty, 10.0)
+        self.assertEqual(fake_model.secondary_uom_qty, 2.0)
+        fake_model.secondary_uom_id = self.secondary_unit_box_10
+        self.assertEqual(fake_model.product_uom_qty, 20.0)
+        self.assertEqual(fake_model.secondary_uom_qty, 2.0)


### PR DESCRIPTION
cc @Tecnativa
ping @carlosdauden @pedrobaeza 