### PR TITLE
[12.0][FIX] product_dimension : compatibility with product_logistics_uom's volume_uom_id

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -10,7 +10,7 @@
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/product-attribute',
-    'depends': ['product'],
+    'depends': ['product', 'product_logistics_uom'],
     'data': ['views/product_view.xml'],
     'installable': True,
     'images': [

--- a/product_dimension/models/product.py
+++ b/product_dimension/models/product.py
@@ -6,76 +6,82 @@ from odoo import models, fields, api
 
 
 class Product(models.Model):
-    _inherit = 'product.product'
+    _inherit = "product.product"
 
-    @api.onchange(
-        'product_length', 'product_height', 'product_width', 'dimensional_uom_id')
-    def onchange_calculate_volume(self):
-        self.volume = self.env['product.template']._calc_volume(
-            self.product_length, self.product_height,
-            self.product_width, self.dimensional_uom_id)
+    product_length = fields.Float("length")
+    product_height = fields.Float("height")
+    product_width = fields.Float("width")
+    dimensional_uom_id = fields.Many2one(
+        "uom.uom",
+        "Dimensional UoM",
+        domain=lambda self: self._get_dimension_uom_domain(),
+        help="UoM for length, height, width",
+        default=lambda self: self.env.ref("uom.product_uom_meter"),
+    )
 
     @api.model
     def _get_dimension_uom_domain(self):
-        return [
-            ('category_id', '=', self.env.ref('uom.uom_categ_length').id)
-        ]
+        return [("category_id", "=", self.env.ref("uom.uom_categ_length").id)]
 
-    product_length = fields.Float('length')
-    product_height = fields.Float('height')
-    product_width = fields.Float('width')
-    dimensional_uom_id = fields.Many2one(
-        'uom.uom',
-        'Dimensional UoM',
-        domain=lambda self: self._get_dimension_uom_domain(),
-        help='UoM for length, height, width',
-        default=lambda self: self.env.ref('uom.product_uom_meter'),
+    @api.onchange(
+        "product_length", "product_height", "product_width", "dimensional_uom_id"
+    )
+    def onchange_calculate_volume(self):
+        self.volume = self.env["product.template"]._calc_volume(
+            self.product_length,
+            self.product_height,
+            self.product_width,
+            self.dimensional_uom_id,
         )
 
 
 class ProductTemplate(models.Model):
-    _inherit = 'product.template'
+    _inherit = "product.template"
+
+    def _convert_to_meters(self, measure, dimensional_uom):
+        uom_meters = self.env.ref("uom.product_uom_meter")
+
+        return dimensional_uom._compute_quantity(
+            qty=measure, to_unit=uom_meters, round=False,
+        )
 
     @api.model
     def _calc_volume(self, product_length, product_height, product_width, uom_id):
         volume = 0
         if product_length and product_height and product_width and uom_id:
-            length_m = self.convert_to_meters(product_length, uom_id)
-            height_m = self.convert_to_meters(product_height, uom_id)
-            width_m = self.convert_to_meters(product_width, uom_id)
+            length_m = self._convert_to_meters(product_length, uom_id)
+            height_m = self._convert_to_meters(product_height, uom_id)
+            width_m = self._convert_to_meters(product_width, uom_id)
             volume = length_m * height_m * width_m
 
         return volume
 
-    @api.onchange(
-        'product_length', 'product_height', 'product_width', 'dimensional_uom_id')
-    def onchange_calculate_volume(self):
-        self.volume = self._calc_volume(
-            self.product_length, self.product_height, self.product_width,
-            self.dimensional_uom_id)
-
-    def convert_to_meters(self, measure, dimensional_uom):
-        uom_meters = self.env.ref('uom.product_uom_meter')
-
-        return dimensional_uom._compute_quantity(
-            qty=measure,
-            to_unit=uom_meters,
-            round=False,
-        )
-
     # Define all the related fields in product.template with 'readonly=False'
     # to be able to modify the values from product.template.
     dimensional_uom_id = fields.Many2one(
-        'uom.uom',
-        'Dimensional UoM',
-        related='product_variant_ids.dimensional_uom_id',
-        help='UoM for length, height, width',
+        "uom.uom",
+        "Dimensional UoM",
+        related="product_variant_ids.dimensional_uom_id",
+        help="UoM for length, height, width",
         readonly=False,
     )
-
     product_length = fields.Float(
-        related='product_variant_ids.product_length', readonly=False)
+        related="product_variant_ids.product_length", readonly=False
+    )
     product_height = fields.Float(
-        related='product_variant_ids.product_height', readonly=False)
+        related="product_variant_ids.product_height", readonly=False
+    )
     product_width = fields.Float(
-        related='product_variant_ids.product_width', readonly=False)
+        related="product_variant_ids.product_width", readonly=False
+    )
+
+    @api.onchange(
+        "product_length", "product_height", "product_width", "dimensional_uom_id"
+    )
+    def onchange_calculate_volume(self):
+        self.volume = self._calc_volume(
+            self.product_length,
+            self.product_height,
+            self.product_width,
+            self.dimensional_uom_id,
+        )

--- a/product_dimension/models/product.py
+++ b/product_dimension/models/product.py
@@ -54,15 +54,17 @@ class ProductTemplate(models.Model):
     def _calc_volume(
         self, product_length, product_height, product_width, uom_id, volume_uom_id
     ):
+        # TODO: in v14 use native UoM data for m3 "uom.product_uom_cubic_meter"
         uom_litre = self.env.ref("uom.product_uom_litre")
-        volume_litre = 0
+        volume_m3 = 0
 
         if product_length and product_height and product_width and uom_id:
             length_m = self._convert_to_meters(product_length, uom_id)
             height_m = self._convert_to_meters(product_height, uom_id)
             width_m = self._convert_to_meters(product_width, uom_id)
-            volume_litre = (length_m * height_m * width_m) * 1000
+            volume_m3 = length_m * height_m * width_m
 
+        volume_litre = volume_m3 * 1000
         return uom_litre._compute_quantity(
             qty=volume_litre, to_unit=volume_uom_id, round=False,
         )

--- a/product_dimension/tests/test_compute_volume.py
+++ b/product_dimension/tests/test_compute_volume.py
@@ -10,9 +10,10 @@ class TestComputeVolumeOnProduct(TransactionCase):
         self.product.product_height = 200.
         self.product.product_width = 100.
         self.product.dimensional_uom_id = self.uom_cm
+        self.product.volume_uom_id = self.uom_litre
         self.product.onchange_calculate_volume()
         self.assertAlmostEqual(
-            0.2,
+            200,
             self.product.volume
         )
 
@@ -21,9 +22,10 @@ class TestComputeVolumeOnProduct(TransactionCase):
         self.product.product_height = 2.
         self.product.product_width = 10.
         self.product.dimensional_uom_id = self.uom_m
+        self.product.volume_uom_id = self.uom_litre
         self.product.onchange_calculate_volume()
         self.assertAlmostEqual(
-            120,
+            120000,
             self.product.volume
         )
 
@@ -33,6 +35,7 @@ class TestComputeVolumeOnProduct(TransactionCase):
         self.product = self.env['product.product'].new()
         self.uom_m = self.env['uom.uom'].search([('name', '=', 'm')])
         self.uom_cm = self.env['uom.uom'].search([('name', '=', 'cm')])
+        self.uom_litre = self.env.ref("uom.product_uom_litre")
 
 
 class TestComputeVolumeOnTemplate(TransactionCase):
@@ -42,9 +45,10 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.template.product_height = 200.
         self.template.product_width = 100.
         self.template.dimensional_uom_id = self.uom_cm
+        self.template.volume_uom_id = self.uom_litre
         self.template.onchange_calculate_volume()
         self.assertAlmostEqual(
-            0.2,
+            200,
             self.template.volume
         )
 
@@ -53,9 +57,10 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.template.product_height = 2.
         self.template.product_width = 10.
         self.template.dimensional_uom_id = self.uom_m
+        self.template.volume_uom_id = self.uom_litre
         self.template.onchange_calculate_volume()
         self.assertAlmostEqual(
-            120,
+            120000,
             self.template.volume
         )
 
@@ -65,3 +70,4 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.template = self.env['product.template'].new()
         self.uom_m = self.env['uom.uom'].search([('name', '=', 'm')])
         self.uom_cm = self.env['uom.uom'].search([('name', '=', 'cm')])
+        self.uom_litre = self.env.ref("uom.product_uom_litre")

--- a/product_dimension/views/product_view.xml
+++ b/product_dimension/views/product_view.xml
@@ -7,7 +7,7 @@
       <field name="inherit_id" ref="product.product_normal_form_view"/>
       <field name="arch" type="xml">
         <xpath expr="//group[@name='inventory']" position="inside">
-          <group name="dimensions" string="Dimensions" colspan="2">
+          <group name="dimensions" string="Dimensions">
             <field name="dimensional_uom_id"/>
             <field name="product_length" string="Length"/>
             <field name="product_height" string="Height"/>
@@ -23,7 +23,7 @@
       <field name="inherit_id" ref="product.product_template_only_form_view"/>
       <field name="arch" type="xml">
         <xpath expr="//group[@name='inventory']" position="inside">
-          <group string="Dimensions" name="dimensions" colspan="2"
+          <group string="Dimensions" name="dimensions"
                 attrs="{'invisible': [('product_variant_count', '&gt;', 1)]}">
             <field name="dimensional_uom_id"/>
             <field name="product_length" string="Length"/>


### PR DESCRIPTION
Both modules **[product_dimension](https://github.com/OCA/product-attribute/tree/12.0/product_dimension)** and **[product_logistics_uom](https://github.com/OCA/product-attribute/tree/12.0/product_logistics_uom)** are merged in 12.0 but could not be used together.

**product_logistics_uom** introduce a field `volume_uom_id` allowing to register product's volume in any choosen Unit of Measure, but **product_dimension** always calculated the product's volume in cubic metre.

This PR makes **product_dimension** taking `volume_uom_id` into account when calculating the product's volume.

Cf the debate on https://github.com/OCA/product-attribute/pull/607#discussion_r416687807
Cc @hparfr @legalsylvain @bealdav @rvalyi 