### PR TITLE
[12.0][FIX] product_pricelist_supplierinfo: Convert price to UOM on the Sale

### DIFF
--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -37,6 +37,12 @@ class ProductTemplate(models.Model):
             # Verbatim copy of part of product.pricelist._compute_price_rule.
             qty_uom_id = self._context.get('uom') or self.uom_id.id
             price_uom = self.env['uom.uom'].browse([qty_uom_id])
+
+            # We need to convert the price to the uom used on the sale, if the
+            # uom on the seller is a different one that the one used there.
+            if seller and seller.product_uom != price_uom:
+                price = seller.product_uom._compute_price(price, price_uom)
+
             convert_to_price_uom = (
                 lambda price: self.uom_id._compute_price(
                     price, price_uom))


### PR DESCRIPTION
If we have a product with a supplier with a UOM "A" but the product is sold with a UOM "B" the price we are getting is the same no matter the UOM. For example:
Product with the price 1200 per Dozen and we sell a 1 unit we are getting the price of 1200 for that unit when we should be obtaining 100.

With these changes, we are converting the price to the UOM that is being used on the sale or the default on the product.
Also, a test was added to prove the previous behaviour.