### PR TITLE
[IMP][12.0] add group to create/edit supplierinfo

### DIFF
--- a/product_supplierinfo_for_customer/security/ir.model.access.csv
+++ b/product_supplierinfo_for_customer/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_product_customerinfo_user,product.customerinfo.user,model_product_customerinfo,base.group_user,1,0,0,0
+access_product_customerinfo_sale_manager,product.customerinfo.sale_manager,model_product_customerinfo,sales_team.group_sale_manager,1,1,1,0
 access_product_customerinfo_manager,product.customerinfo.manager,model_product_customerinfo,base.group_system,1,1,1,1


### PR DESCRIPTION
Fix #761 
I used an existing group from sale module as installing supplierinfo for customer without sale module installed seems a little weird.