### PR TITLE
[13.0][IMP] product_medical: Change in layout, add multiple docs

### DIFF
--- a/product_medical/__manifest__.py
+++ b/product_medical/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Product Medical",
     "summary": "Base  structure to handle medical products",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "license": "AGPL-3",

--- a/product_medical/i18n/de.po
+++ b/product_medical/i18n/de.po
@@ -18,15 +18,10 @@ msgstr ""
 "X-Generator: Weblate 3.10\n"
 
 #. module: product_medical
-#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+#: model:ir.model.fields,field_description:product_medical.field_product_product__ce_certificate_medical_class_ids
+#: model:ir.model.fields,field_description:product_medical.field_product_template__ce_certificate_medical_class_ids
 msgid "CE Certificate"
 msgstr "CE Zertifikat"
-
-#. module: product_medical
-#: model:ir.model.fields,field_description:product_medical.field_product_product__ce_certificate_medical_class
-#: model:ir.model.fields,field_description:product_medical.field_product_template__ce_certificate_medical_class
-msgid "CE Certificate Medical class"
-msgstr "CE Zertifikate Medizinprodukte"
 
 #. module: product_medical
 #: model:ir.model.fields,field_description:product_medical.field_product_product__medical_certificate_url
@@ -70,10 +65,20 @@ msgid "CE Class Is"
 msgstr "CE Klasse Is"
 
 #. module: product_medical
+#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+msgid "Categories"
+msgstr "Kategorien"
+
+#. module: product_medical
 #: model:ir.model.fields,field_description:product_medical.field_product_product__ce_certificate_validity_date
 #: model:ir.model.fields,field_description:product_medical.field_product_template__ce_certificate_validity_date
 msgid "Certificate Validity Date"
 msgstr "Zertifikat Gültigkeitsdatum"
+
+#. module: product_medical
+#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+msgid "Conformity"
+msgstr "Konformität"
 
 #. module: product_medical
 #: model:ir.model.fields,field_description:product_medical.field_in_vitro_diagnostic__create_uid
@@ -92,9 +97,8 @@ msgid "Created on"
 msgstr "Erstellt am"
 
 #. module: product_medical
-#: model:ir.model.fields,field_description:product_medical.field_product_product__conformity_declaration
-#: model:ir.model.fields,field_description:product_medical.field_product_template__conformity_declaration
-#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+#: model:ir.model.fields,field_description:product_medical.field_product_product__conformity_declaration_ids
+#: model:ir.model.fields,field_description:product_medical.field_product_template__conformity_declaration_ids
 msgid "Declaration of Conformity"
 msgstr "Konformitätserklärung"
 
@@ -110,6 +114,11 @@ msgstr "Diagnosetyp besteht bereits"
 #: model:ir.model.fields,field_description:product_medical.field_ppe_category__display_name
 msgid "Display Name"
 msgstr "Anzeigename"
+
+#. module: product_medical
+#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+msgid "Documents"
+msgstr "Dokumente"
 
 #. module: product_medical
 #: model:medicine.category,name:product_medical.category_d
@@ -193,9 +202,10 @@ msgid "Lot Related"
 msgstr "Chargennummer relevant"
 
 #. module: product_medical
-#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
-msgid "MDR"
-msgstr "MDR"
+#: model:ir.model.fields,field_description:product_medical.field_product_product__medicine_category_id
+#: model:ir.model.fields,field_description:product_medical.field_product_template__medicine_category_id
+msgid "Medical Category"
+msgstr ""
 
 #. module: product_medical
 #: model:ir.model,name:product_medical.model_medical_class
@@ -237,6 +247,12 @@ msgstr "Name"
 #: model:ir.model.fields,field_description:product_medical.field_product_template__notified_body_id
 msgid "Notified Body"
 msgstr "Organisme notifié"
+
+#. module: product_medical
+#: model:ir.model.fields,field_description:product_medical.field_product_product__ppe_category_id
+#: model:ir.model.fields,field_description:product_medical.field_product_template__ppe_category_id
+msgid "PPE Category"
+msgstr "PPE Kategorie"
 
 #. module: product_medical
 #: model:ir.model,name:product_medical.model_ppe_category

--- a/product_medical/i18n/product_medical.pot
+++ b/product_medical/i18n/product_medical.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-04 14:03+0000\n"
+"PO-Revision-Date: 2021-02-04 14:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,14 +16,9 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_medical
-#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+#: model:ir.model.fields,field_description:product_medical.field_product_product__ce_certificate_medical_class_ids
+#: model:ir.model.fields,field_description:product_medical.field_product_template__ce_certificate_medical_class_ids
 msgid "CE Certificate"
-msgstr ""
-
-#. module: product_medical
-#: model:ir.model.fields,field_description:product_medical.field_product_product__ce_certificate_medical_class
-#: model:ir.model.fields,field_description:product_medical.field_product_template__ce_certificate_medical_class
-msgid "CE Certificate Medical class"
 msgstr ""
 
 #. module: product_medical
@@ -66,9 +63,19 @@ msgid "CE Class Is"
 msgstr ""
 
 #. module: product_medical
+#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+msgid "Categories"
+msgstr ""
+
+#. module: product_medical
 #: model:ir.model.fields,field_description:product_medical.field_product_product__ce_certificate_validity_date
 #: model:ir.model.fields,field_description:product_medical.field_product_template__ce_certificate_validity_date
 msgid "Certificate Validity Date"
+msgstr ""
+
+#. module: product_medical
+#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+msgid "Conformity"
 msgstr ""
 
 #. module: product_medical
@@ -88,9 +95,8 @@ msgid "Created on"
 msgstr ""
 
 #. module: product_medical
-#: model:ir.model.fields,field_description:product_medical.field_product_product__conformity_declaration
-#: model:ir.model.fields,field_description:product_medical.field_product_template__conformity_declaration
-#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+#: model:ir.model.fields,field_description:product_medical.field_product_product__conformity_declaration_ids
+#: model:ir.model.fields,field_description:product_medical.field_product_template__conformity_declaration_ids
 msgid "Declaration of Conformity"
 msgstr ""
 
@@ -105,6 +111,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:product_medical.field_medicine_category__display_name
 #: model:ir.model.fields,field_description:product_medical.field_ppe_category__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: product_medical
+#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
+msgid "Documents"
 msgstr ""
 
 #. module: product_medical
@@ -189,8 +200,9 @@ msgid "Lot Related"
 msgstr ""
 
 #. module: product_medical
-#: model_terms:ir.ui.view,arch_db:product_medical.product_template_only_form_view
-msgid "MDR"
+#: model:ir.model.fields,field_description:product_medical.field_product_product__medicine_category_id
+#: model:ir.model.fields,field_description:product_medical.field_product_template__medicine_category_id
+msgid "Medical Category"
 msgstr ""
 
 #. module: product_medical
@@ -232,6 +244,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:product_medical.field_product_product__notified_body_id
 #: model:ir.model.fields,field_description:product_medical.field_product_template__notified_body_id
 msgid "Notified Body"
+msgstr ""
+
+#. module: product_medical
+#: model:ir.model.fields,field_description:product_medical.field_product_product__ppe_category_id
+#: model:ir.model.fields,field_description:product_medical.field_product_template__ppe_category_id
+msgid "PPE Category"
 msgstr ""
 
 #. module: product_medical

--- a/product_medical/migrations/13.0.1.1.0/post-migration.py
+++ b/product_medical/migrations/13.0.1.1.0/post-migration.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    ir_attachment = env["ir.attachment"]
+
+    # Attachments are not removed from the database when the field on the
+    # anchor model is removed, but we still need to adapt the contents
+    # in ir_attachment so that the widget 'many2many_binary' knows how to
+    # find the attachments from the UI.
+    for old_field_name, new_table_rel_name in [
+        ("conformity_declaration", "product_conformity_declaration_rel"),
+        ("ce_certificate_medical_class", "product_ce_certificate_medical_class_rel"),
+    ]:
+        for attachment in ir_attachment.search(
+            [
+                ("res_model", "=", "product.template"),
+                ("res_field", "=", old_field_name),
+            ]
+        ):
+            env.cr.execute(
+                """
+                INSERT INTO {}(product_template_id, attachment_id)
+                VALUES(%s, %s);
+                """.format(
+                    new_table_rel_name
+                ),
+                (attachment.res_id, attachment.id),
+            )
+            env.cr.execute(
+                """
+                UPDATE ir_attachment
+                SET res_field = NULL,
+                    res_id = 0
+                WHERE id = %s;
+                """,
+                (attachment.id,),
+            )

--- a/product_medical/models/product_template.py
+++ b/product_medical/models/product_template.py
@@ -10,10 +10,8 @@ class ProductTemplate(models.Model):
     is_medical = fields.Boolean(string="Is Medical", default=False)
 
     medical_certificate_url = fields.Char(string="CE Certificate medical devices")
-    medical_class_id = fields.Many2one("medical.class", string="Medical Class")
-    medicine_category_id = fields.Many2one(
-        "medicine.category", string="Medical Category"
-    )
+    medical_class_id = fields.Many2one("medical.class", string="Medical Device Class")
+    medicine_category_id = fields.Many2one("medicine.category", string="Drug Category")
     ppe_category_id = fields.Many2one("ppe.category", string="PPE Category")
 
     in_vitro_diagnostic = fields.Many2one(

--- a/product_medical/models/product_template.py
+++ b/product_medical/models/product_template.py
@@ -11,17 +11,29 @@ class ProductTemplate(models.Model):
 
     medical_certificate_url = fields.Char(string="CE Certificate medical devices")
     medical_class_id = fields.Many2one("medical.class", string="Medical Class")
+    medicine_category_id = fields.Many2one(
+        "medicine.category", string="Medical Category"
+    )
+    ppe_category_id = fields.Many2one("ppe.category", string="PPE Category")
 
     in_vitro_diagnostic = fields.Many2one(
         "in.vitro.diagnostic", string="In vitro diagnostics"
     )
-    conformity_declaration = fields.Binary(
-        string="Declaration of Conformity", attachment=True
+    conformity_declaration_ids = fields.Many2many(
+        "ir.attachment",
+        relation="product_conformity_declaration_rel",
+        column1="product_template_id",
+        column2="attachment_id",
+        string="Declaration of Conformity",
     )
     doc_lot_related = fields.Boolean(string="Lot Related", default=False)
     doc_validity_date = fields.Date(string="Validity Date")
-    ce_certificate_medical_class = fields.Binary(
-        string="CE Certificate Medical class", attachment=True
+    ce_certificate_medical_class_ids = fields.Many2many(
+        "ir.attachment",
+        relation="product_ce_certificate_medical_class_rel",
+        column1="product_template_id",
+        column2="attachment_id",
+        string="CE Certificate",
     )
     ce_certificate_validity_date = fields.Date(string="Certificate Validity Date")
     notified_body_id = fields.Many2one(

--- a/product_medical/views/product_template.xml
+++ b/product_medical/views/product_template.xml
@@ -13,26 +13,28 @@
             >
                 <field name="is_medical" />
             </xpath>
-            <xpath
-                expr="//form/sheet/notebook"
-                position="inside"
-                attrs="{'readonly':[('is_medical','=',0)]}"
-            >
-                <page name="mdr" string="MDR">
-                    <group name="mdr">
-                        <group name="mdr_left" string="Declaration of Conformity">
-                            <field name="conformity_declaration" />
-                            <field name="doc_lot_related" />
-                            <field name="doc_validity_date" />
+            <xpath expr="//form/sheet/notebook" position="inside">
+                <page name="conformity" string="Conformity">
+                    <group name="conformity">
+                        <group name="conformity_left" string="Categories">
+                            <field name="medical_class_id" />
+                            <field name="medicine_category_id" />
+                            <field name="ppe_category_id" />
+                            <field name="in_vitro_diagnostic" />
+                            <field name="notified_body_id" />
                         </group>
-                        <group name="mdr_right" string="CE Certificate">
+                        <group name="conformity_right" string="Documents">
                             <field
-                                name="ce_certificate_medical_class"
-                                string="Medical class"
+                                name="conformity_declaration_ids"
+                                widget="many2many_binary"
+                            />
+                            <field name="doc_validity_date" />
+                            <field
+                                name="ce_certificate_medical_class_ids"
+                                widget="many2many_binary"
                             />
                             <field name="ce_certificate_validity_date" />
-                            <field name="notified_body_id" />
-                            <field name="medical_class_id" />
+                            <field name="doc_lot_related" />
                             <field name="medical_certificate_url" widget="url" />
                         </group>
                     </group>


### PR DESCRIPTION
This builds on https://github.com/OCA/product-attribute/pull/650.

Includes commit https://github.com/OCA/product-attribute/pull/795/commits/8c223ee6c66717e52cd792c18a4776ff391c12a0 from https://github.com/OCA/product-attribute/pull/791.

Three improvements have been done in this PR w.r.t. https://github.com/OCA/product-attribute/pull/650:

1. The layout for the old tab MDR (now called Conformity)
   has been changed to split the fields into two categories:
   conformity-related and documents-related.

2. The two fields storing the "Declaration of Conformity" and
   the "CE Certificate Medical class", that before stored an
   attachment, now allow to store several attachments.
       To make this change, a migration script has been
   provided, because the field names have changed to adhere
   to the naming conventions.

3. The string for the field ce_certificate_medical_class_ids
   has changed from 'CE Certificate Medical class' to 'CE Certificate'.
   The translation files have been updated.
