### PR TITLE
[14.0][FIX] product_dimension: dimension not saved at record creation

### DIFF
--- a/product_dimension/models/product.py
+++ b/product_dimension/models/product.py
@@ -69,6 +69,19 @@ class ProductTemplate(models.Model):
             round=False,
         )
 
+    @api.model
+    def create(self, vals):
+        product_template = super().create(vals)
+        product_template.write(
+            {
+                "dimensional_uom_id": vals.get("dimensional_uom_id", False),
+                "product_length": vals.get("product_length", False),
+                "product_height": vals.get("product_height", False),
+                "product_width": vals.get("product_width", False),
+            }
+        )
+        return product_template
+
     # Define all the related fields in product.template with 'readonly=False'
     # to be able to modify the values from product.template.
     dimensional_uom_id = fields.Many2one(

--- a/product_dimension/tests/test_compute_volume.py
+++ b/product_dimension/tests/test_compute_volume.py
@@ -51,3 +51,25 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.template = self.env["product.template"].new()
         self.uom_m = self.env["uom.uom"].search([("name", "=", "m")])
         self.uom_cm = self.env["uom.uom"].search([("name", "=", "cm")])
+
+
+class TestCreateProductTemplate(TransactionCase):
+    def setUp(self):
+        super(TestCreateProductTemplate, self).setUp()
+        self.uom_cm = self.env["uom.uom"].search([("name", "=", "cm")])
+
+    def test_product_template_creation_should_save_user_inputs(self):
+        product_template = self.env["product.template"].create(
+            {
+                "name": "test",
+                "product_width": 12,
+                "product_height": 12,
+                "product_length": 12,
+                "dimensional_uom_id": self.uom_cm.id,
+            }
+        )
+        self.assertEqual(12, product_template.product_width)
+        self.assertEqual(12, product_template.product_height)
+        self.assertEqual(12, product_template.product_length)
+        self.assertEqual(12, product_template.product_length)
+        self.assertEqual(self.uom_cm.id, product_template.dimensional_uom_id.id)


### PR DESCRIPTION
... while creating product template with dimension
fields related are not write to the default product_product
I guess the instance is not set created so we get default value
from the product product