### PR TITLE
[13.0][FIX] product_pricelist_revision: Applied the new way for digits

### DIFF
--- a/product_pricelist_revision/README.rst
+++ b/product_pricelist_revision/README.rst
@@ -40,8 +40,7 @@ Configuration
 To configure this module, you need to:
 
 #. Go to *Sales > Configuration > Settings* and check
-   "Multiple Sales Prices per Product" option and
-   "Prices computed from formulas" after that.
+   "Pricelists" option and "Advanced price rules" after that.
 
 Usage
 =====
@@ -85,6 +84,7 @@ Contributors
 
   * Carlos Dauden
   * Ernesto Tejeda
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_pricelist_revision/readme/CONFIGURE.rst
+++ b/product_pricelist_revision/readme/CONFIGURE.rst
@@ -1,5 +1,4 @@
 To configure this module, you need to:
 
 #. Go to *Sales > Configuration > Settings* and check
-   "Multiple Sales Prices per Product" option and
-   "Prices computed from formulas" after that.
+   "Pricelists" option and "Advanced price rules" after that.

--- a/product_pricelist_revision/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_revision/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 
   * Carlos Dauden
   * Ernesto Tejeda
+  * Carlos Roca

--- a/product_pricelist_revision/static/description/index.html
+++ b/product_pricelist_revision/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product Pricelist Revision</title>
 <style type="text/css">
 
@@ -390,8 +390,7 @@ variation between a version and the previous one.</p>
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to <em>Sales &gt; Configuration &gt; Settings</em> and check
-“Multiple Sales Prices per Product” option and
-“Prices computed from formulas” after that.</li>
+“Pricelists” option and “Advanced price rules” after that.</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -433,6 +432,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos Dauden</li>
 <li>Ernesto Tejeda</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 </ul>

--- a/product_pricelist_revision/wizards/pricelist_duplicate_wizard.py
+++ b/product_pricelist_revision/wizards/pricelist_duplicate_wizard.py
@@ -5,8 +5,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields, models
 
-from odoo.addons import decimal_precision as dp
-
 
 class ProductPricelistItemDuplicateWizard(models.TransientModel):
     _name = "product.pricelist.item.duplicate.wizard"
@@ -14,9 +12,7 @@ class ProductPricelistItemDuplicateWizard(models.TransientModel):
 
     date_start = fields.Date(required=True)
     date_end = fields.Date()
-    variation_percent = fields.Float(
-        digits=dp.get_precision("Product Price"), string="Variation %"
-    )
+    variation_percent = fields.Float(digits="Product Price", string="Variation %")
 
     def action_apply(self):
         PricelistItem = self.env["product.pricelist.item"]


### PR DESCRIPTION
Before this change on runbot we caught a Warning about deprecated call to decimal_precision.get_precision(<application>)

cc @Tecnativa TT27468

please @ernestotejeda @carlosdauden review this