### PR TITLE
[13.0][IMP] product_medical: views for conformity categories

### DIFF
--- a/product_medical/__manifest__.py
+++ b/product_medical/__manifest__.py
@@ -14,6 +14,10 @@
         "data/medical_data.xml",
         "security/ir.model.access.csv",
         "views/product_template.xml",
+        "views/in_vitro_diagnostic.xml",
+        "views/medical_class.xml",
+        "views/medicine_category.xml",
+        "views/ppe_category.xml",
     ],
     "installable": True,
 }

--- a/product_medical/views/in_vitro_diagnostic.xml
+++ b/product_medical/views/in_vitro_diagnostic.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl) -->
+<odoo>
+    <record id="in_vitro_diagnostic_tree_view" model="ir.ui.view">
+        <field name="name">in.vitro.diagnostic tree</field>
+        <field name="model">in.vitro.diagnostic</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+    <record id="in_vitro_diagnostic_action" model="ir.actions.act_window">
+        <field name="name">In Vitro Diagnostics</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">in.vitro.diagnostic</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your in vitro diagnostic here.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/product_medical/views/medical_class.xml
+++ b/product_medical/views/medical_class.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl) -->
+<odoo>
+    <record id="medical_class_tree_view" model="ir.ui.view">
+        <field name="name">medical.class tree</field>
+        <field name="model">medical.class</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+    <record id="medical_class_action" model="ir.actions.act_window">
+        <field name="name">Medical Classes</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">medical.class</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your medical class here.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/product_medical/views/medicine_category.xml
+++ b/product_medical/views/medicine_category.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl) -->
+<odoo>
+    <record id="medicine_category_tree_view" model="ir.ui.view">
+        <field name="name">medicine.category tree</field>
+        <field name="model">medicine.category</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+    <record id="medicine_category_action" model="ir.actions.act_window">
+        <field name="name">Medicine Categories</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">medicine.category</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your medicine categories here.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/product_medical/views/ppe_category.xml
+++ b/product_medical/views/ppe_category.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl) -->
+<odoo>
+    <record id="ppe_category_tree_view" model="ir.ui.view">
+        <field name="name">ppe.category tree</field>
+        <field name="model">ppe.category</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+    <record id="ppe_category_action" model="ir.actions.act_window">
+        <field name="name">PPE Categories</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">ppe.category</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your PPE categories here.
+            </p>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The attributes for the Conformity Configuration (Medical Class,
Medical Category, PPE Category, and In Vitro Diagnostics) had no
views associated to them, so the only way of accessing them was
through the entry they have in the form for product.template.

With this PR, tree views and their actions have been added, so
that they can be reused in other modules to accessed them
from custom menu-items.