### PR TITLE
[14.0][ADD] product_pricelist_from_commitment_date

### DIFF
--- a/product_pricelist_from_commitment_date/__init__.py
+++ b/product_pricelist_from_commitment_date/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/product_pricelist_from_commitment_date/__manifest__.py
+++ b/product_pricelist_from_commitment_date/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Product Pricelist From Commitment Date",
+    "summary": "Use sale order commitment date to compute line price from pricelist",
+    "version": "14.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/product-attribute",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sale"],
+    "installable": True,
+}

--- a/product_pricelist_from_commitment_date/models/__init__.py
+++ b/product_pricelist_from_commitment_date/models/__init__.py
@@ -1,0 +1,6 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import product_pricelist
+from . import product_product
+from . import sale_order
+from . import sale_order_line

--- a/product_pricelist_from_commitment_date/models/product_pricelist.py
+++ b/product_pricelist_from_commitment_date/models/product_pricelist.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ProductPricelist(models.Model):
+
+    _inherit = "product.pricelist"
+
+    def get_products_price(
+        self, products, quantities, partners, date=False, uom_id=False
+    ):
+        new_date = date
+        force_pricelist_date = self.env.context.get("force_pricelist_date")
+        if force_pricelist_date:
+            new_date = force_pricelist_date
+        return super().get_products_price(
+            products, quantities, partners, new_date, uom_id
+        )

--- a/product_pricelist_from_commitment_date/models/product_product.py
+++ b/product_pricelist_from_commitment_date/models/product_product.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ProductProduct(models.Model):
+
+    _inherit = "product.product"
+
+    @api.depends_context(
+        "pricelist",
+        "partner",
+        "quantity",
+        "uom",
+        "date",
+        "no_variant_attributes_price_extra",
+        "force_pricelist_date",
+    )
+    def _compute_product_price(self):
+        # Just add force_pricelist_date in list of depends context
+        return super()._compute_product_price()

--- a/product_pricelist_from_commitment_date/models/sale_order.py
+++ b/product_pricelist_from_commitment_date/models/sale_order.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    def _apply_pricelist_from_commitment_date(self):
+        self.ensure_one()
+        for line in self.order_line:
+            if line.product_updatable:
+                # Call product_uom_change as it only update price_unit using pricelist
+                line.with_context(
+                    force_pricelist_date=self.commitment_date
+                ).product_uom_change()
+
+    @api.onchange("commitment_date", "pricelist_id")
+    def onchange_price_with_commitment_date(self):
+        self._apply_pricelist_from_commitment_date()
+
+    def create(self, vals):
+        sale = super().create(vals)
+        if sale.commitment_date:
+            sale._apply_pricelist_from_commitment_date()
+        return sale
+
+    def write(self, vals):
+        if "commitment_date" not in vals and "pricelist_id" not in vals:
+            return super().write(vals)
+        for sale in self:
+            old_commitment_date = sale.commitment_date
+            old_pricelist = sale.pricelist_id
+            super(SaleOrder, sale).write(vals)
+            if (
+                old_commitment_date != sale.commitment_date
+                or old_pricelist != sale.pricelist_id
+            ):
+                sale._apply_pricelist_from_commitment_date()
+        return True

--- a/product_pricelist_from_commitment_date/models/sale_order.py
+++ b/product_pricelist_from_commitment_date/models/sale_order.py
@@ -11,7 +11,8 @@ class SaleOrder(models.Model):
     def _apply_pricelist_from_commitment_date(self):
         self.ensure_one()
         for line in self.order_line:
-            if line.product_updatable:
+            # Price unit is still modifiable if not quantity invoiced
+            if not line.qty_invoiced:
                 # Call product_uom_change as it only update price_unit using pricelist
                 line.with_context(
                     force_pricelist_date=self.commitment_date

--- a/product_pricelist_from_commitment_date/models/sale_order_line.py
+++ b/product_pricelist_from_commitment_date/models/sale_order_line.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+
+    _inherit = "sale.order.line"
+
+    @api.onchange("product_id")
+    def product_id_change(self):
+        return super(
+            SaleOrderLine,
+            self.with_context(force_pricelist_date=self.order_id.commitment_date),
+        ).product_id_change()
+
+    @api.onchange("product_uom", "product_uom_qty")
+    def product_uom_change(self):
+        return super(
+            SaleOrderLine,
+            self.with_context(force_pricelist_date=self.order_id.commitment_date),
+        ).product_uom_change()

--- a/product_pricelist_from_commitment_date/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_from_commitment_date/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Julien Coux <julien.coux@camptocamp.com>

--- a/product_pricelist_from_commitment_date/readme/DESCRIPTION.rst
+++ b/product_pricelist_from_commitment_date/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+When the sale order commitment date is set,
+this date is used by pricelist to compute price unit instead of using order date.

--- a/product_pricelist_from_commitment_date/tests/__init__.py
+++ b/product_pricelist_from_commitment_date/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_pricelist_from_commitment_date

--- a/product_pricelist_from_commitment_date/tests/test_pricelist_from_commitment_date.py
+++ b/product_pricelist_from_commitment_date/tests/test_pricelist_from_commitment_date.py
@@ -1,0 +1,92 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class PricelistFromCommitmentDate(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        # Pricelists.
+        cls.pricelist_default = cls.env.ref("product.list0")
+        cls.pricelist_parent = cls._create_price_list("Parent Pricelist")
+        cls.pricelist = cls._create_price_list("Simple Pricelist")
+        cls.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": cls.pricelist.id,
+                "applied_on": "3_global",
+                "compute_price": "formula",
+                "base": "pricelist",
+                "base_pricelist_id": cls.pricelist_parent.id,
+            }
+        )
+        # Test in the past to avoid to have date order in the interval
+        cls._create_price_list_item(cls.pricelist, 10, "2020-03-05", "2020-03-09")
+        cls._create_price_list_item(cls.pricelist, 20, "2020-03-10", "2020-03-14")
+        # Parent item
+        cls._create_price_list_item(
+            cls.pricelist_parent, 30, "2020-03-15", "2020-03-20"
+        )
+
+        # Create the SO with 1 order line
+        cls.sale = cls.env.ref("sale.sale_order_1")
+
+    @classmethod
+    def _create_price_list(cls, name):
+        return cls.env["product.pricelist"].create(
+            {
+                "name": name,
+                "active": True,
+                "currency_id": cls.env.ref("base.USD").id,
+                "company_id": cls.env.user.company_id.id,
+            }
+        )
+
+    @classmethod
+    def _create_price_list_item(cls, pricelist, price, date_start=None, date_end=None):
+        values = {
+            "pricelist_id": pricelist.id,
+            "applied_on": "3_global",
+            "base": "list_price",
+            "compute_price": "fixed",
+            "fixed_price": price,
+        }
+        if date_start:
+            values["date_start"] = date_start
+        if date_end:
+            values["date_end"] = date_end
+        return cls.env["product.pricelist.item"].create(values)
+
+    def test_pricelist(self):
+        sale = self.sale
+        order_line = sale.order_line[0]
+        product = order_line.product_id
+        self.assertEqual(order_line.price_unit, product.list_price)
+        # Change pricelist have no effect as no item match
+        sale.pricelist_id = self.pricelist
+        self.assertEqual(order_line.price_unit, product.list_price)
+        # Test with commitment date
+        sale.commitment_date = "2020-03-08"
+        self.assertEqual(order_line.price_unit, 10)
+        sale.commitment_date = "2020-03-12"
+        self.assertEqual(order_line.price_unit, 20)
+        # Parent price list must match
+        sale.commitment_date = "2020-03-17"
+        self.assertEqual(order_line.price_unit, 30)
+        sale.date_order = "2020-03-08"
+        # No change with changing order date
+        self.assertEqual(order_line.price_unit, 30)
+        # Call the recompute function to be sure we have no changes
+        sale._apply_pricelist_from_commitment_date()
+        self.assertEqual(order_line.price_unit, 30)
+        # Remove commitment date, will match on date_order
+        sale.commitment_date = False
+        self.assertEqual(order_line.price_unit, 10)
+        # Remove the order date, will match on default price
+        sale.date_order = False
+        # Simulate change of product as the date order must no change normally
+        order_line.product_id_change()
+        self.assertEqual(order_line.price_unit, product.list_price)


### PR DESCRIPTION
When the sale order commitment date is set,
this date is used by pricelist to compute price unit instead of using order date.