### PR TITLE
[13.0][FIX] product_pricelist_direct_print: Error when date is not defined

### DIFF
--- a/product_pricelist_direct_print/views/report_product_pricelist.xml
+++ b/product_pricelist_direct_print/views/report_product_pricelist.xml
@@ -88,7 +88,7 @@
                                     </td>
                                     <td t-if="pricelist" class="text-right">
                                         <strong
-                                            t-field="product.with_context(pricelist=pricelist.id, date=o.date).price"
+                                            t-field="product.with_context(pricelist=pricelist.id, date=o.date or None).price"
                                         />
                                     </td>
                                 </tr>

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from datetime import datetime
+
 from odoo import fields, models, tools
 
 


### PR DESCRIPTION
When we check the price of any product, the date that we pass on the context has to be a Datetime value or None. With this change we avoid to pass a False.

Here you have the reference to the code that check that https://github.com/OCA/OCB/blob/13.0/addons/product/models/product.py#L599-L600

TT29935