### PR TITLE
[FIX] lenght name consistency migration

### DIFF
--- a/product_packaging_dimension/migrations/14.0.1.0.1/pre-migrate.py
+++ b/product_packaging_dimension/migrations/14.0.1.0.1/pre-migrate.py
@@ -1,0 +1,9 @@
+# Copyright 2021 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tools.sql import rename_column
+
+
+def migrate(cr, version):
+    # Rename packaging_length into lnght (keeping name consistency across modules)
+    rename_column(cr, "product_packaging", "packaging_length", "lnght")

--- a/product_packaging_dimension/models/product_packaging.py
+++ b/product_packaging_dimension/models/product_packaging.py
@@ -12,7 +12,7 @@ class ProductPackaging(models.Model):
     _sql_constraints = [
         ("positive_height", "CHECK(height>=0.0)", "Height must be positive"),
         ("positive_width", "CHECK(width>=0.0)", "Width must be positive"),
-        ("positive_length", "CHECK(packaging_length>=0.0)", "Length must be positive"),
+        ("positive_length", "CHECK(lnght>=0.0)", "Length must be positive"),
         (
             "positive_max_weight",
             "CHECK(max_weight>=0.0)",
@@ -21,7 +21,7 @@ class ProductPackaging(models.Model):
     ]
     height = fields.Float("Height")
     width = fields.Float("Width")
-    packaging_length = fields.Float("Length")
+    lnght = fields.Float("Length")
 
     length_uom_id = fields.Many2one(
         "uom.uom",
@@ -88,24 +88,20 @@ class ProductPackaging(models.Model):
         readonly=True,
     )
 
-    @api.depends(
-        "packaging_length", "width", "height", "length_uom_id", "volume_uom_id"
-    )
+    @api.depends("lnght", "width", "height", "length_uom_id", "volume_uom_id")
     def _compute_volume(self):
         self.volume = self._calculate_volume(
-            self.packaging_length,
+            self.lnght,
             self.height,
             self.width,
             self.length_uom_id,
             self.volume_uom_id,
         )
 
-    def _calculate_volume(
-        self, packaging_length, height, width, length_uom_id, volume_uom_id
-    ):
+    def _calculate_volume(self, lnght, height, width, length_uom_id, volume_uom_id):
         volume_m3 = 0
-        if packaging_length and height and width and length_uom_id:
-            length_m = self.convert_to_meters(packaging_length, length_uom_id)
+        if lnght and height and width and length_uom_id:
+            length_m = self.convert_to_meters(lnght, length_uom_id)
             height_m = self.convert_to_meters(height, length_uom_id)
             width_m = self.convert_to_meters(width, length_uom_id)
             volume_m3 = length_m * height_m * width_m

--- a/product_packaging_dimension/tests/test_packaging_volume.py
+++ b/product_packaging_dimension/tests/test_packaging_volume.py
@@ -23,7 +23,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         # Volume always in m3 (using default parameter), but with different initial UoM.
 
         # Initial dimensions in meter
-        self.packaging.packaging_length = 10.0
+        self.packaging.lnght = 10.0
         self.packaging.height = 10.0
         self.packaging.width = 10.0
         self.packaging.length_uom_id = self.uom_m
@@ -32,7 +32,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.assertEqual(1000, self.packaging.volume)
 
         #  Initial dimensions in cm
-        self.packaging2.packaging_length = 10.0
+        self.packaging2.lnght = 10.0
         self.packaging2.height = 10.0
         self.packaging2.width = 10.0
         self.packaging2.length_uom_id = self.uom_cm
@@ -41,7 +41,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.assertEqual(0.001, self.packaging2.volume)
 
         # Initial dimensions in feet
-        self.packaging3.packaging_length = 10.0
+        self.packaging3.lnght = 10.0
         self.packaging3.height = 10.0
         self.packaging3.width = 10.0
         self.packaging3.length_uom_id = self.uom_ft
@@ -52,7 +52,7 @@ class TestPackagingVolumeCompute(TransactionCase):
     def test_compute_volume(self):
         # initial UoM always in meters and Volume in m3, but with different dimensions.
 
-        self.packaging.packaging_length = 10
+        self.packaging.lnght = 10
         self.packaging.height = 8.0
         self.packaging.width = 10.8
         self.packaging.length_uom_id = self.uom_m
@@ -60,7 +60,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging._compute_volume()
         self.assertEqual(864, self.packaging.volume)
 
-        self.packaging2.packaging_length = 6.0
+        self.packaging2.lnght = 6.0
         self.packaging2.height = 14.0
         self.packaging2.width = 1.2
         self.packaging2.length_uom_id = self.uom_m
@@ -68,7 +68,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging2._compute_volume()
         self.assertAlmostEqual(100.8, self.packaging2.volume)
 
-        self.packaging3.packaging_length = 100.0
+        self.packaging3.lnght = 100.0
         self.packaging3.height = 50.5
         self.packaging3.width = 80.0
         self.packaging3.length_uom_id = self.uom_m
@@ -80,7 +80,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         # Tests with both different initial and volume UoMs.
 
         # feet to Liters
-        self.packaging.packaging_length = 10.0
+        self.packaging.lnght = 10.0
         self.packaging.height = 10.0
         self.packaging.width = 10.0
         self.packaging.length_uom_id = self.uom_ft
@@ -89,7 +89,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.assertAlmostEqual(28316.8439, self.packaging.volume)
 
         #  cm to cubic feet
-        self.packaging2.packaging_length = 10.0
+        self.packaging2.lnght = 10.0
         self.packaging2.height = 10.0
         self.packaging2.width = 10.0
         self.packaging2.length_uom_id = self.uom_cm
@@ -98,7 +98,7 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.assertAlmostEqual(0.0353, self.packaging2.volume)
 
         # meters to cubic feet
-        self.packaging3.packaging_length = 10.0
+        self.packaging3.lnght = 10.0
         self.packaging3.height = 10.0
         self.packaging3.width = 10.0
         self.packaging3.length_uom_id = self.uom_m

--- a/product_packaging_dimension/views/product_packaging.xml
+++ b/product_packaging_dimension/views/product_packaging.xml
@@ -12,9 +12,9 @@
                             <field name="volume" />
                             <field name="volume_uom_name" />
                         </div>
-                    <label for="packaging_length" />
+                    <label for="lnght" />
                         <div class="o_row">
-                            <field name="packaging_length" />
+                            <field name="lnght" />
                             <field name="length_uom_name" />
                         </div>
                     <label for="width" />


### PR DESCRIPTION
Rename  "packaging_length" to the original name "lnght" in order to keep consistency with other modules. 