### PR TITLE
[14.0][IMP] product_state: Prevent a write with both values

### DIFF
--- a/product_state/models/product_template.py
+++ b/product_state/models/product_template.py
@@ -13,6 +13,7 @@ class ProductTemplate(models.Model):
         index=True,
         compute="_compute_product_state",
         inverse="_inverse_product_state",
+        readonly=True,
         store=True,
     )
     product_state_id = fields.Many2one(


### PR DESCRIPTION
As fields are on the form view, a write is called with them. This
is an unwanted behaviour.