### PR TITLE
[12.0][FIX] product_pricelist_supplierinfo: Avoid min qty in Supplierinfo

### DIFF
--- a/product_pricelist_supplierinfo/models/product_product.py
+++ b/product_pricelist_supplierinfo/models/product_product.py
@@ -3,7 +3,7 @@
 # Copyright 2019 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import models, fields
 
 
 class ProductProduct(models.Model):
@@ -24,3 +24,34 @@ class ProductProduct(models.Model):
             return dict.fromkeys(self.ids, 1.0)
         return super().price_compute(
             price_type, uom=uom, currency=currency, company=company)
+
+    def _select_seller(
+            self, partner_id=False, quantity=0.0, date=None, uom_id=False,
+            params=False):
+        if not params or not params.get('avoid_min_qty'):
+            return super()._select_seller(partner_id, quantity, date, uom_id, params)
+
+        # Section based on the original Odoo's method '_select_seller' but in here the
+        # validation of the min_qty on the seller is being avoided with the use of the
+        # field `no_supplierinfo_min_quantity` on the model `product.pricelist.item`.
+        self.ensure_one()
+        if date is None:
+            date = fields.Date.context_today(self)
+
+        res = self.env['product.supplierinfo']
+        sellers = self._prepare_sellers(params)
+        company_id = self.env.context.get('force_company')
+        if company_id:
+            sellers = sellers.filtered(
+                lambda s: not s.company_id or s.company_id.id == company_id)
+        for seller in sellers:
+            if (
+                (not seller.date_start or seller.date_start <= date)
+                and (not seller.date_end or seller.date_end >= date)
+                and (not partner_id
+                     or seller.name in [partner_id, partner_id.parent_id])
+                and (not seller.product_id or seller.product_id == self)
+            ):
+                res |= seller
+                break
+        return res

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -18,17 +18,22 @@ class ProductTemplate(models.Model):
         product = self.product_variant_id
         if product_id:
             product = product.browse(product_id)
-        if rule.no_supplierinfo_min_quantity:
-            quantity = 1.0
         # The product_variant_id returns empty recordset if template is not
         # active, so we must ensure variant exists or _select_seller fails.
         if product:
             if type(date) == datetime:
                 date = date.date()
+            # If the field `no_supplierinfo_min_quantity` is set as True, we need
+            # to use the select seller that doesn't take into account the `min_qty`
+            # for the validation to know if the seller can be used (Using the param
+            # `avoid_min_qty`).
             seller = product._select_seller(
                 partner_id=rule.filter_supplier_id,
                 quantity=quantity,
-                date=date)
+                date=date,
+                params={
+                    'avoid_min_qty': rule.no_supplierinfo_min_quantity,
+                })
             if seller:
                 price = seller._get_supplierinfo_pricelist_price()
         if price:


### PR DESCRIPTION
Before this commit, using the field `no_supplierinfo_min_quantity` in the `product.pricelist.item` only allow us to use `product.supplierinfo` with `min_qty` equals 0 or 1, even when there is a supplierinfo with the same sequence but a higher `min_qty` and the order of that model is 'sequence, min_qty desc, price' which tell us that the seller with a higher `min_qty` should be first.

For example in the test `test_pricelist_min_quantity` when the field `no_supplierinfo_min_quantity` is set to True the order of the
supplierinfo arrive first the one with the vendor "cls.supplier1" and the price 50 because both sellers have the same sequence but this has the higher `min_qty, but with the method `_select_seller` sending the qty with 1 only allows us to use the first supplierinfo with the qty of 1 or 0 so that is why the price that was obtained was 10 instead of 50.

![Test Supplierinfo Error](https://user-images.githubusercontent.com/26889951/125005507-82ec5100-e021-11eb-8297-8fdf6b2e2c1d.png)

Adding a param to the method `_select_seller` in the model `product.product` 'avoid_min_qty' that can be sent in the parameter
`params` where we will avoid the validation of the `min_qty` of the supplierinfo to use on the method `_get_supplierinfo_pricelist_price` of the model `product.template` when the field `no_supplierinfo_min_quantity` is set as True.