### PR TITLE
[13.0][IMP] product_supplierinfo_for_customer: introduce _select_customerinfo

### DIFF
--- a/product_supplierinfo_for_customer/readme/CONTRIBUTORS.rst
+++ b/product_supplierinfo_for_customer/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Aaron Henriquez <ahenriquez@forgeflow.com>
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Tecnativa - Sergio Teruel <sergio.teruel@tecnativa.com>
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
+++ b/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
@@ -48,6 +48,7 @@ class TestProductSupplierinfoForCustomer(SavepointCase):
         return cls.env["product." + supplierinfo_type + "info"].create(
             {
                 "name": partner.id,
+                "product_tmpl_id": product.product_tmpl_id.id,
                 "product_id": product.id,
                 "product_code": "00001",
                 "price": 100.0,
@@ -80,7 +81,7 @@ class TestProductSupplierinfoForCustomer(SavepointCase):
         )
 
     def test_product_supplierinfo_price(self):
-        price = self.product._get_price_from_customerinfo(partner_id=self.customer.id)
+        price = self.product._get_price_from_customerinfo(partner_id=self.customer)
         self.assertEqual(
             price, 100.0, "Error: Price not found for product and customer"
         )


### PR DESCRIPTION
This method mimics [standard "brother" `_select_seller`](https://github.com/odoo/odoo/blob/14.0/addons/product/models/product.py#L602) to make the
module more consistent and to introduce a standard way to get the
customerinfo in modules depending on this one.

@ForgeFlow