### PR TITLE
14.0 imp product packaging type display code and qty in name

### DIFF
--- a/product_packaging_type/data/product_packaging_type.xml
+++ b/product_packaging_type/data/product_packaging_type.xml
@@ -3,6 +3,8 @@
     <record id="product_packaging_type_default" model="product.packaging.type">
         <field name="name">Default Type</field>
         <field name="code">DEFAULT</field>
+        <field name="display_code_in_name" eval="True"/>
+        <field name="display_qty_in_name" eval="False"/>
         <field name="sequence">1</field>
         <field name="is_default" eval="True" />
     </record>

--- a/product_packaging_type/models/product_packaging_type.py
+++ b/product_packaging_type/models/product_packaging_type.py
@@ -13,6 +13,7 @@ class ProductPackagingType(models.Model):
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(required=True)
+    display_code_in_name = fields.Boolean(default=True)
     sequence = fields.Integer(required=True)
     has_gtin = fields.Boolean()
     active = fields.Boolean(default=True)
@@ -32,7 +33,10 @@ class ProductPackagingType(models.Model):
     def name_get(self):
         result = []
         for record in self:
-            result.append((record.id, "{} ({})".format(record.name, record.code)))
+            if self.display_code_in_name:
+                result.append((record.id, "{} ({})".format(record.name, record.code)))
+            else:
+                result.append((record.id, record.name))
         return result
 
 

--- a/product_packaging_type/models/product_packaging_type.py
+++ b/product_packaging_type/models/product_packaging_type.py
@@ -14,6 +14,7 @@ class ProductPackagingType(models.Model):
     name = fields.Char(required=True, translate=True)
     code = fields.Char(required=True)
     display_code_in_name = fields.Boolean(default=True)
+    display_qty_in_name = fields.Boolean(default=False)
     sequence = fields.Integer(required=True)
     has_gtin = fields.Boolean()
     active = fields.Boolean(default=True)
@@ -33,8 +34,8 @@ class ProductPackagingType(models.Model):
     def name_get(self):
         result = []
         for record in self:
-            if self.display_code_in_name:
-                result.append((record.id, "{} ({})".format(record.name, record.code)))
+            if record.display_code_in_name:
+                result.append((record.id, "[{}] {}".format(record.code, record.name)))
             else:
                 result.append((record.id, record.name))
         return result
@@ -142,7 +143,15 @@ class ProductPackaging(models.Model):
         result = []
         for record in self:
             if record.product_id and record.packaging_type_id:
-                result.append((record.id, record.packaging_type_id.display_name))
+                if record.packaging_type_id.display_qty_in_name:
+                    result.append((record.id, "{} ({})".format(
+                        record.packaging_type_id.display_name,
+                        str(record.product_uom_id._compute_quantity(
+                            record.qty,
+                            record.product_uom_id)) + record.product_uom_id.name
+                    )))
+                else:
+                    result.append((record.id, record.packaging_type_id.display_name))
             else:
                 result.append((record.id, record.name))
         return result

--- a/product_packaging_type/views/product_packaging_type_view.xml
+++ b/product_packaging_type/views/product_packaging_type_view.xml
@@ -29,11 +29,13 @@
                         <group name="codes">
                             <field name="code" />
                             <field name="display_code_in_name"/>
+                            <field name="display_qty_in_name"/>
                             <field name="has_gtin" />
                         </group>
                         <group name="misc">
                             <field name="sequence" />
                             <field name="active" />
+                            <field name="is_default" />
                         </group>
                     </group>
                 </sheet>

--- a/product_packaging_type/views/product_packaging_type_view.xml
+++ b/product_packaging_type/views/product_packaging_type_view.xml
@@ -28,6 +28,7 @@
                     <group name="main">
                         <group name="codes">
                             <field name="code" />
+                            <field name="display_code_in_name"/>
                             <field name="has_gtin" />
                         </group>
                         <group name="misc">


### PR DESCRIPTION
Added two options in product packaging type to hide or display the code and/or the quantity (when possible) in the product packaging name

- Display code in name: e.g. BOX (BX)
- Display quantity in name: e.g. BOX (2.0KG) (BX)