### PR TITLE
[14.0][FIX] product_secondary_unit : ZeroDivisionError when qty is null

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -99,10 +99,13 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
                 field=rec._fields["secondary_uom_qty"], records=rec
             )
             factor = rec._get_factor_line()
-            qty = float_round(
-                rec.secondary_uom_qty * factor,
-                precision_rounding=rec._get_uom_line().rounding,
-            )
+            try:
+                qty = float_round(
+                    rec.secondary_uom_qty * factor,
+                    precision_rounding=rec._get_uom_line().rounding,
+                )
+            except ZeroDivisionError:
+                pass
             rec[rec._secondary_unit_fields["qty_field"]] = qty
 
     def _onchange_helper_product_uom_for_secondary(self):


### PR DESCRIPTION
@sergio-teruel, @rousseldenis, @hparfr 
As mentioned by  @Bilbonet (https://github.com/OCA/sale-workflow/pull/1671#issuecomment-894473115), a quantity set as 0 brings the ZeroDivisionError: float division by zero