### PR TITLE
[FIX] product_pricelist_supplierinfo: public users

### DIFF
--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -26,9 +26,12 @@ class ProductTemplate(models.Model):
             if type(date) == datetime:
                 date = date.date()
             seller = product._select_seller(
-                partner_id=rule.filter_supplier_id,
+                # For a public user this record could be not accessible, but we
+                # need to get the price anyway
+                partner_id=rule.sudo().filter_supplier_id,
                 quantity=quantity,
-                date=date)
+                date=date
+            )
             if seller:
                 price = seller._get_supplierinfo_pricelist_price()
         if price:


### PR DESCRIPTION
In the e-commerce, if we have a pricelist with a rule based on
supplierinfo for a determined supplier partner, such partner could be
not accesible for public users and the affected products could not be
reached.

cc @Tecnativa TT31476

ping @pedrobaeza @CarlosRoca13 