### PR TITLE
[14.0][FIX] secondary_uom: independent behavior

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -85,13 +85,14 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
     def _compute_helper_target_field_qty(self):
         """Set the target qty field defined in model"""
         for rec in self:
-            if (
-                not rec.secondary_uom_id
-                or rec.secondary_uom_id.dependency_type == "independent"
-            ):
+            if not rec.secondary_uom_id:
                 rec[rec._secondary_unit_fields["qty_field"]] = rec._origin[
                     rec._secondary_unit_fields["qty_field"]
                 ]
+                continue
+            if rec.secondary_uom_id.dependency_type == "independent":
+                if rec[rec._secondary_unit_fields["qty_field"]] == 0.0:
+                    rec[rec._secondary_unit_fields["qty_field"]] = 1.0
                 continue
             # To avoid recompute secondary_uom_qty field when
             # secondary_uom_id changes.

--- a/product_secondary_unit/tests/test_secondary_unit_mixin.py
+++ b/product_secondary_unit/tests/test_secondary_unit_mixin.py
@@ -119,9 +119,13 @@ class TestProductSecondaryUnitMixin(SavepointCase, FakeModelLoader):
         fake_model.secondary_uom_id = self.secondary_unit_box_5
         fake_model.secondary_uom_id.write({"dependency_type": "independent"})
         fake_model.write({"secondary_uom_qty": 2})
-        self.assertEqual(fake_model.product_uom_qty, 0)
+        self.assertEqual(fake_model.product_uom_qty, 1)
         self.assertEqual(fake_model.secondary_uom_qty, 2)
 
         fake_model.write({"product_uom_qty": 17})
-        self.assertEqual(fake_model.secondary_uom_qty, 2)
         self.assertEqual(fake_model.product_uom_qty, 17)
+        self.assertEqual(fake_model.secondary_uom_qty, 2)
+
+        fake_model.write({"secondary_uom_qty": 4})
+        self.assertEqual(fake_model.product_uom_qty, 17)
+        self.assertEqual(fake_model.secondary_uom_qty, 4)


### PR DESCRIPTION
@hparfr, @sergio-teruel 
Fix minor behavior of the independent mode : 
- put 1 as primary unit quantity by default
- Change of the secondary unit quantity doesn't change the primary unit quantity when both UoM are independent. 