### PR TITLE
[IMP] product_packaging_dimension: have product_uom_mm for dependants…

### DIFF
--- a/product_packaging_dimension/__manifest__.py
+++ b/product_packaging_dimension/__manifest__.py
@@ -13,6 +13,7 @@
     ],
     "website": "https://github.com/OCA/product-attribute",
     "data": [
+        "data/uom.xml",
         "views/product_packaging.xml",
     ],
     "installable": True,

--- a/product_packaging_dimension/data/uom.xml
+++ b/product_packaging_dimension/data/uom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This is from https://github.com/OCA/stock-logistics-warehouse/blob/14.0/stock_measuring_device/data/uom.xml
+    and intended to be used in modules those depend on this module.
+-->
+<odoo>
+    <record id="product_uom_mm" model="uom.uom">
+        <field name="category_id" ref="uom.uom_categ_length" />
+        <field name="name">mm</field>
+        <field name="factor" eval="1000" />
+        <field name="uom_type">smaller</field>
+    </record>
+</odoo>


### PR DESCRIPTION
… to use

Module `shopfloor_batch_automatic_creation` is depending on this module and need `product_uom_mm` uom for testing. The uom is in `stock_measuring_device` module but the former module does not need the later module. So this commit is to move the uom to this module for better dependency.