### PR TITLE
[14.0][FIX] product_packaging_unit_price_calculator: fix access rights

### DIFF
--- a/product_packaging_unit_price_calculator/security/ir.model.access.csv
+++ b/product_packaging_unit_price_calculator/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_product_package_price_wizard,access.product.package.price.wizard,model_product_package_price_wizard,stock.group_stock_user,1,1,1,1
+access_product_package_price_wizard,access.product.package.price.wizard,model_product_package_price_wizard,base.group_system,1,1,1,0


### PR DESCRIPTION
To not depend on `stock` module.

Use of `base.group_system` to be aligned with the standard `product` module.

Fix the following error:
```
Exception: Module loading product_packaging_unit_price_calculator failed: file product_packaging_unit_price_calculator/security/ir.model.access.csv could not be processed:

 No matching record found for external id 'stock.group_stock_user' in field 'Group'
```