### PR TITLE
[FIX] product_pricelist_direct_print: company in report

### DIFF
--- a/product_pricelist_direct_print/views/report_product_pricelist.xml
+++ b/product_pricelist_direct_print/views/report_product_pricelist.xml
@@ -4,8 +4,9 @@
 <odoo>
     <template id="report_product_pricelist_document">
         <t t-call="web.html_container">
+            <t t-set="pricelist" t-value="o.get_pricelist_to_print()" />
+            <t t-set="company" t-value="pricelist.company_id or env.company" />
             <t t-call="web.external_layout">
-                <t t-set="pricelist" t-value="o.get_pricelist_to_print()" />
                 <div class="page">
                     <h2>Price List</h2>
                     <div class="row mt32 mb32">


### PR DESCRIPTION
In a multicompany environment we need to contextualize the report
company. Otherwise, the pricelists will be printed with the header and
data of the current user's default company, which can be incoherent.

cc @Tecnativa TT32544

ping @pedrobaeza @carlosdauden 