### PR TITLE
[13.0][FIX] product_manufacturer: Keep manufacture information for first variant product creation

### DIFF
--- a/product_manufacturer/models/product_manufacturer.py
+++ b/product_manufacturer/models/product_manufacturer.py
@@ -79,3 +79,23 @@ class ProductTemplate(models.Model):
                 template.product_variant_ids.manufacturer_purl = (
                     template.manufacturer_purl
                 )
+
+    @api.model
+    def create(self, vals):
+        """Overwrite creation for rewriting manufacturer information (if set and having
+        only one variant), after the variant creation, that is performed in super.
+        """
+        template = super().create(vals)
+        if len(template.product_variant_ids) == 1:
+            related_vals = {}
+            if vals.get("manufacturer"):
+                related_vals["manufacturer"] = vals["manufacturer"]
+            if vals.get("manufacturer_pname"):
+                related_vals["manufacturer_pname"] = vals["manufacturer_pname"]
+            if vals.get("manufacturer_pref"):
+                related_vals["manufacturer_pref"] = vals["manufacturer_pref"]
+            if vals.get("manufacturer_purl"):
+                related_vals["manufacturer_purl"] = vals["manufacturer_purl"]
+            if related_vals:
+                template.write(related_vals)
+        return template

--- a/product_manufacturer/readme/CONTRIBUTORS.rst
+++ b/product_manufacturer/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Héctor Villarreal <hector.villarreal@forgeflow.com>

--- a/product_manufacturer/tests/__init__.py
+++ b/product_manufacturer/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_manufacturer

--- a/product_manufacturer/tests/test_product_manufacturer.py
+++ b/product_manufacturer/tests/test_product_manufacturer.py
@@ -8,6 +8,7 @@ class TestProductManufacturer(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.manufacturer_a = cls.env["res.partner"].create({"name": "Manufacturer A"})
         cls.manufacturer_b = cls.env["res.partner"].create({"name": "Manufacturer B"})
         cls.attr1 = cls.env["product.attribute"].create({"name": "color"})
@@ -99,4 +100,28 @@ class TestProductManufacturer(SavepointCase):
         self.assertEqual(
             self.product1.product_variant_ids[0].manufacturer_purl,
             "https://www.manufacturerb.com/test_product_b",
+        )
+
+    def test_03_product_manufacturer_creation(self):
+        new_pt = self.env["product.template"].create(
+            {
+                "name": "New Product Template",
+                "manufacturer": self.manufacturer_a.id,
+                "manufacturer_pname": "Test Product A",
+                "manufacturer_pref": "TPA",
+                "manufacturer_purl": "https://www.manufacturera.com/test_product_a",
+            }
+        )
+
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer.id, new_pt.manufacturer.id
+        )
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer_pname, new_pt.manufacturer_pname
+        )
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer_pref, new_pt.manufacturer_pref
+        )
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer_purl, new_pt.manufacturer_purl
         )

--- a/product_manufacturer/tests/test_product_manufacturer.py
+++ b/product_manufacturer/tests/test_product_manufacturer.py
@@ -1,0 +1,102 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo.tests.common import SavepointCase
+
+
+class TestProductManufacturer(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.manufacturer_a = cls.env["res.partner"].create({"name": "Manufacturer A"})
+        cls.manufacturer_b = cls.env["res.partner"].create({"name": "Manufacturer B"})
+        cls.attr1 = cls.env["product.attribute"].create({"name": "color"})
+        cls.attr1_1 = cls.env["product.attribute.value"].create(
+            {"name": "red", "attribute_id": cls.attr1.id}
+        )
+        cls.attr1_2 = cls.env["product.attribute.value"].create(
+            {"name": "blue", "attribute_id": cls.attr1.id}
+        )
+        cls.product1 = cls.env["product.template"].create(
+            {"name": "Test Product Manufacturer 1"}
+        )
+
+    def test_01_product_manufacturer(self):
+        self.product1.update(
+            {
+                "manufacturer": self.manufacturer_a.id,
+                "manufacturer_pname": "Test Product A",
+                "manufacturer_pref": "TPA",
+                "manufacturer_purl": "https://www.manufacturera.com/test_product_a",
+            }
+        )
+
+        self.assertEqual(
+            self.product1.product_variant_id.manufacturer.id, self.manufacturer_a.id
+        )
+        self.assertEqual(
+            self.product1.product_variant_id.manufacturer_pname, "Test Product A"
+        )
+        self.assertEqual(self.product1.product_variant_id.manufacturer_pref, "TPA")
+        self.assertEqual(
+            self.product1.product_variant_id.manufacturer_purl,
+            "https://www.manufacturera.com/test_product_a",
+        )
+
+    def test_02_product_manufacturer(self):
+        self.product1.update(
+            {
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.attr1.id,
+                            "value_ids": [(6, 0, [self.attr1_1.id, self.attr1_2.id])],
+                        },
+                    ),
+                ],
+            }
+        )
+        self.product1.product_variant_ids[0].update(
+            {
+                "manufacturer": self.manufacturer_b.id,
+                "manufacturer_pname": "Test Product B",
+                "manufacturer_pref": "TPB",
+                "manufacturer_purl": "https://www.manufacturerb.com/test_product_b",
+            }
+        )
+        self.product1.product_variant_ids[1].update(
+            {
+                "manufacturer": self.manufacturer_a.id,
+                "manufacturer_pname": "Test Product A",
+                "manufacturer_pref": "TPA",
+                "manufacturer_purl": "https://www.manufacturera.com/test_product_a",
+            }
+        )
+        self.assertEqual(self.product1.manufacturer.id, False)
+        self.assertEqual(self.product1.manufacturer_pname, False)
+        self.assertEqual(self.product1.manufacturer_pref, False)
+        self.assertEqual(self.product1.manufacturer_purl, False)
+        self.assertEqual(
+            self.product1.product_variant_ids[1].manufacturer.id, self.manufacturer_a.id
+        )
+        self.assertEqual(
+            self.product1.product_variant_ids[1].manufacturer_pname, "Test Product A"
+        )
+        self.assertEqual(self.product1.product_variant_ids[1].manufacturer_pref, "TPA")
+        self.assertEqual(
+            self.product1.product_variant_ids[1].manufacturer_purl,
+            "https://www.manufacturera.com/test_product_a",
+        )
+        self.assertEqual(
+            self.product1.product_variant_ids[0].manufacturer.id, self.manufacturer_b.id
+        )
+        self.assertEqual(
+            self.product1.product_variant_ids[0].manufacturer_pname, "Test Product B"
+        )
+        self.assertEqual(self.product1.product_variant_ids[0].manufacturer_pref, "TPB")
+        self.assertEqual(
+            self.product1.product_variant_ids[0].manufacturer_purl,
+            "https://www.manufacturerb.com/test_product_b",
+        )


### PR DESCRIPTION
Regarding https://github.com/OCA/product-attribute/pull/681#issuecomment-952751088

- [x] Fix applied to do not lose manufacture information when creating a new product template.
- [x] Backport tests from 14.0
- [x] Add test for product template creation

#### After merging

- [x] Forwardport 3257b72 and 3149052 
https://github.com/OCA/product-attribute/pull/936

CC @ForgeFlow @juppe 