### PR TITLE
[14.0] product_state: move default states to demo data

### DIFF
--- a/product_state/README.rst
+++ b/product_state/README.rst
@@ -50,6 +50,11 @@ To add a product to a state:
 #. Go to the product itself and edit.
 #. You can select the desired status in the list of buttons above the form.
 
+Known issues / Roadmap
+======================
+
+File data/product_state_data.xml will be moved to demo/product_state_demo.xml since version 15.0
+
 Bug Tracker
 ===========
 

--- a/product_state/data/product_state_data.xml
+++ b/product_state/data/product_state_data.xml
@@ -9,6 +9,7 @@
         <field name="code">sellable</field>
         <field name="name">Normal</field>
         <field name="sequence">20</field>
+        <field name="default">True</field>
     </record>
     <record id="product_state_end" model="product.state">
         <field name="code">end</field>

--- a/product_state/models/product_state.py
+++ b/product_state/models/product_state.py
@@ -1,7 +1,8 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductState(models.Model):
@@ -14,6 +15,7 @@ class ProductState(models.Model):
     sequence = fields.Integer(
         string="Sequence", help="Used to order the States", default=25
     )
+    active = fields.Boolean(default=True)
     description = fields.Text(translate=True)
     product_ids = fields.One2many(
         comodel_name="product.template",
@@ -24,7 +26,7 @@ class ProductState(models.Model):
         string="Number of products",
         compute="_compute_products_count",
     )
-
+    default = fields.Boolean("Default state")
     _sql_constraints = [
         ("code_unique", "UNIQUE(code)", "Product State Code must be unique.")
     ]
@@ -42,3 +44,8 @@ class ProductState(models.Model):
         }
         for state in self:
             state.products_count = mapped_data.get(state.id, 0)
+
+    @api.constrains("default")
+    def _check_default(self):
+        if self.search_count([("default", "=", True)]) > 1:
+            raise ValidationError(_("There should be only one default state"))

--- a/product_state/models/product_template.py
+++ b/product_state/models/product_template.py
@@ -28,9 +28,7 @@ class ProductTemplate(models.Model):
 
     @api.model
     def _get_default_product_state_id(self):
-        return self.env.ref(
-            "product_state.product_state_sellable", raise_if_not_found=False
-        )
+        return self.env["product.state"].search([("default", "=", True)], limit=1).id
 
     @api.depends("product_state_id")
     def _compute_product_state(self):

--- a/product_state/readme/ROADMAP.rst
+++ b/product_state/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+File data/product_state_data.xml will be moved to demo/product_state_demo.xml since version 15.0

--- a/product_state/static/description/index.html
+++ b/product_state/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product State</title>
 <style type="text/css">
 
@@ -379,11 +379,12 @@ ul.auto-toc {
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -401,8 +402,12 @@ ul.auto-toc {
 <li>You can select the desired status in the list of buttons above the form.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<p>File data/product_state_data.xml will be moved to demo/product_state_demo.xml since version 15.0</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/product-attribute/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -410,15 +415,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>Cedric Pigeon &lt;<a class="reference external" href="mailto:cedric.pigeon&#64;acsone.eu">cedric.pigeon&#64;acsone.eu</a>&gt;</li>
 <li>Alexandre Saunier &lt;<a class="reference external" href="mailto:alexandre.saunier&#64;camptocamp.com">alexandre.saunier&#64;camptocamp.com</a>&gt;</li>
@@ -429,7 +434,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/product_state/tests/test_product_state.py
+++ b/product_state/tests/test_product_state.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 import logging
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
 
 _logger = logging.getLogger(__name__)
@@ -42,7 +43,6 @@ class TestProductState(SavepointCase):
             self.env.ref("product_state.product_state_sellable"),
             self.product.product_state_id,
         )
-
         self._create_product(self.state)
         self.assertEqual(
             self.state,
@@ -69,3 +69,16 @@ class TestProductState(SavepointCase):
             self.state,
             self.product.product_state_id,
         )
+
+    def test_03_set_constrains_product_state(self):
+        """
+        Create another default state,
+        It should have the existing only one default state at time
+        """
+
+        with self.assertRaises(ValidationError) as cm:
+            self.env["product.state"].create(
+                {"name": "Default State 2", "code": "df2", "default": True}
+            )
+            wn_expect = cm.exception.args[0]
+            self.assertEqual("There should be only one default state", wn_expect)

--- a/product_tier_validation/data/product_state_data.xml
+++ b/product_tier_validation/data/product_state_data.xml
@@ -1,7 +1,4 @@
 <odoo noupdate="1">
-    <record id="product_state.product_state_draft" model="product.state">
-        <field name="code">draft</field>
-    </record>
     <record id="product_state.product_state_sellable" model="product.state">
         <field name="code">confirmed</field>
     </record>


### PR DESCRIPTION
@simahawk suggestion in [issue comment](https://github.com/OCA/product-attribute/pull/925#issuecomment-950631523)
- Add fields, `active`, `default` in `product.state`
- Default `product_state_id` only get records which `default=True`