### PR TITLE
[14.0][FIX] product_manufacture: Keep manufacture information for first variant product creation

### DIFF
--- a/product_manufacturer/models/product_manufacturer.py
+++ b/product_manufacturer/models/product_manufacturer.py
@@ -79,3 +79,24 @@ class ProductTemplate(models.Model):
                 template.product_variant_ids.manufacturer_purl = (
                     template.manufacturer_purl
                 )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Overwrite creation for rewriting manufacturer information (if set and having
+        only one variant), after the variant creation, that is performed in super.
+        """
+        templates = super().create(vals_list)
+        for template, vals in zip(templates, vals_list):
+            if len(template.product_variant_ids) == 1:
+                related_vals = {}
+                if vals.get("manufacturer"):
+                    related_vals["manufacturer"] = vals["manufacturer"]
+                if vals.get("manufacturer_pname"):
+                    related_vals["manufacturer_pname"] = vals["manufacturer_pname"]
+                if vals.get("manufacturer_pref"):
+                    related_vals["manufacturer_pref"] = vals["manufacturer_pref"]
+                if vals.get("manufacturer_purl"):
+                    related_vals["manufacturer_purl"] = vals["manufacturer_purl"]
+                if related_vals:
+                    template.write(related_vals)
+        return templates

--- a/product_manufacturer/tests/test_product_manufacturer.py
+++ b/product_manufacturer/tests/test_product_manufacturer.py
@@ -8,6 +8,7 @@ class TestProductManufacturer(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.manufacturer_a = cls.env["res.partner"].create({"name": "Manufacturer A"})
         cls.manufacturer_b = cls.env["res.partner"].create({"name": "Manufacturer B"})
         cls.attr1 = cls.env["product.attribute"].create({"name": "color"})
@@ -101,4 +102,28 @@ class TestProductManufacturer(SavepointCase):
         self.assertEqual(
             self.product1.product_variant_ids[0].manufacturer_purl,
             "https://www.manufacturerb.com/test_product_b",
+        )
+
+    def test_03_product_manufacturer_creation(self):
+        new_pt = self.env["product.template"].create(
+            {
+                "name": "New Product Template",
+                "manufacturer": self.manufacturer_a.id,
+                "manufacturer_pname": "Test Product A",
+                "manufacturer_pref": "TPA",
+                "manufacturer_purl": "https://www.manufacturera.com/test_product_a",
+            }
+        )
+
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer.id, new_pt.manufacturer.id
+        )
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer_pname, new_pt.manufacturer_pname
+        )
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer_pref, new_pt.manufacturer_pref
+        )
+        self.assertEqual(
+            new_pt.product_variant_id.manufacturer_purl, new_pt.manufacturer_purl
         )


### PR DESCRIPTION
Forward-Port of https://github.com/OCA/product-attribute/pull/930

CC @ForgeFlow @juppe @dreispt 