### PR TITLE
[14.0][IMP] product_tier_validation: Simplify flow

### DIFF
--- a/product_tier_validation/__manifest__.py
+++ b/product_tier_validation/__manifest__.py
@@ -10,7 +10,7 @@
     "license": "AGPL-3",
     "installable": True,
     "maintainers": ["dreispt"],
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "depends": ["product_state", "base_tier_validation"],
     "data": [
         "data/tier_definition.xml",

--- a/product_tier_validation/__manifest__.py
+++ b/product_tier_validation/__manifest__.py
@@ -14,7 +14,6 @@
     "depends": ["product_state", "base_tier_validation"],
     "data": [
         "data/tier_definition.xml",
-        "data/product_state_data.xml",
         "views/product_template_view.xml",
     ],
 }

--- a/product_tier_validation/data/product_state_data.xml
+++ b/product_tier_validation/data/product_state_data.xml
@@ -1,8 +1,0 @@
-<odoo noupdate="1">
-    <record id="product_state.product_state_sellable" model="product.state">
-        <field name="code">confirmed</field>
-    </record>
-    <record id="product_state.product_state_end" model="product.state">
-        <field name="code">cancel</field>
-    </record>
-</odoo>

--- a/product_tier_validation/models/product_template.py
+++ b/product_tier_validation/models/product_template.py
@@ -1,36 +1,10 @@
 # Copyright 2021 Open Source Integrators
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import models
 
 
 class ProductTemplate(models.Model):
     _name = "product.template"
     _inherit = ["product.template", "tier.validation"]
     _tier_validation_manual_config = False
-
-    @api.model
-    def _is_tier_validated_active(self, state_code):
-        return state_code != "draft"
-
-    @api.model
-    def create(self, vals):
-        new = super().create(vals)
-        if new.need_validation and self._is_tier_validated_active(new.state):
-            new.active = False
-        return new
-
-    def write(self, vals):
-        """
-        Default `active` is False.
-        It is set to True when State changes to confirmed.
-        """
-        if "state" in vals:
-            vals["active"] = self._is_tier_validated_active(vals["state"])
-        return super().write(vals)
-
-    @api.model
-    def _get_default_product_state_id(self):
-        return self.env.ref(
-            "product_state.product_state_draft", raise_if_not_found=False
-        )


### PR DESCRIPTION
- [x] Don't modify product 'active' field.
- [x] Don't modify initial states as now, you can archive them to use others.
- [x] Don't get default state as now it is configurable on state level.
- [x] Change to 'Beta'

If we want to manage that, it should be done in combination with https://github.com/OCA/product-attribute/pull/948