### PR TITLE
[FIX] product_packaging_dimension: use integer instead of float

### DIFF
--- a/product_packaging_dimension/migrations/14.0.1.0.0/pre-migrate.py
+++ b/product_packaging_dimension/migrations/14.0.1.0.0/pre-migrate.py
@@ -5,18 +5,9 @@ from odoo.tools.sql import column_exists, rename_column
 
 
 def migrate(cr, version):
-    # Rename lnght into packaging_length
-    if column_exists(cr, "product_packaging", "lnght"):
-        rename_column(cr, "product_packaging", "lnght", "packaging_length")
 
-        # Convert old hard-coded uom values (mm)
-        # into new default uom values (m)
-        cr.execute(
-            """
-        UPDATE product_packaging
-        SET
-        packaging_length = packaging_length/1000,
-        height = height/1000,
-        width = width/1000,
-        """
-        )
+    # Rename lngth into packaging_length
+    if column_exists(cr, "product_packaging", "packaging_length"):
+        cr.execute("UPDATE product_packaging SET packaging_length = lngth")
+    elif column_exists(cr, "product_packaging", "lngth"):
+        rename_column(cr, "product_packaging", "lngth", "packaging_length")

--- a/product_packaging_dimension/models/product_packaging.py
+++ b/product_packaging_dimension/models/product_packaging.py
@@ -10,18 +10,18 @@ class ProductPackaging(models.Model):
     # The redundancy here avoids unnecessary dependencies on sale modules.
 
     _sql_constraints = [
-        ("positive_height", "CHECK(height>=0.0)", "Height must be positive"),
-        ("positive_width", "CHECK(width>=0.0)", "Width must be positive"),
-        ("positive_length", "CHECK(packaging_length>=0.0)", "Length must be positive"),
+        ("positive_height", "CHECK(height>=0)", "Height must be positive"),
+        ("positive_width", "CHECK(width>=0)", "Width must be positive"),
+        ("positive_length", "CHECK(packaging_length>=0)", "Length must be positive"),
         (
             "positive_max_weight",
-            "CHECK(max_weight>=0.0)",
+            "CHECK(max_weight>=0)",
             "Max Weight must be positive",
         ),
     ]
-    height = fields.Float("Height")
-    width = fields.Float("Width")
-    packaging_length = fields.Float("Length")
+    height = fields.Integer("Height")
+    width = fields.Integer("Width")
+    packaging_length = fields.Integer("Length")
 
     length_uom_id = fields.Many2one(
         "uom.uom",

--- a/product_packaging_dimension/tests/test_packaging_volume.py
+++ b/product_packaging_dimension/tests/test_packaging_volume.py
@@ -53,28 +53,28 @@ class TestPackagingVolumeCompute(TransactionCase):
         # initial UoM always in meters and Volume in m3, but with different dimensions.
 
         self.packaging.packaging_length = 10
-        self.packaging.height = 8.0
-        self.packaging.width = 10.8
+        self.packaging.height = 8
+        self.packaging.width = 10
         self.packaging.length_uom_id = self.uom_m
         self.packaging.volume_uom_id = self.uom_m3
         self.packaging._compute_volume()
-        self.assertEqual(864, self.packaging.volume)
+        self.assertEqual(800, self.packaging.volume)
 
         self.packaging2.packaging_length = 6.0
         self.packaging2.height = 14.0
-        self.packaging2.width = 1.2
+        self.packaging2.width = 1.0
         self.packaging2.length_uom_id = self.uom_m
         self.packaging2.volume_uom_id = self.uom_m3
         self.packaging2._compute_volume()
-        self.assertAlmostEqual(100.8, self.packaging2.volume)
+        self.assertEqual(84.0, self.packaging2.volume)
 
         self.packaging3.packaging_length = 100.0
-        self.packaging3.height = 50.5
-        self.packaging3.width = 80.0
+        self.packaging3.height = 50
+        self.packaging3.width = 80
         self.packaging3.length_uom_id = self.uom_m
         self.packaging3.volume_uom_id = self.uom_m3
         self.packaging3._compute_volume()
-        self.assertEqual(404000, self.packaging3.volume)
+        self.assertEqual(400000, self.packaging3.volume)
 
     def test_output_uom(self):
         # Tests with both different initial and volume UoMs.


### PR DESCRIPTION
set same field type as defined in core to be compatible with other addons as this field is used all over stock management stack
fix migration step
remove fields converting - idea is that previously value was stored in mm and customer wants to keep this measure in mm, we cannot set length_uom_id to mm as they defined in "stock_measuring_device" addon which is not mandatory installed so update of this field need to be handled by the customer separately 