### PR TITLE
[14.0][IMP] product_tier_validation: get default from product_state

### DIFF
--- a/product_tier_validation/data/product_state_data.xml
+++ b/product_tier_validation/data/product_state_data.xml
@@ -1,8 +1,21 @@
 <odoo noupdate="1">
-    <record id="product_state.product_state_sellable" model="product.state">
-        <field name="code">confirmed</field>
-    </record>
-    <record id="product_state.product_state_end" model="product.state">
+    <record id="product_state_cancel" model="product.state">
         <field name="code">cancel</field>
+        <field name="name">Cancelled</field>
+        <field name="sequence">50</field>
     </record>
+
+    <function name="write" model="product.state">
+        <function name="search" model="product.state">
+            <value eval="[('default', '=', True), ('active', 'in', [False, True])]" />
+        </function>
+        <value eval="{'default': False}" />
+    </function>
+
+    <function name="write" model="product.state">
+        <function name="search" model="product.state">
+            <value eval="[('code', '=', 'draft'), ('active', 'in', [False, True])]" />
+        </function>
+        <value eval="{'active': True, 'default': True}" />
+    </function>
 </odoo>

--- a/product_tier_validation/models/product_template.py
+++ b/product_tier_validation/models/product_template.py
@@ -28,9 +28,3 @@ class ProductTemplate(models.Model):
         if "state" in vals:
             vals["active"] = self._is_tier_validated_active(vals["state"])
         return super().write(vals)
-
-    @api.model
-    def _get_default_product_state_id(self):
-        return self.env.ref(
-            "product_state.product_state_draft", raise_if_not_found=False
-        )

--- a/product_tier_validation/tests/test_product_tier_validation.py
+++ b/product_tier_validation/tests/test_product_tier_validation.py
@@ -34,6 +34,7 @@ class TestProductTierValidation(common.SavepointCase):
                 "list_price": 120.00,
             }
         )
+        self.assertEqual(product.state, "draft")
         product.request_validation()
         product.with_user(self.test_user_1).validate_tier()
         product.write({"product_state_id": self.normal_state.id})


### PR DESCRIPTION
- With updated product_state, default state can be get instead of hard code.
- The code `confirmed` does not match with state name `Sellable`. It
  does little value in code. So it can be removed to avoid failure in
  tests of other modules.