### PR TITLE
[14.0][IMP] product_code_unique: Allow to inactivate products with same code

### DIFF
--- a/product_code_unique/models/product.py
+++ b/product_code_unique/models/product.py
@@ -10,7 +10,7 @@ class ProductProduct(models.Model):
     _sql_constraints = [
         (
             "default_code_uniq",
-            "unique(default_code)",
+            "EXCLUDE (default_code WITH =) WHERE (active = True)",
             "Internal Reference must be unique across the database!",
         )
     ]


### PR DESCRIPTION
For reason X or Y (e.g. wrong unit of measure), it would be convenient to archive a product and create a new one with same default_code.