### PR TITLE
[FIX] product_pricelist_supplierinfo: override min quantity

### DIFF
--- a/product_pricelist_supplierinfo/models/product_product.py
+++ b/product_pricelist_supplierinfo/models/product_product.py
@@ -9,6 +9,17 @@ from odoo import models
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
+    def _prepare_sellers(self, params):
+        """When we override min qty we want that _select_sellers gives us the
+        first possible seller for every other criteria ignoring the quantity. As
+        supplierinfos are sorted by min_qty descending, we want to revert such
+        order so we get the very first one, which is probably the one to go.
+        """
+        sellers = super()._prepare_sellers(params)
+        if self.env.context.get("override_min_qty"):
+            sellers = sellers.sorted("min_qty")
+        return sellers
+
     def _get_supplierinfo_pricelist_price(
             self, rule, date=None, quantity=None):
         return self.product_tmpl_id._get_supplierinfo_pricelist_price(

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -19,13 +19,17 @@ class ProductTemplate(models.Model):
         if product_id:
             product = product.browse(product_id)
         if rule.no_supplierinfo_min_quantity:
-            quantity = 1.0
+            # No matter which minimum qty, we'll get every seller. We set a
+            # number absurdidly high
+            quantity = 1e9
         # The product_variant_id returns empty recordset if template is not
         # active, so we must ensure variant exists or _select_seller fails.
         if product:
             if type(date) == datetime:
                 date = date.date()
-            seller = product._select_seller(
+            seller = product.with_context(
+                override_min_qty=rule.no_supplierinfo_min_quantity
+            )._select_seller(
                 # For a public user this record could be not accessible, but we
                 # need to get the price anyway
                 partner_id=rule.sudo().filter_supplier_id,


### PR DESCRIPTION
If we don't have a supplierinfo that below 1 unit we won't get any
seller. We want to ensure that the condition is fully ignored to get
whatever price given the other criterias.

cc @Tecnativa TT33659

What do you think @pedrobaeza ?

ping @sergio-teruel @carlosdauden 