### PR TITLE
[FIX] product_dimension: Always make dimensions visible in product.product

### DIFF
--- a/product_dimension/views/product_view.xml
+++ b/product_dimension/views/product_view.xml
@@ -7,7 +7,8 @@
       <field name="inherit_id" ref="product.product_normal_form_view"/>
       <field name="arch" type="xml">
         <xpath expr="//group[@name='inventory']" position="inside">
-          <group name="dimensions" string="Dimensions">
+          <group name="dimensions" string="Dimensions"
+                attrs="{'invisible': False}">
             <field name="dimensional_uom_id"/>
             <field name="product_length" string="Length"/>
             <field name="product_height" string="Height"/>


### PR DESCRIPTION
For reasons that are a little beyond me, dimensions are not visible on product variants. Explicitly setting invisible as false makes them visible.

There probably is a better way to do this.

Although I have only tested this against 12.0, a quick glance at 14.0 shows that the issue might exist on that branch as well.