### PR TITLE
[13.0][ADD]product_attribute_value_menu

### DIFF
--- a/product_attribute_value_menu/__manifest__.py
+++ b/product_attribute_value_menu/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 ForgeFlow
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Product Attribute Value Menu",
+    "summary": """
+        Add a menu item containing the Attribute Values
+        """,
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "ForgeFlow,Odoo Community Association (OCA)",
+    "depends": ["sale", "stock"],
+    "data": ["views/product_attribute_value.xml"],
+    "website": "https://github.com/OCA/product-attribute",
+}

--- a/product_attribute_value_menu/readme/CONTRIBUTORS.rst
+++ b/product_attribute_value_menu/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/product_attribute_value_menu/readme/DESCRIPTION.rst
+++ b/product_attribute_value_menu/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module adds a new menu item on the Sales and Inventory Applications. This menu item
+with name *Attribute Values* it's located under the *Attributes*' one.
+
+The new menu item contains all the Attribute Values on a tree view, having the attribute
+associated with a link and the value.

--- a/product_attribute_value_menu/readme/USAGE.rst
+++ b/product_attribute_value_menu/readme/USAGE.rst
@@ -1,0 +1,1 @@
+To acces the new view, simply go to Sales/Inventory > Configuration > Attribute Values.

--- a/product_attribute_value_menu/views/product_attribute_value.xml
+++ b/product_attribute_value_menu/views/product_attribute_value.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_attribute_value_tree_view" model="ir.ui.view">
+        <field name="name">product.attribute.value.tree</field>
+        <field name="model">product.attribute.value</field>
+        <field name="arch" type="xml">
+            <tree string="Attribute Values">
+                <field name="attribute_id" widget="many2one" />
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="product_attribute_value_search_view" model="ir.ui.view">
+        <field name="name">product.attribute.value.search</field>
+        <field name="model">product.attribute.value</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="attribute_id" />
+                <group expand="1" string="Group By">
+                    <filter
+                        string="Attribute"
+                        name="attribute"
+                        context="{'group_by':'attribute_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <act_window
+        id="attribute_value_action"
+        name="Attributes Values"
+        res_model="product.attribute.value"
+        view_mode="tree"
+    />
+
+    <menuitem
+        id="sale_menu_product_archived_attribute_action"
+        action="attribute_value_action"
+        parent="sale.prod_config_main"
+        groups="product.group_product_variant"
+        sequence="2"
+    />
+
+    <menuitem
+        id="stock_menu_product_archived_attribute_action"
+        action="attribute_value_action"
+        parent="stock.menu_product_in_config_stock"
+        sequence="4"
+        groups="product.group_product_variant"
+    />
+
+</odoo>

--- a/setup/product_attribute_value_menu/odoo/addons/product_attribute_value_menu
+++ b/setup/product_attribute_value_menu/odoo/addons/product_attribute_value_menu
@@ -1,0 +1,1 @@
+../../../../product_attribute_value_menu

--- a/setup/product_attribute_value_menu/setup.py
+++ b/setup/product_attribute_value_menu/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This new module it's based on this https://github.com/OCA/product-attribute/pull/984 which was proposing an improvement to the product_attribute_archive module. Instead, i'ts now a separate module which adds a **Attribute Values** menu item and tree view.
@ForgeFlow @JordiMForgeFlow @AaronHForgeFlow 
