### PR TITLE
[IMP]product_attribute_archive: Add active field on the Attribute Values tree view

### DIFF
--- a/product_attribute_archive/__manifest__.py
+++ b/product_attribute_archive/__manifest__.py
@@ -8,7 +8,7 @@
     "version": "13.0.1.0.1",
     "license": "AGPL-3",
     "author": "Akretion,Odoo Community Association (OCA)",
-    "depends": ["product"],
-    "data": ["views/product_attribute.xml"],
+    "depends": ["product", "product_attribute_value_menu"],
+    "data": ["views/product_attribute.xml", "views/product_attribute_value.xml"],
     "website": "https://github.com/OCA/product-attribute",
 }

--- a/product_attribute_archive/readme/CONTRIBUTORS.rst
+++ b/product_attribute_archive/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Kevin Khao <kevin.khao@akretion.com>
+* Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/product_attribute_archive/views/product_attribute_value.xml
+++ b/product_attribute_archive/views/product_attribute_value.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_attribute_value_tree_view" model="ir.ui.view">
+        <field
+            name="name"
+        >product.attribute.value.tree - product_attribute_archive</field>
+        <field name="model">product.attribute.value</field>
+        <field
+            name="inherit_id"
+            ref="product_attribute_value_menu.product_attribute_value_tree_view"
+        />
+        <field name="arch" type="xml">
+            <tree string="Attribute Values">
+                <field name="active" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="product_attribute_value_search_view" model="ir.ui.view">
+        <field
+            name="name"
+        >product.attribute.value.search - product_attribute_archive</field>
+        <field name="model">product.attribute.value</field>
+        <field
+            name="inherit_id"
+            ref="product_attribute_value_menu.product_attribute_value_search_view"
+        />
+        <field name="arch" type="xml">
+            <field name="attribute_id" position="after">
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active', '=', False)]"
+                />
+            </field>
+        </field>
+
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module extends the tree view of **Attribute Values**, adding an active field. It's related to this PR: https://github.com/OCA/product-attribute/pull/997
@ForgeFlow