### PR TITLE
[13.0][IMP] stock_account_product_cost_security: improved security

### DIFF
--- a/stock_account_product_cost_security/__init__.py
+++ b/stock_account_product_cost_security/__init__.py
@@ -1,1 +1,2 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import models

--- a/stock_account_product_cost_security/models/__init__.py
+++ b/stock_account_product_cost_security/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/stock_account_product_cost_security/models/product_template.py
+++ b/stock_account_product_cost_security/models/product_template.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    show_update_cost = fields.Boolean(compute="_compute_show_update_cost")
+
+    def _compute_show_update_cost(self):
+        """A user could have full cost permissions but no product edition permissions.
+        We want to prevent those from updating costs."""
+        for product in self:
+            product.show_update_cost = self.check_access_rights(
+                "write", raise_exception=False
+            )

--- a/stock_account_product_cost_security/views/product_views.xml
+++ b/stock_account_product_cost_security/views/product_views.xml
@@ -19,11 +19,17 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock_account.view_template_property_form" />
         <field name="arch" type="xml">
+            <field name="list_price" position="after">
+                <field name="show_update_cost" invisible="1" />
+            </field>
             <!-- To hide button that opens wizard to update standard price , new in v13.0 -->
             <xpath expr="//span[@name='update_cost_price']" position="attributes">
                 <attribute
                     name="groups"
                 >product_cost_security.group_product_cost</attribute>
+                <attribute
+                    name="attrs"
+                >{'invisible': [('show_update_cost', '=', False)]}</attribute>
             </xpath>
         </field>
     </record>

--- a/stock_account_product_cost_security/views/product_views.xml
+++ b/stock_account_product_cost_security/views/product_views.xml
@@ -15,4 +15,16 @@
             </xpath>
         </field>
     </record>
+    <record id="view_template_property_form" model="ir.ui.view">
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="stock_account.view_template_property_form" />
+        <field name="arch" type="xml">
+            <!-- To hide button that opens wizard to update standard price , new in v13.0 -->
+            <xpath expr="//span[@name='update_cost_price']" position="attributes">
+                <attribute
+                    name="groups"
+                >product_cost_security.group_product_cost</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
- Fixed product.template view. It was possible to edit costs without the proper permission.
- Users without product write privileges won't be able to update costs although they have the full cost permission.

cc @Tecnativa TT33932

please review @sergio-teruel @pedrobaeza 


edit: finally, no intermediate group 