### PR TITLE
[14.0][FIX] product_status: status bar not clickable

### DIFF
--- a/product_status/__manifest__.py
+++ b/product_status/__manifest__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "depends": ["product", "product_state"],
     "data": [
+        "data/ir_cron.xml",
         "data/function_deactive_default_product_state_data.xml",
         "data/product_state_data.xml",
         "views/product_views.xml",

--- a/product_status/data/ir_cron.xml
+++ b/product_status/data/ir_cron.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+  <record model="ir.cron" id="cron_recompute_product_state">
+    <field name='name'>Recompute Product State</field>
+    <field name='interval_number'>1</field>
+    <field name='interval_type'>days</field>
+    <field name="numbercall">-1</field>
+    <field name="active" eval="True" />
+    <field name="doall" eval="False" />
+    <field
+            name="nextcall"
+            eval="(datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d 00:00:00')"
+        />
+    <field name="model_id" ref="product_status.model_product_state" />
+    <field name="state">code</field>
+    <field name="code">model._cron_recompute_product_state()</field>
+  </record>
+
+</odoo>

--- a/product_status/models/product_state.py
+++ b/product_status/models/product_state.py
@@ -1,8 +1,9 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.osv import expression
 
 
 class ProductState(models.Model):
@@ -30,3 +31,50 @@ class ProductState(models.Model):
     def _get_module_data(self):
         code = ["new", "discontinued", "phaseout", "endoflife"]
         return self.env["product.state"].search([("code", "in", code)])
+
+    @api.model
+    def _domain_recompute_product_state(self):
+        today = fields.Date.today()
+        return expression.OR(
+            [
+                # get 'phaseout' products that should be updated to 'endoflife'
+                [
+                    ("end_of_life_date", "!=", False),
+                    ("end_of_life_date", "<", today),
+                    ("state", "=", "phaseout"),
+                ],
+                # discontinued
+                [
+                    ("discontinued_until", "!=", False),
+                    ("discontinued_until", "<", today),
+                    ("state", "=", "discontinued"),
+                ],
+                # get products that aren't 'new' anymore
+                [
+                    ("new_until", "!=", False),
+                    ("new_until", "<", today),
+                    ("state", "=", "new"),
+                ],
+            ]
+        )
+
+    @api.model
+    def _get_products_recompute_product_state(self):
+        domain = self._domain_recompute_product_state()
+        templates = (
+            self.env["product.template"].with_context(active_test=False).search(domain)
+        )
+        variants = (
+            self.env["product.product"].with_context(active_test=False).search(domain)
+        )
+        return templates, variants
+
+    @api.model
+    def _cron_recompute_product_state(self):
+        """Recompute the state of products."""
+        templates, variants = self._get_products_recompute_product_state()
+        for template in templates:
+            template._check_dates_of_states(template)
+        for variant in variants:
+            variant.product_tmpl_id._check_dates_of_states(variant)
+        return bool(templates or variants)

--- a/product_status/tests/test_product_status.py
+++ b/product_status/tests/test_product_status.py
@@ -18,6 +18,7 @@ class TestProductStatusCase(TestProductCommon):
         cls.product2 = cls.env.ref("product.product_product_4b")
         # To avoid error with filestore and Form test
         cls.product.image_1920 = False
+        cls.state_model = cls.env["product.state"]
 
     def test_default(self):
         self.assertEqual(self.product.product_state_id.code, "sellable")
@@ -145,3 +146,51 @@ class TestProductStatusCase(TestProductCommon):
             self.assertTrue(current_default_state.write(vals))
         new_state = st_env.create({"name": "New State", "code": "new_state"})
         new_state.unlink()
+
+    def test_cron_recompute_product_state_endoflife(self):
+        self.product.end_of_life_date = "2020-09-15"
+        # compute the value and put it in cache so it's not recomputed
+        # automatically afterwards
+        self.product.state  # pylint: disable=pointless-statement
+        # starting point, the product hasn't passed its end of life date
+        with freeze_time("2020-09-15"):
+            self.product.product_tmpl_id._check_dates_of_states(self.product)
+            self.assertEqual(self.product.state, "phaseout")
+        # the next day the product is now flagged 'endoflife'
+        with freeze_time("2020-09-16"):
+            __, variants = self.state_model._get_products_recompute_product_state()
+            self.assertIn(self.product, variants)
+            self.state_model._cron_recompute_product_state()
+            self.assertEqual(self.product.state, "endoflife")
+
+    def test_cron_recompute_product_state_discontinued(self):
+        self.product.discontinued_until = "2020-09-15"
+        # compute the value and put it in cache so it's not recomputed
+        # automatically afterwards
+        self.product.state  # pylint: disable=pointless-statement
+        # starting point, the product is flagged as 'discontinued'
+        with freeze_time("2020-09-15"):
+            self.product.product_tmpl_id._check_dates_of_states(self.product)
+            self.assertEqual(self.product.state, "discontinued")
+        # the next day the product isn't discontinued anymore
+        with freeze_time("2020-09-16"):
+            __, variants = self.state_model._get_products_recompute_product_state()
+            self.assertIn(self.product, variants)
+            self.state_model._cron_recompute_product_state()
+            self.assertEqual(self.product.state, "sellable")
+
+    def test_cron_recompute_product_state_new(self):
+        self.product.new_until = "2020-09-15"
+        # compute the value and put it in cache so it's not recomputed
+        # automatically afterwards
+        self.product.state  # pylint: disable=pointless-statement
+        # starting point, the product is flagged as 'new'
+        with freeze_time("2020-09-15"):
+            self.product.product_tmpl_id._check_dates_of_states(self.product)
+            self.assertEqual(self.product.state, "new")
+        # the next day the product isn't new anymore
+        with freeze_time("2020-09-16"):
+            __, variants = self.state_model._get_products_recompute_product_state()
+            self.assertIn(self.product, variants)
+            self.state_model._cron_recompute_product_state()
+            self.assertEqual(self.product.state, "sellable")

--- a/product_status/views/product_views.xml
+++ b/product_status/views/product_views.xml
@@ -84,4 +84,16 @@
     </field>
   </record>
 
+  <record id="product_template_form_view" model="ir.ui.view">
+    <field name="name">product.template.form.inherit</field>
+    <field name="model">product.template</field>
+    <field name="inherit_id" ref="product_state.product_template_form_view" />
+    <field name="arch" type="xml">
+      <field name="product_state_id" position="attributes">
+        <!-- State cannot anymore be changed manually through the statusbar -->
+        <attribute name="options">{'clickable': 0}</attribute>
+      </field>
+    </field>
+  </record>
+
 </odoo>


### PR DESCRIPTION
As the state is computed with  `product_status`.

**TODO:**
- [x] as the computation of the state is based on some dates, having it stored won't refresh its value automatically. We need a daily cron to check this.