### PR TITLE
[FIX] product_supplierinfo_for_customer: new line removes product and variant in old ones, fixes #986

### DIFF
--- a/product_supplierinfo_for_customer/models/product_customerinfo.py
+++ b/product_supplierinfo_for_customer/models/product_customerinfo.py
@@ -11,6 +11,15 @@ class ProductCustomerInfo(models.Model):
 
     name = fields.Many2one(string="Customer", help="Customer of this product")
 
+    def onchange(self, values, field_name, field_onchange):
+        if "product_tmpl_id" in values and field_name != "product_tmpl_id":
+            values.pop(
+                "product_tmpl_id", None
+            )  # otherwise it will be removed from the defaults
+        return super(ProductCustomerInfo, self).onchange(
+            values, field_name, field_onchange
+        )
+
     @api.model
     def get_import_templates(self):
         return [

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -68,6 +68,7 @@
             </form>
         </field>
     </record>
+
     <record id="product_customerinfo_tree_view" model="ir.ui.view">
         <field name="name">product.customerinfo.tree.view</field>
         <field name="model">product.customerinfo</field>
@@ -75,15 +76,12 @@
             <tree string="Customer Information">
                 <field name="sequence" widget="handle" />
                 <field name="name" string="Customer" />
+                <field name="product_tmpl_id" string="Product" />
                 <field
                     name="product_id"
-                    invisible="context.get('product_template_invisible_variant', False)"
                     groups="product.group_product_variant"
-                />
-                <field
-                    name="product_tmpl_id"
-                    string="Product"
-                    invisible="context.get('visible_product_tmpl_id', True)"
+                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"
+                    optional="hide"
                 />
                 <field name="product_name" string="Customer Product Name" />
                 <field name="product_code" string="Customer Product Code" />
@@ -99,10 +97,44 @@
             </tree>
         </field>
     </record>
+
+    <record id="product_customerinfo_editable_view_tree" model="ir.ui.view">
+        <field name="model">product.customerinfo</field>
+        <field
+            name="inherit_id"
+            ref="product_supplierinfo_for_customer.product_customerinfo_tree_view"
+        />
+        <field name="mode">primary</field>
+        <field name="priority" eval="1000" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="editable">bottom</attribute>
+            </xpath>
+            <field name="product_tmpl_id" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_customerinfo_editable_variant_view_tree" model="ir.ui.view">
+        <field name="model">product.customerinfo</field>
+        <field
+            name="inherit_id"
+            ref="product_supplierinfo_for_customer.product_customerinfo_editable_view_tree"
+        />
+        <field name="mode">primary</field>
+        <field name="priority" eval="1000" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="attributes">
+                <attribute name="optional">show</attribute>
+            </field>
+        </field>
+    </record>
+
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.common.form</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="after">
                 <separator string="Customers" />
@@ -111,17 +143,48 @@
                     nolabel="1"
                     context="{
                            'default_product_tmpl_id': context.get('product_tmpl_id',active_id),
-                           'product_template_invisible_variant': True,
+                           'tree_view_ref':'product_supplierinfo_for_customer.product_customerinfo_editable_view_tree'
                        }"
-                    attrs="{'invisible': [('product_variant_count','&gt;',1)]}"
+                    attrs="{'invisible': [('product_variant_count','&gt;',1)], 'readonly': [('product_variant_count','&gt;',1)]}"
                 />
                 <field
                     name="variant_customer_ids"
                     nolabel="1"
                     context="{
                             'default_product_tmpl_id': context.get('product_tmpl_id',active_id),
+                            'tree_view_ref':'product_supplierinfo_for_customer.product_customerinfo_editable_variant_view_tree'
                         }"
-                    attrs="{'invisible': [('product_variant_count','&lt;=',1)]}"
+                    attrs="{'invisible': [('product_variant_count','&lt;=',1)], 'readonly': [('product_variant_count','&lt;=',1)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_product_form_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales']/group[@name='sale']" position="after">
+                <separator string="Customers" />
+                <field
+                    name="customer_ids"
+                    nolabel="1"
+                    context="{
+                           'default_product_tmpl_id': context.get('product_tmpl_id',active_id),
+                           'default_product_id': active_id,
+                           'tree_view_ref':'product_supplierinfo_for_customer.product_customerinfo_editable_view_tree'
+                       }"
+                    attrs="{'invisible': [('product_variant_count','&gt;',1)], 'readonly': [('product_variant_count','&gt;',1)]}"
+                />
+                <field
+                    name="variant_customer_ids"
+                    nolabel="1"
+                    context="{
+                            'default_product_tmpl_id': context.get('product_tmpl_id',active_id),
+                            'default_product_id': active_id,
+                            'tree_view_ref':'product_supplierinfo_for_customer.product_customerinfo_editable_variant_view_tree'
+                        }"
+                    attrs="{'invisible': [('product_variant_count','&lt;=',1)], 'readonly': [('product_variant_count','&lt;=',1)]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Includes changes in #987

The problem is when you add a new customerinfo in a product variant, when there already are defined ones.