### PR TITLE
[12.0][FIX] product_lot_sequence: Avoid generate extra sequences on duplicates

### DIFF
--- a/product_lot_sequence/models/product.py
+++ b/product_lot_sequence/models/product.py
@@ -86,11 +86,14 @@ class ProductTemplate(models.Model):
         for template in self:
             tracking = vals.get("tracking", False) or template.tracking
             if tracking in ["lot", "serial"]:
-                if not vals.get("lot_sequence_id", False):
+                if (
+                    not vals.get("lot_sequence_id", False)
+                    and not template.lot_sequence_id
+                ):
                     vals["lot_sequence_id"] = (
                         template.sudo()._create_lot_sequence(vals).id
                     )
-                else:
+                elif vals.get("lot_sequence_id", False):
                     lot_sequence_id = self.env["ir.sequence"].browse(
                         vals["lot_sequence_id"]
                     )


### PR DESCRIPTION
A weird behavior of this module is that anytime you update a product template field the write method generate a new ir.sequence because it does not check if an lot_sequence_id is already set on the template.

This fix aims to avoid this duplicates, it is more like a patch because in my opinion lot_sequence generation has to be moved outside write and create method

CC @ForgeFlow 