### PR TITLE
[13.0][FIX] stock_account_product_cost_security: Align view groups with Odoo core

### DIFF
--- a/stock_account_product_cost_security/views/product_views.xml
+++ b/stock_account_product_cost_security/views/product_views.xml
@@ -6,6 +6,7 @@
             name="inherit_id"
             ref="stock_account.product_variant_easy_edit_view_inherit"
         />
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]" />
         <field name="arch" type="xml">
             <!-- To hide button that opens wizard to update standard price , new in v13.0 -->
             <xpath expr="//div[@name='update_cost_price']" position="attributes">
@@ -18,6 +19,7 @@
     <record id="view_template_property_form" model="ir.ui.view">
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock_account.view_template_property_form" />
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]" />
         <field name="arch" type="xml">
             <field name="list_price" position="after">
                 <field name="show_update_cost" invisible="1" />


### PR DESCRIPTION
Due to https://github.com/odoo/odoo/commit/4289887496a155bc863f1e26bbec5c2cbb8c451c it is required to add stock manager group to those views.

CC @ForgeFlow

Fast track it: @pedrobaeza @sergio-teruel 