### PR TITLE
[14.0] [IMP] `base_product_mass_addition`: avoid writing on product's metadata + add tests

### DIFF
--- a/base_product_mass_addition/readme/CONTRIBUTORS.rst
+++ b/base_product_mass_addition/readme/CONTRIBUTORS.rst
@@ -5,3 +5,6 @@ Akretion
 * Pierrick Brun <pierrick.brun@akretion.com>
 * David Béal <david.beal@akretion.com>
 * Kevin Khao <kevin.khao@akretion.com>
+* `Camptocamp <https://www.camptocamp.com>`_
+
+    * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/base_product_mass_addition/tests/__init__.py
+++ b/base_product_mass_addition/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_mass_addition

--- a/base_product_mass_addition/tests/models/order.py
+++ b/base_product_mass_addition/tests/models/order.py
@@ -1,0 +1,36 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ModelOrder(models.Model):
+    _name = "model.order"
+    _description = "Test Model Order (base_product_mass_addition)"
+    _inherit = "product.mass.addition"
+
+    line_ids = fields.One2many("model.order.line", "order_id")
+
+    def _get_quick_line(self, product):
+        return fields.first(
+            self.line_ids.filtered(lambda rec: rec.product_id == product)
+        )
+
+    def _get_quick_line_qty_vals(self, product):
+        return {"product_qty": product.qty_to_process}
+
+    def _complete_quick_line_vals(self, vals, lines_key=""):
+        return super()._complete_quick_line_vals(vals, lines_key="line_ids")
+
+    def _add_quick_line(self, product, lines_key=""):
+        return super()._add_quick_line(product, lines_key="line_ids")
+
+
+class ModelOrderLine(models.Model):
+    _name = "model.order.line"
+    _description = "Test Model Order Line (base_product_mass_addition)"
+
+    order_id = fields.Many2one("model.order")
+    product_id = fields.Many2one("product.product")
+    product_qty = fields.Float()

--- a/base_product_mass_addition/tests/test_product_mass_addition.py
+++ b/base_product_mass_addition/tests/test_product_mass_addition.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo_test_helper import FakeModelLoader
+
+from odoo.tests.common import SavepointCase
+
+
+class TestProductMassAddition(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Setup Fake Models
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .models.order import ModelOrder, ModelOrderLine
+
+        cls.loader.update_registry((ModelOrder, ModelOrderLine))
+
+        # Setup data
+        cls.order = cls.env["model.order"].create({})
+        cls.quick_ctx = dict(parent_model=cls.order._name, parent_id=cls.order.id)
+        cls.product = cls.env.ref("product.product_product_8").with_context(
+            **cls.quick_ctx
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
+
+    def test_quick_line_add(self):
+        """Test quick lines are added, updated and removed"""
+        # Case 1: Create new line
+        self.assertFalse(self.order.line_ids)
+        self.product.qty_to_process = 5.0
+        self.assertEqual(len(self.order.line_ids), 1, "A new line should be created")
+        self.assertAlmostEqual(self.order.line_ids.product_qty, 5.0)
+        # Case 2: Update existing line
+        self.product.qty_to_process = 2.0
+        self.assertEqual(len(self.order.line_ids), 1)
+        self.assertAlmostEqual(self.order.line_ids.product_qty, 2.0)
+        # Case 3: Set to 0 should remove the line
+        self.product.qty_to_process = 0.0
+        self.assertFalse(self.order.line_ids)
+
+    def test_quick_should_not_write_on_product(self):
+        """Using quick magic fields shouldn't write on product's metadata"""
+        user_demo = self.env.ref("base.user_demo")
+        self.product.write_uid = user_demo
+        self.env["base"].flush()
+        self.assertEqual(self.product.write_uid, user_demo)
+        # Case 1: Updating qty_to_process shouldn't write on products
+        self.product.qty_to_process = 1.0
+        self.env["base"].flush()
+        self.assertEqual(self.product.write_uid, user_demo)
+        # Case 2: Updating other fields should still work
+        self.product.name = "Testing"
+        self.env["base"].flush()
+        self.assertEqual(self.product.write_uid, self.env.user)


### PR DESCRIPTION
Supress `LOG_ACCESS_COLUMNS` writes if we're only writing on quick magic fields, as they could lead to concurrency issues.

Moreover, from a functional perspective, these magic fields aren't really modifying the product's data so it doesn't make sense to update its metadata.

We achieve it by reverting the changes made by ``write`` [^1], before [^2] reaching any explicit flush [^3] or inverse computation [^4].

[^1]: https://github.com/odoo/odoo/blob/f74434c6f/odoo/models.py#L3652-L3663
[^2]: https://github.com/odoo/odoo/blob/f74434c6f/odoo/models.py#L3686
[^3]: https://github.com/odoo/odoo/blob/f74434c6f/odoo/models.py#L3689
[^4]: https://github.com/odoo/odoo/blob/f74434c6f/odoo/models.py#L3703

Basically, if all we're modifying are quick magic fields, and we don't have any other column to flush besides the `LOG_ACCESS_COLUMNS`, clear it.