### PR TITLE
[14.0][FIX] product_stock_state : product_template_view

### DIFF
--- a/product_stock_state/views/product_template_view.xml
+++ b/product_stock_state/views/product_template_view.xml
@@ -4,10 +4,12 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
-            <field name="route_ids" position="before">
-                <field name="stock_state_threshold" />
-                <field name="manual_stock_state_threshold" class="oe_edit_only" />
-            </field>
+            <xpath expr="//group[@name='group_lots_and_weight']" position="after">
+                <group name="treshold" string="Stock Threshold">
+                    <field name="stock_state_threshold" />
+                    <field name="manual_stock_state_threshold" class="oe_edit_only" />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Fix missing labels in product_template_view for "stock_state_threshold" and "manual_stock_state_threshold".
cc @sebastienbeau , @legalsylvain , @simahawk 

Before fix : 
![2022-04-27_18-34](https://user-images.githubusercontent.com/75080572/165578933-baa5c129-0675-4cf9-8315-99e55abd28ea.png)

After fix : 
![2022-04-27_18-39_1](https://user-images.githubusercontent.com/75080572/165578986-bcc3a22b-9db3-47cc-a003-88c7e9ef0676.png)



