### PR TITLE
[IMP] product_tier_validation (Change product state to use stage state field)

### DIFF
--- a/product_tier_validation/__manifest__.py
+++ b/product_tier_validation/__manifest__.py
@@ -14,6 +14,7 @@
     "depends": ["product_state", "base_tier_validation"],
     "data": [
         "data/tier_definition.xml",
+        "views/product_state_view.xml",
         "views/product_template_view.xml",
     ],
 }

--- a/product_tier_validation/models/__init__.py
+++ b/product_tier_validation/models/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Open Source Integrators
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import product_state
 from . import product_template
 from . import tier_definition

--- a/product_tier_validation/models/product_state.py
+++ b/product_tier_validation/models/product_state.py
@@ -1,0 +1,17 @@
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ProductState(models.Model):
+    _inherit = "product.state"
+
+    state = fields.Selection(
+        [("draft", "To Approve"), ("confirmed", "Approved"), ("cancel", "Archived")],
+        string="Related State",
+        default="confirmed",
+        help="""Tier validation uses specific states (To and From) to trigger
+              validation needs. Since the Code field is a unique and user defined
+              field, this state field provides the states used for valdiation.""",
+    )

--- a/product_tier_validation/models/product_template.py
+++ b/product_tier_validation/models/product_template.py
@@ -1,22 +1,77 @@
 # Copyright 2021 Open Source Integrators
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 
 class ProductTemplate(models.Model):
     _name = "product.template"
     _inherit = ["product.template", "tier.validation"]
+    _state_from = ["draft", "cancel"]
+    _state_to = ["confirmed"]
     _tier_validation_manual_config = False
+
+    @api.depends("product_state_id")
+    def _compute_product_state(self):
+        # This module is incompatible with product_status so if its installed,
+        # use its method. Otherwise update by state and not code.
+        product_status_module = self.env["ir.module.module"].search(
+            [["name", "=", "product_status"]]
+        )
+        for product_tmpl in self:
+            if product_status_module and product_status_module.state == "installed":
+                self._check_dates_of_states(product_tmpl)
+            else:
+                product_tmpl.state = product_tmpl.product_state_id.state
+
+    @api.model
+    def _set_product_state_id(self, record):
+        # Overrides product state method since tier validation needs to look at state.
+        # Backwards compatibility is built in else to satisfy other module unit tests.
+        # This method can be called by variant so the record is either
+        # product.template or product.product
+        # The record param is for similar state field at product.product model.
+        ProductState = record.env["product.state"]
+        if record.state in ["draft", "confirmed", "cancel"]:
+            product_state = ProductState.search([("state", "=", record.state)], limit=1)
+            if not product_state:
+                msg = _("The product state %s could not be found.")
+                raise UserError(msg % record.state)
+            if product_state.state != record.state:
+                record.product_state_id = product_state.id
+        else:
+            product_state = ProductState.search([("code", "=", record.state)], limit=1)
+            if record.state and not product_state:
+                msg = _("The product state code %s could not be found.")
+                raise UserError(msg % record.state)
+            record.product_state_id = product_state.id
 
     def write(self, vals):
         # Tier Validation does not work with Stages, only States :-(
         # So, signal state transition by adding it to the vals
+        # This module is incompatible with product_status so if its installed,
+        # update state with code and not the state on the stage.
         if "product_state_id" in vals:
             stage_id = vals.get("product_state_id")
             stage = self.env["product.state"].browse(stage_id)
-            vals["state"] = stage.code  # yes, "code" is used to represent a "state"
+            product_status_module = self.env["ir.module.module"].sudo().search(
+                [("name", "=", "product_status")]
+            )
+            if (
+                stage.state in self._state_from
+                or stage.state in self._state_to
+                and not product_status_module
+                or product_status_module.state != "installed"
+                and stage.state != self.state
+            ):
+                vals["state"] = stage.state
+            elif stage.code != self.state:
+                vals["state"] = stage.code
         res = super().write(vals)
-        if "product_state_id" in vals:
+        if (
+            "product_state_id" in vals
+            and vals.get("product_state_id") in self._state_from
+        ):
             self.restart_validation()
         return res

--- a/product_tier_validation/readme/CONFIGURATION.rst
+++ b/product_tier_validation/readme/CONFIGURATION.rst
@@ -5,9 +5,6 @@ that can be used as a starting point fot this configuration.
 This configuration is done at
 *Settings > Technical > Tier Validations > Tier Definition*.
 
-Note that, since Product start as archived records,
-the *Definition Domain* must include ``"|",["active","=",True],["active","=",False]``.
-Otherwise the validation rule won't apply correctly in new records.
-
-Setting new Products inactive can be disabled,
-by removing the "draft" code from the initial Product State.
+Note: This module is incompatible with product_status.
+Since tier validations use the state field and the product_status module needs
+specific states/stages, tier validations will not trigger if that module is installed.

--- a/product_tier_validation/views/product_state_view.xml
+++ b/product_tier_validation/views/product_state_view.xml
@@ -1,0 +1,17 @@
+<odoo>
+
+    <record id="product_state_tier_form" model="ir.ui.view">
+        <field name="name">product.state.tier.form</field>
+        <field name="model">product.state</field>
+        <field name="inherit_id" ref="product_state.view_product_state_form" />
+        <field name="arch" type="xml">
+            <field name="default" position="after">
+                <field
+                    name="state"
+                    help="The related internal state (selection field) that the product will be set to."
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR improves on the previous changes that updated tier validation to work with stages. There was an issue where the user could move the product to a stage that was later in the list and then move it back to active so this fixes that issue by adding a 'related state' field to the stage so tier validation can properly work with states. This is similar to how partner_stage functions.