### PR TITLE
[13.0][FIX] product_secondary_unit: Don't alter previous quantity

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -76,7 +76,7 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
         """Set the target qty field defined in model"""
         for rec in self:
             if not rec.secondary_uom_id:
-                rec[rec._secondary_unit_fields["qty_field"]] = rec._origin[
+                rec[rec._secondary_unit_fields["qty_field"]] = rec[
                     rec._secondary_unit_fields["qty_field"]
                 ]
                 continue


### PR DESCRIPTION
Steps to reproduce the problem:

- Apply the mixin to the purchase orders.
- Create a purchase order line without secondary unit.

Current behavior: the line quantity is 0.

Expected behavior: the line quantity is 1.

Explanation:

ORM framework in v13 has a problem, raising CacheMiss on records that are not assigned in their compute method although being stored, but we have to assign the value in cache, not the one in the `_origin` internal variable, as a newly record doesn't have any, putting 0 in the quantity.

@Tecnativa TT27363