### PR TITLE
[FIX]product_sequence: remove dependence

### DIFF
--- a/product_sequence/README.rst
+++ b/product_sequence/README.rst
@@ -26,7 +26,7 @@ Product Sequence
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
 This module allows to associate a sequence to the product reference.
-The reference (default code) is unique (SQL constraint) and required.
+The reference (default code) is required. If you want to enforce reference uniqueness you can also install product_code_unique from this same repository.
 
 You can optionally specify different sequences for different product
 categories.

--- a/product_sequence/__manifest__.py
+++ b/product_sequence/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/product-attribute",
     "license": "AGPL-3",
     "category": "Product",
-    "depends": ["product", "product_code_unique"],
+    "depends": ["product"],
     "data": [
         "data/product_sequence.xml",
         "views/product_category.xml",


### PR DESCRIPTION
The dependence is removed that is not required by the module. It does not affect anyone who has this module installed, but in new installations you can choose or not to use uniqueness.