### PR TITLE
product_main_supplierinfo: fix default sellers for variant

### DIFF
--- a/product_main_supplierinfo/models/product_product.py
+++ b/product_main_supplierinfo/models/product_product.py
@@ -35,7 +35,7 @@ class ProductProduct(models.Model):
         They are ordered and filtered like it is done in the standard 'product' addon.
         """
         self.ensure_one()
-        all_sellers = self._prepare_sellers().filtered(
+        all_sellers = self._prepare_sellers(False).filtered(
             lambda s: not s.company_id or s.company_id.id == self.env.company.id
         )
         today = fields.Date.context_today(self)
@@ -49,5 +49,7 @@ class ProductProduct(models.Model):
             )
         )
         if not sellers:
-            sellers = all_sellers
-        return sellers
+            sellers = all_sellers.filtered(lambda s: (s.product_id == self))
+            if not sellers:
+                sellers = sellers = all_sellers.filtered(lambda s: not s.product_id)
+        return sellers.sorted("price")

--- a/product_main_supplierinfo/tests/test_product_main_supplier.py
+++ b/product_main_supplierinfo/tests/test_product_main_supplier.py
@@ -13,16 +13,81 @@ class TestProductMainSupplierInfo(SavepointCase):
         cls.product = cls.env.ref("product.product_product_6")
         cls.seller_1 = cls.env.ref("product.product_supplierinfo_1")
         cls.seller_1.sequence = 1
+        cls.seller_1.price = 700
         cls.seller_2 = cls.env.ref("product.product_supplierinfo_2")
         cls.seller_2.sequence = 2
+        cls.seller_2.price = 720
         cls.seller_2bis = cls.env.ref("product.product_supplierinfo_2bis")
         cls.seller_2bis.sequence = 3
+        cls.seller_2bis.price = 740
         cls.company_2 = cls.env.company.create({"name": "Company2"})
+        # For the test case 4
+        cls.attribute = cls.env["product.attribute"].create({"name": "Size"})
+        cls.attribute_value_1 = cls.env["product.attribute.value"].create(
+            {"name": "L", "attribute_id": cls.attribute.id}
+        )
+        cls.attribute_value_2 = cls.env["product.attribute.value"].create(
+            {"name": "XL", "attribute_id": cls.attribute.id}
+        )
+        cls.template1 = cls.env["product.template"].create(
+            {
+                "name": "Hat",
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": cls.attribute.id,
+                            "value_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        cls.attribute_value_1.id,
+                                        cls.attribute_value_2.id,
+                                    ],
+                                )
+                            ],
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.product_1 = cls.template1.product_variant_ids[0]
+        cls.product_2 = cls.template1.product_variant_ids[1]
+        cls.date_old = "2000-01-01"
+        cls.date_older = "2000-12-31"
+        cls.product_template_supply = cls.seller_2.copy(
+            {
+                "product_tmpl_id": cls.product_2.product_tmpl_id.id,
+                "sequence": 1,
+                "date_start": cls.date_older,
+                "date_end": cls.date_old,
+            }
+        )
+        cls.product_1_supply = cls.seller_1.copy(
+            {
+                "product_tmpl_id": cls.product_1.product_tmpl_id.id,
+                "product_id": cls.product_1.id,
+                "sequence": 2,
+                "date_start": cls.date_older,
+                "date_end": cls.date_old,
+            }
+        )
+        cls.product_2_supply = cls.seller_2.copy(
+            {
+                "product_tmpl_id": cls.product_2.product_tmpl_id.id,
+                "product_id": cls.product_2.id,
+                "sequence": 3,
+                "date_start": cls.date_older,
+                "date_end": cls.date_old,
+            }
+        )
 
     def test_main_seller_1(self):
         """ "Case 1: all the sellers share the same company."""
         self.assertEqual(self.product.main_seller_id, self.seller_1)
-        self.seller_2.sequence = -1
+        self.seller_2.price = 650
         self.assertEqual(self.product.main_seller_id, self.seller_2)
 
     def test_main_seller_2(self):
@@ -45,3 +110,8 @@ class TestProductMainSupplierInfo(SavepointCase):
         self.seller_1.date_start = tomorrow
         self.seller_2.date_end = yesterday
         self.assertEqual(self.product.main_seller_id, self.seller_2bis)
+
+    def test_main_seller_4(self):
+        """Case 4: No valid supplier so select one related to the variant."""
+        self.assertEqual(self.product_1.main_seller_id, self.product_1_supply)
+        self.assertEqual(self.product_2.main_seller_id, self.product_2_supply)


### PR DESCRIPTION
If no specific record are found by the first filter. The Odoo default
method will return all active supplier info.
Which will include also supplier info record related to other specific
variant.

With this change if some supplier info related to the product
variant exist, they will be returned instead.