### PR TITLE
[13.0][FIX] product_pricelist_supplierinfo: Allow to show shop for public users

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -21,7 +21,7 @@ class ProductPricelist(models.Model):
             if rule.compute_price == "formula" and rule.base == "supplierinfo":
                 context = self.env.context
                 result[product.id] = (
-                    product._get_supplierinfo_pricelist_price(
+                    product.sudo()._get_supplierinfo_pricelist_price(
                         rule,
                         date=date or context.get("date", fields.Date.today()),
                         quantity=qty,


### PR DESCRIPTION
0581b669ee435de4b1c068e6883e92a1e511ea41 is not enough on v13 for avoiding the access error, so we sudoed the whole price fetch operation.

@Tecnativa TT36898