### PR TITLE
[IMP] product_state (Move Data to Demo)

### DIFF
--- a/product_state/__manifest__.py
+++ b/product_state/__manifest__.py
@@ -12,10 +12,10 @@
     "depends": ["product", "sale"],
     "data": [
         "security/ir.model.access.csv",
-        "data/product_state_data.xml",
         "security/ir.model.access.csv",
         "views/product_template.xml",
     ],
+    "demo": ["demo/product_state_demo.xml"],
     "application": False,
     "maintainers": ["emagdalenaC2i"],
     "post_init_hook": "post_init_hook",

--- a/product_state/demo/product_state_demo.xml
+++ b/product_state/demo/product_state_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="1">
+<odoo>
     <record id="product_state_draft" model="product.state">
         <field name="code">draft</field>
         <field name="name">In Development</field>

--- a/product_state/readme/ROADMAP.rst
+++ b/product_state/readme/ROADMAP.rst
@@ -1,1 +1,0 @@
-File data/product_state_data.xml will be moved to demo/product_state_demo.xml since version 15.0


### PR DESCRIPTION
The stages in the data file is demo data. Having it in data causes issues when the module is updated and the sample stages were deleted as it will repopulate them, even though there is the no update flag.

It was already stated in the roadmap readme for v15, but why not fix it here.