### PR TITLE
product_status: fix product_tmpl back to default state

### DIFF
--- a/product_status/models/product_template.py
+++ b/product_status/models/product_template.py
@@ -67,7 +67,7 @@ class ProductTemplate(models.Model):
             record.state = "new"
         else:
             if record._name == "product.template":
-                product_state = record.product_state_id
+                product_state = record._get_default_product_state()
             else:
                 product_state = record.product_tmpl_id.product_state_id
             record.state = product_state.code

--- a/product_status/tests/test_product_status.py
+++ b/product_status/tests/test_product_status.py
@@ -16,6 +16,7 @@ class TestProductStatusCase(TestProductCommon):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.product = cls.env.ref("product.product_product_4")
         cls.product2 = cls.env.ref("product.product_product_4b")
+        cls.product_tmpl = cls.product.product_tmpl_id
         # To avoid error with filestore and Form test
         cls.product.image_1920 = False
         cls.state_model = cls.env["product.state"]
@@ -31,6 +32,16 @@ class TestProductStatusCase(TestProductCommon):
         self.product.new_until = "2020-09-14"
         self.assertEqual(self.product.state, "sellable")
         self.assertEqual(self.product.product_state_id.code, "sellable")
+
+    @freeze_time("2020-09-15")
+    def test_product_template_no_specific_state(self):
+        """Check product template back to default state."""
+        self.product_tmpl.new_until = "2020-09-16"
+        self.assertEqual(self.product_tmpl.state, "new")
+        self.assertEqual(self.product_tmpl.product_state_id.code, "new")
+        self.product_tmpl.new_until = "2020-09-14"
+        self.assertEqual(self.product_tmpl.state, "sellable")
+        self.assertEqual(self.product_tmpl.product_state_id.code, "sellable")
 
     @freeze_time("2020-09-15")
     def test_discontinued(self):


### PR DESCRIPTION
Before this change a product would never get back into its default
state. Example: a new proudct with a new until date in the past will keep
a state set as `new`.
Instead it should be set to the default status.