### PR TITLE
[12.0][ADD] product_dimension_compute_volume

### DIFF
--- a/product_dimension/tests/test_compute_volume.py
+++ b/product_dimension/tests/test_compute_volume.py
@@ -11,6 +11,10 @@ class TestComputeVolumeOnProduct(TransactionCase):
         self.product.product_width = 100.
         self.product.dimensional_uom_id = self.uom_cm
         self.product.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(
+            0,
+            self.product.volume
+        )
         self.product.onchange_calculate_volume()
         self.assertAlmostEqual(
             200,
@@ -23,6 +27,10 @@ class TestComputeVolumeOnProduct(TransactionCase):
         self.product.product_width = 10.
         self.product.dimensional_uom_id = self.uom_m
         self.product.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(
+            0,
+            self.product.volume
+        )
         self.product.onchange_calculate_volume()
         self.assertAlmostEqual(
             120000,
@@ -46,6 +54,10 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.template.product_width = 100.
         self.template.dimensional_uom_id = self.uom_cm
         self.template.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(
+            0,
+            self.template.volume
+        )
         self.template.onchange_calculate_volume()
         self.assertAlmostEqual(
             200,
@@ -58,6 +70,10 @@ class TestComputeVolumeOnTemplate(TransactionCase):
         self.template.product_width = 10.
         self.template.dimensional_uom_id = self.uom_m
         self.template.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(
+            0,
+            self.template.volume
+        )
         self.template.onchange_calculate_volume()
         self.assertAlmostEqual(
             120000,

--- a/product_dimension_compute_volume/__init__.py
+++ b/product_dimension_compute_volume/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import models

--- a/product_dimension_compute_volume/__init__.py
+++ b/product_dimension_compute_volume/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models

--- a/product_dimension_compute_volume/__manifest__.py
+++ b/product_dimension_compute_volume/__manifest__.py
@@ -7,7 +7,7 @@
         Automatically compute the volume depending on the dimensions.""",
     "version": "12.0.1.0.0",
     "category": "Product",
-    "website": "https://coopiteasy.be",
+    "website": "https://github.com/OCA/product-attribute",
     "author": "Odoo Community Association (OCA), Coop IT Easy SCRLfs",
     "maintainers": ["carmenbianca"],
     "license": "AGPL-3",
@@ -15,8 +15,4 @@
     "depends": [
         "product_dimension",
     ],
-    "excludes": [],
-    "data": [],
-    "demo": [],
-    "qweb": [],
 }

--- a/product_dimension_compute_volume/__manifest__.py
+++ b/product_dimension_compute_volume/__manifest__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "Product Dimension Compute Volume",

--- a/product_dimension_compute_volume/__manifest__.py
+++ b/product_dimension_compute_volume/__manifest__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+    "name": "Product Dimension Compute Volume",
+    "summary": """
+        Automatically compute the volume depending on the dimensions.""",
+    "version": "12.0.1.0.0",
+    "category": "Product",
+    "website": "https://coopiteasy.be",
+    "author": "Odoo Community Association (OCA), Coop IT Easy SCRLfs",
+    "maintainers": ["carmenbianca"],
+    "license": "AGPL-3",
+    "application": False,
+    "depends": [
+        "product_dimension",
+    ],
+    "excludes": [],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/product_dimension_compute_volume/models/__init__.py
+++ b/product_dimension_compute_volume/models/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import product

--- a/product_dimension_compute_volume/models/__init__.py
+++ b/product_dimension_compute_volume/models/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import product

--- a/product_dimension_compute_volume/models/product.py
+++ b/product_dimension_compute_volume/models/product.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 

--- a/product_dimension_compute_volume/models/product.py
+++ b/product_dimension_compute_volume/models/product.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import api, fields, models
+
+
+class Product(models.Model):
+    _inherit = "product.product"
+
+    volume = fields.Float(compute="_compute_volume", store=True)
+
+    @api.depends(
+        "product_length",
+        "product_height",
+        "product_width",
+        "dimensional_uom_id",
+        "volume_uom_id",
+    )
+    def _compute_volume(self):
+        product_template = self.env["product.template"]
+        for product in self:
+            product.volume = product_template._calc_volume(
+                product.product_length,
+                product.product_height,
+                product.product_width,
+                product.dimensional_uom_id,
+                product.volume_uom_id,
+            )

--- a/product_dimension_compute_volume/readme/CONTRIBUTORS.rst
+++ b/product_dimension_compute_volume/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SCRLfs <https://coopiteasy.be>`_:
+
+  * Carmen Bianca Bakker

--- a/product_dimension_compute_volume/readme/DESCRIPTION.rst
+++ b/product_dimension_compute_volume/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Automatically compute the volume depending on the dimensions.

--- a/product_dimension_compute_volume/readme/ROADMAP.rst
+++ b/product_dimension_compute_volume/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+Don't Repeat Yourself in the tests. A common class in product_dimension would
+reduce repeated code by a lot.

--- a/product_dimension_compute_volume/tests/__init__.py
+++ b/product_dimension_compute_volume/tests/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import test_product

--- a/product_dimension_compute_volume/tests/__init__.py
+++ b/product_dimension_compute_volume/tests/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_product

--- a/product_dimension_compute_volume/tests/test_product.py
+++ b/product_dimension_compute_volume/tests/test_product.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo.tests.common import SavepointCase
+
+
+class TestComputeVolumeOnProduct(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product = cls.env["product.product"].create({"name": "Product"})
+        cls.uom_m = cls.env["uom.uom"].search([("name", "=", "m")])
+        cls.uom_cm = cls.env["uom.uom"].search([("name", "=", "cm")])
+        cls.uom_litre = cls.env.ref("uom.product_uom_litre")
+
+    def test_compute_in_cm(self):
+        self.assertAlmostEqual(self.product.volume, 0)
+
+        self.product.product_length = 10
+        self.product.product_height = 200
+        self.product.product_width = 100
+        self.product.dimensional_uom_id = self.uom_cm
+        self.product.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(self.product.volume, 200)
+
+        self.product.product_length = 0
+        self.assertAlmostEqual(self.product.volume, 0)
+
+    def test_compute_in_m(self):
+        self.product.product_length = 6
+        self.product.product_height = 2
+        self.product.product_width = 10
+        self.product.dimensional_uom_id = self.uom_m
+        self.product.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(self.product.volume, 120000)
+
+
+class TestComputeVolumeOnTemplate(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.template = cls.env["product.template"].create({"name": "Template"})
+        cls.uom_m = cls.env["uom.uom"].search([("name", "=", "m")])
+        cls.uom_cm = cls.env["uom.uom"].search([("name", "=", "cm")])
+        cls.uom_litre = cls.env.ref("uom.product_uom_litre")
+
+    def test_compute_in_cm(self):
+        self.assertAlmostEqual(self.template.volume, 0)
+
+        self.template.product_length = 10
+        self.template.product_height = 200
+        self.template.product_width = 100
+        self.template.dimensional_uom_id = self.uom_cm
+        self.template.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(self.template.volume, 200)
+
+        self.template.product_length = 0
+        self.assertAlmostEqual(self.template.volume, 0)
+
+    def test_compute_in_m(self):
+        self.template.product_length = 6
+        self.template.product_height = 2
+        self.template.product_width = 10
+        self.template.dimensional_uom_id = self.uom_m
+        self.template.volume_uom_id = self.uom_litre
+        self.assertAlmostEqual(self.template.volume, 120000)

--- a/product_dimension_compute_volume/tests/test_product.py
+++ b/product_dimension_compute_volume/tests/test_product.py
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2022 Coop IT Easy SCRLfs
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2015 Camptocamp SA
+# Copyright 2022 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import SavepointCase
 

--- a/setup/product_dimension_compute_volume/odoo/addons/product_dimension_compute_volume
+++ b/setup/product_dimension_compute_volume/odoo/addons/product_dimension_compute_volume
@@ -1,0 +1,1 @@
+../../../../product_dimension_compute_volume

--- a/setup/product_dimension_compute_volume/setup.py
+++ b/setup/product_dimension_compute_volume/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
A simple module that doesn't just add an `onchange` for recomputing the volume, but makes `volume` a computed field.

Internal task: https://gestion.coopiteasy.be/web#id=8355&action=475&active_id=231&model=project.task&view_type=form&menu_id=536