### PR TITLE
[14.0] product_pricelist_revision: fix date_end/date_start are datetime

### DIFF
--- a/product_pricelist_revision/tests/test_product_pricelist_revision.py
+++ b/product_pricelist_revision/tests/test_product_pricelist_revision.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from datetime import date
+from datetime import datetime
 
 from odoo.tests.common import SavepointCase
 
@@ -90,8 +90,8 @@ class TestProductPricelistRevision(SavepointCase):
         active_ids = self.pricelist_item_product_product.ids
         wizard = wizard_obj.with_context(active_ids=active_ids).create(
             {
-                "date_start": date.today(),
-                "date_end": date.today(),
+                "date_start": datetime.now(),
+                "date_end": datetime.now(),
                 "variation_percent": 50,
             }
         )

--- a/product_pricelist_revision/wizards/pricelist_duplicate_wizard.py
+++ b/product_pricelist_revision/wizards/pricelist_duplicate_wizard.py
@@ -10,8 +10,8 @@ class ProductPricelistItemDuplicateWizard(models.TransientModel):
     _name = "product.pricelist.item.duplicate.wizard"
     _description = "Wizard Product Pricelist Item Duplicate"
 
-    date_start = fields.Date(required=True)
-    date_end = fields.Date()
+    date_start = fields.Datetime(required=True)
+    date_end = fields.Datetime()
     variation_percent = fields.Float(digits="Product Price", string="Variation %")
 
     def action_apply(self):
@@ -27,7 +27,7 @@ class ProductPricelistItemDuplicateWizard(models.TransientModel):
                     * (1.0 + self.variation_percent / 100.0),
                 }
             )
-            item.date_end = self.date_start - relativedelta(days=1)
+            item.date_end = self.date_start - relativedelta(seconds=1)
 
         action = self.env.ref(
             "product_pricelist_revision.product_pricelist_item_action"


### PR DESCRIPTION
On version 14 the date_end / date_start on "product.pricelist.item" are datetime, so we should use datetime in the wizard too.

Right now if you set the 2022-06-15 as date_start, you will have (I am in UTC +2)
- date_end: 2022-06-15 02:00:00
- date_stop: 2022-06-14 02:00:00

So you do not have price for the day 2022-06-14

@sergio-teruel @ernestotejeda @pedrobaeza 