### PR TITLE
[14.0][IMP] product_sequence: Check for subsequent duplicates

### DIFF
--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -59,5 +59,10 @@ class ProductProduct(models.Model):
         if default is None:
             default = {}
         if self.default_code and "default_code" not in default:
-            default.update({"default_code": self.default_code + _("-copy")})
+            code = self.default_code
+            while True:  # check for previous duplicates
+                code += _("-copy")
+                if not self.search([("default_code", "=", code)]):
+                    break
+            default.update({"default_code": code})
         return super().copy(default)

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -132,3 +132,9 @@ class TestProductSequence(TransactionCase):
             {"default_code": "product test sequence"}
         )
         self.assertEqual(copy_product_2.default_code, "product test sequence")
+
+    def test_product_subsequent_copies(self):
+        self.product_template.default_code = "PSTEST001"
+        template1 = self.product_template.copy()
+        template2 = self.product_template.copy()
+        self.assertNotEqual(template1.default_code, template2.default_code)


### PR DESCRIPTION
Steps to reproduce the problem:

- Install `product_code_unique` OCA module.
- Duplicate a product with a code.
- A new product is created with the code + `-copy`.
- Take the original product and duplicate it again.
- An error is shown about duplicated product code.

Searching previously if the code exists, we prevent this integration problem, and it makes sense to do this distinction even if the other module is not installed.

Forward-port of #1100 

@Tecnativa