### PR TITLE
[14.0][IMP] product_categ_image: Remove image field leftover from migration

### DIFF
--- a/product_categ_image/models/product_category.py
+++ b/product_categ_image/models/product_category.py
@@ -2,11 +2,9 @@
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import models
 
 
 class ProductCategory(models.Model):
     _name = "product.category"
     _inherit = [_name, "image.mixin"]
-
-    image = fields.Binary(string="Category Image", attachment=True)


### PR DESCRIPTION
The binary image field is no longer used. As a matter of fact, the image.mixin was added, and the field `image_1920` is used in the view.

the image field was most likely left over from the migration, and can be removed.