### PR TITLE
[14.0] product_pricelist_supplierinfo: Sale margin is not computed correctly

### DIFF
--- a/product_pricelist_supplierinfo/models/product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/models/product_supplierinfo.py
@@ -18,5 +18,5 @@ class ProductSupplierinfo(models.Model):
         self.ensure_one()
         sale_price = self.price
         if self.sale_margin:
-            sale_price = (self.price + (self.price * (self.sale_margin / 100))) or 0.0
+            sale_price = (self.price * (100 / (100 - self.sale_margin))) or 0.0
         return sale_price

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -173,17 +173,17 @@ class TestProductSupplierinfo(common.SavepointCase):
         seller.sale_margin = 50
         self.assertAlmostEqual(
             seller._get_supplierinfo_pricelist_price(),
-            75.0,
+            100.0,
         )
         self.assertAlmostEqual(
             self.pricelist.get_product_price(self.product, 6, False),
-            75.0,
+            100.0,
         )
         self.assertAlmostEqual(
             self.product.product_tmpl_id.with_context(
                 pricelist=self.pricelist.id, quantity=6
             ).price,
-            75.0,
+            100.0,
         )
 
     def test_supplierinfo_per_variant(self):


### PR DESCRIPTION
The formula for the margin is not correct.

If you have a product that you sale 100 € this a sale margin of 50% you buy it 50€

Right now having a sale margin on the supplier of 50% with a purchase price of 50€ will generate as sale price of 75€

Test and formula was wrong, fix it