### PR TITLE
[12.0][FIX] Backport from 14.0: product_state: Prevent a write with both values

### DIFF
--- a/product_state/models/product_template.py
+++ b/product_state/models/product_template.py
@@ -48,6 +48,7 @@ class ProductTemplate(models.Model):
         index=True,
         compute="_compute_product_state",
         inverse="_inverse_product_state",
+        readonly=True,
         store=True,
     )
     product_state_id = fields.Many2one(


### PR DESCRIPTION
https://github.com/OCA/product-attribute/pull/879

@rousseldenis 