### PR TITLE
[15.0][FIX] product_code_mandatory: align code with Odoo way to set default code

### DIFF
--- a/product_code_mandatory/__init__.py
+++ b/product_code_mandatory/__init__.py
@@ -1,17 +1,27 @@
 from . import models
 
+from odoo import api, SUPERUSER_ID
+
 
 def pre_init_product_code(cr):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
     cr.execute(
-        """UPDATE product_template
-        SET default_code = 'DEFAULT' || nextval('ir_default_id_seq')
+        """
+        SELECT product_tmpl_id from product_product
         WHERE default_code is NULL
-        OR LENGTH(default_code) = 0"""
+        OR LENGTH(default_code) = 0
+        GROUP BY product_tmpl_id
+        HAVING COUNT(product_tmpl_id) = 1"""
     )
+    product_template_ids = [x[0] for x in cr.fetchall()]
     cr.execute(
         """UPDATE product_product
         SET default_code = 'DEFAULT' || nextval('ir_default_id_seq')
         WHERE default_code is NULL
         OR LENGTH(default_code) = 0"""
     )
+
+    env["product.template"].browse(product_template_ids)._compute_default_code()
+
     return True


### PR DESCRIPTION
The Issue: When install this module, it generate diferents default codes for each product_product and product_template where default_code is not set.

Example: 
for product_product(1) generate the default code: DEFAULT4
for the product template of product_product(1) enerate the default code: DEFAULT9

Odoo:
Odoo has a method called _compute_default_code(), where de default_code of product_template is asseigned depending of its variants