### PR TITLE
[FIX][12.0] product_standard_price_tax_included : make the price computation working with product variants AND product templates

### DIFF
--- a/product_standard_price_tax_included/models/__init__.py
+++ b/product_standard_price_tax_included/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_tax
 from . import product_pricelist_item
 from . import product_product
+from . import product_template

--- a/product_standard_price_tax_included/models/product_template.py
+++ b/product_standard_price_tax_included/models/product_template.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2022 - Today: GRAP (http://www.grap.coop)
+# @author Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    standard_price_tax_included = fields.Float(
+        related="product_variant_ids.standard_price_tax_included"
+    )

--- a/product_standard_price_tax_included/tests/test_module.py
+++ b/product_standard_price_tax_included/tests/test_module.py
@@ -68,3 +68,22 @@ class TestProductStandardPriceTaxIncluded(TransactionCase):
             self.order.amount_total, 6.0,
             "Computation of Price based on Cost Price Tax Included incorrect."
             " when discount is set")
+
+    def test_10_product_product_computation(self):
+        product_price = self.product.with_context(
+            pricelist=self.pricelist.id
+        ).price
+
+        self.assertEquals(
+            product_price, 12.0,
+            "Computation of Price based on Cost Price Tax Included incorrect"
+            " for product.product model.")
+
+    def test_11_product_template_computation(self):
+        template_price = self.product.product_tmpl_id.with_context(
+            pricelist=self.pricelist.id
+        ).price
+        self.assertEquals(
+            template_price, 12.0,
+            "Computation of Price based on Cost Price Tax Included incorrect"
+            " for product.template model.")


### PR DESCRIPTION
Rational : 

in some rare cases, price can be asked for a template. (it can occurs when using ``product_pricelist_direct_print`` same repository)

before that patch, the call to the computed function of the field ``price`` was failing with templates.