### PR TITLE
[15.0][IMP] product_lot_sequence: Add sequence policies 

### DIFF
--- a/product_lot_sequence/__manifest__.py
+++ b/product_lot_sequence/__manifest__.py
@@ -10,5 +10,5 @@
     "author": "ForgeFlow S.L., Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["stock"],
-    "data": ["views/product_views.xml"],
+    "data": ["data/ir_config_parameter.xml", "views/product_views.xml"],
 }

--- a/product_lot_sequence/data/ir_config_parameter.xml
+++ b/product_lot_sequence/data/ir_config_parameter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record model="ir.config_parameter" id="lot_sequence_policy">
+        <field name="key">product_lot_sequence.policy</field>
+        <field name="value">product</field>
+    </record>
+</odoo>

--- a/product_lot_sequence/models/stock_production_lot.py
+++ b/product_lot_sequence/models/stock_production_lot.py
@@ -1,29 +1,66 @@
 # Copyright 2020 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ProductionLot(models.Model):
     _inherit = "stock.production.lot"
 
+    name = fields.Char(default=lambda self: self._default_name())
+
+    @api.model
+    def _get_sequence_policy(self):
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("product_lot_sequence.policy")
+        )
+
+    @api.model
+    def _default_name(self):
+        seq_policy = self._get_sequence_policy()
+        if seq_policy != "product":
+            return self.env["ir.sequence"].next_by_code("stock.lot.serial")
+        return ""
+
     @api.onchange("product_id")
     def onchange_product_id(self):
-        if self.product_id and self.product_id.product_tmpl_id.lot_sequence_id:
+        seq_policy = self._get_sequence_policy()
+        if (
+            seq_policy == "product"
+            and self.product_id
+            and self.product_id.product_tmpl_id.lot_sequence_id
+        ):
             self.name = self.product_id.product_tmpl_id.lot_sequence_id._next()
 
     @api.model_create_multi
     def create(self, vals_list):
-        for lot_vals in vals_list:
-            if "name" not in lot_vals:
-                product = self.env["product.product"].browse(lot_vals["product_id"])
-                if product and product.product_tmpl_id.lot_sequence_id:
-                    lot_vals["name"] = product.product_tmpl_id.lot_sequence_id._next()
+        seq_policy = self._get_sequence_policy()
+        if seq_policy in ["product", "global"]:
+            for lot_vals in vals_list:
+                if "name" not in lot_vals:
+                    if seq_policy == "product":
+                        product = self.env["product.product"].browse(
+                            lot_vals["product_id"]
+                        )
+                        if product and product.product_tmpl_id.lot_sequence_id:
+                            lot_vals[
+                                "name"
+                            ] = product.product_tmpl_id.lot_sequence_id._next()
+                    else:
+                        lot_vals["name"] = self.env["ir.sequence"].next_by_code(
+                            "stock.lot.serial"
+                        )
         return super(ProductionLot, self).create(vals_list)
 
     @api.model
     def _get_next_serial(self, company, product):
-        seq = product.lot_sequence_id
-        if seq:
-            return seq._next()
+        seq_policy = self._get_sequence_policy()
+        if seq_policy == "product":
+            seq = product.product_tmpl_id.lot_sequence_id
+            if seq:
+                return seq._next()
+        elif seq_policy == "global":
+            return self.env["ir.sequence"].next_by_code("stock.lot.serial")
         return super()._get_next_serial(company, product)

--- a/product_lot_sequence/readme/CONFIGURATION.rst
+++ b/product_lot_sequence/readme/CONFIGURATION.rst
@@ -1,0 +1,13 @@
+There are two ways you can configure this module through the use of System Parameter
+`product_lot_sequence.policy`:
+
+- "product": This is the default behaviour once you install this module. It's the
+  same than in previous Odoo versions with this module installed, i.e. it allows
+  to define a dedicated sequence on each product.
+
+- "global": This was the default behaviour from previous Odoo versions when this
+  module was not installed, i.e it will always use the same global sequence for every product.
+
+If any other value is used for this System Parameter, then you will get the default
+behaviour from odoo 15.0 which will look for the last lot number for each product and
+will increment it.

--- a/product_lot_sequence/readme/CONTRIBUTORS.rst
+++ b/product_lot_sequence/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Domantas Girdžiūnas <domantas@vialaurea.lt>
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -11,9 +11,11 @@ class TestProductLotSequence(TransactionCase):
         self.stock_production_lot = self.env["stock.production.lot"]
 
     def test_product_sequence(self):
+        self.assertEqual(self.stock_production_lot._get_sequence_policy(), "product")
         product = self.product_product.create(
             dict(name="The bar of foo", tracking="serial")
         )
+        self.assertTrue(product.lot_sequence_id)
         product.lot_sequence_id.write(
             dict(
                 prefix="foo/",
@@ -29,7 +31,9 @@ class TestProductLotSequence(TransactionCase):
         self.assertRegexpMatches(next_serial, r"foo/\d{5}/bar")
 
     def test_lot_onchange_product_id(self):
+        self.assertEqual(self.stock_production_lot._get_sequence_policy(), "product")
         product = self.product_product.create(dict(name="Shiba plush", tracking="lot"))
+        self.assertTrue(product.lot_sequence_id)
         product.lot_sequence_id.write(
             dict(prefix="shiba/", padding=4, number_increment=1, number_next_actual=1)
         )
@@ -38,3 +42,49 @@ class TestProductLotSequence(TransactionCase):
         lot_form.company_id = self.env.company
         lot = lot_form.save()
         self.assertRegexpMatches(lot.name, r"shiba/\d{4}$")
+
+    def test_global_sequence(self):
+        self.env["ir.config_parameter"].set_param(
+            "product_lot_sequence.policy", "global"
+        )
+        product_1 = self.product_product.create(
+            {"name": "Test global 1", "tracking": "serial"}
+        )
+        self.assertFalse(product_1.lot_sequence_id)
+        product_2 = self.product_product.create(
+            {"name": "Test global 2", "tracking": "lot"}
+        )
+        self.assertFalse(product_2.lot_sequence_id)
+        seq = self.env["ir.sequence"].search([("code", "=", "stock.lot.serial")])
+        next_sequence_number = seq.get_next_char(seq.number_next_actual)
+        next_serial = self.env["stock.production.lot"]._get_next_serial(
+            self.env.company, product_1
+        )
+        self.assertEqual(next_serial, next_sequence_number)
+        seq._get_number_next_actual()
+        next_sequence_number_2 = seq.get_next_char(seq.number_next_actual)
+        next_serial_2 = self.env["stock.production.lot"]._get_next_serial(
+            self.env.company, product_2
+        )
+        self.assertEqual(next_serial_2, next_sequence_number_2)
+
+    def test_lot_onchange_product_id_global(self):
+        self.env["ir.config_parameter"].set_param(
+            "product_lot_sequence.policy", "global"
+        )
+        product = self.product_product.create(
+            {"name": "Test global", "tracking": "serial"}
+        )
+        self.assertFalse(product.lot_sequence_id)
+        seq = self.env["ir.sequence"].search([("code", "=", "stock.lot.serial")])
+        next_sequence_number = seq.get_next_char(seq.number_next_actual)
+        lot_form = Form(
+            self.stock_production_lot.with_context(
+                default_company_id=self.env.company.id
+            )
+        )
+        self.assertEqual(lot_form.name, next_sequence_number)
+        self.assertEqual(lot_form.company_id, self.env.company)
+        lot_form.product_id = product
+        lot = lot_form.save()
+        self.assertEqual(lot.name, next_sequence_number)

--- a/product_lot_sequence/views/product_views.xml
+++ b/product_lot_sequence/views/product_views.xml
@@ -7,21 +7,22 @@
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
             <field name="tracking" position="after">
+                <field name="display_lot_sequence_fields" invisible="1" />
                 <field
                     name="lot_sequence_prefix"
-                    attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': [('tracking', 'not in', ['lot', 'serial'])]}"
+                    attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False)]}"
                 />
                 <field
                     name="lot_sequence_padding"
-                    attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': [('tracking', 'not in', ['lot', 'serial'])]}"
+                    attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False)]}"
                 />
                 <field
                     name="lot_sequence_number_next"
-                    attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': [('tracking', 'not in', ['lot', 'serial'])]}"
+                    attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False)]}"
                 />
                 <field
                     name="lot_sequence_id"
-                    attrs="{'invisible': [('tracking', 'not in', ['lot', 'serial'])]}"
+                    attrs="{'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False)]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
Provide multiple configuration options with this module installed:

- "product": This is the default behaviour once you install this module. It's the
  same than in previous Odoo versions with this module installed, i.e. it allows
  to define a dedicated sequence on each product.

- "global": This was the default behaviour from previous Odoo versions when this
  module was not installed, i.e it will always use the same global sequence for every product.

Depends on:
 - [x] #1145 