### PR TITLE
[14.0][FIX] product_pricelist_supplierinfo: Show text in the view

### DIFF
--- a/product_pricelist_supplierinfo/views/product_pricelist_item_views.xml
+++ b/product_pricelist_supplierinfo/views/product_pricelist_item_views.xml
@@ -5,7 +5,10 @@
         <field name="model">product.pricelist.item</field>
         <field name="inherit_id" ref="product.product_pricelist_item_form_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='base']/../div" position="inside">
+            <xpath
+                expr="//group[@name='pricelist_rule_advanced']/div"
+                position="inside"
+            >
                 <span
                     attrs="{'invisible':[('base', '!=', 'supplierinfo')]}"
                 >Supplier price  -  </span>


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/product-attribute/pull/1204

Show text in the view

**Before**
![antes](https://user-images.githubusercontent.com/4117568/202996711-7ecab881-54f8-4352-be8b-7d0401f0b17c.png)

**After**
![despues](https://user-images.githubusercontent.com/4117568/202996736-293e0f47-fe45-4295-bdd0-4aeb085bfa43.png)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT36975