### PR TITLE
[14.0][FIX] product_attribute_value_menu: deprecated use of <act_window>

### DIFF
--- a/product_attribute_value_menu/views/product_attribute_value_views.xml
+++ b/product_attribute_value_menu/views/product_attribute_value_views.xml
@@ -45,12 +45,11 @@
         </field>
     </record>
 
-    <act_window
-        id="attribute_value_action"
-        name="Attributes Values"
-        res_model="product.attribute.value"
-        view_mode="tree"
-    />
+    <record id="attribute_value_action" model="ir.actions.act_window">
+        <field name="name">Attributes Values</field>
+        <field name="res_model">product.attribute.value</field>
+        <field name="view_mode">tree</field>
+    </record>
 
     <menuitem
         id="sale_menu_product_archived_attribute_action"


### PR DESCRIPTION
Backport from 15.0: https://github.com/OCA/product-attribute/pull/1144

@Tecnativa