### PR TITLE
[14.0][IMP] product_pricelist_direct_print: allow export product images

### DIFF
--- a/product_pricelist_direct_print/views/report_product_pricelist.xml
+++ b/product_pricelist_direct_print/views/report_product_pricelist.xml
@@ -63,6 +63,9 @@
                                 <th t-if="pricelist" class="text-right">
                                     <strong>List Price</strong>
                                 </th>
+                                <th t-if="o.show_product_images" class="text-right">
+                                    <strong>Image</strong>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
@@ -90,6 +93,14 @@
                                     <td t-if="pricelist" class="text-right">
                                         <strong
                                             t-field="product.with_context(pricelist=pricelist.id, date=o.date or None).price"
+                                        />
+                                    </td>
+                                    <td t-if="o.show_product_images" class="text-right">
+                                        <img
+                                            t-if="product.image_128"
+                                            t-att-src="image_data_uri(product.image_128)"
+                                            alt="Img"
+                                            style="max-height: 80px;"
                                         />
                                     </td>
                                 </tr>

--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -57,6 +57,7 @@ class ProductPricelistPrint(models.TransientModel):
     # Excel export options
     breakage_per_category = fields.Boolean(string="Breakage per category", default=True)
     show_internal_category = fields.Boolean(string="Show internal categories")
+    show_product_images = fields.Boolean(string="Show product images")
 
     @api.depends("partner_ids")
     def _compute_partner_count(self):

--- a/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
@@ -78,6 +78,7 @@
                         <group>
                             <field name="breakage_per_category" />
                             <field name="show_internal_category" />
+                            <field name="show_product_images" />
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
Allow exporting the pricelist report with product images. For scaling I set the images dimensions to be 64px at max.

During the development I found some images to be impossible to insert on xlsx, the only way I've found of checking it is by trying the `Image.open()` with the product image.

Here's an example of the resulting report:

![imagen](https://user-images.githubusercontent.com/79899255/207885279-4f4ac09d-9b33-4973-b72b-d2d3f2f019c1.png)

![imagen](https://user-images.githubusercontent.com/79899255/209161573-f496f740-a192-4785-b064-f4aec6001d95.png)
