### PR TITLE
[13.0][FIX] product_pricelist_supplierinfo: Seller got from other company

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -20,8 +20,12 @@ class ProductPricelist(models.Model):
             rule = rule_obj.browse(result[product.id][1])
             if rule.compute_price == "formula" and rule.base == "supplierinfo":
                 context = self.env.context
+                # Getting the company from the context is not ideal, but it is enough and
+                # is improved in higher versions
                 result[product.id] = (
-                    product.sudo()._get_supplierinfo_pricelist_price(
+                    product.sudo()
+                    .with_context(force_company=self.env.company.id)
+                    ._get_supplierinfo_pricelist_price(
                         rule,
                         date=date or context.get("date", fields.Date.today()),
                         quantity=qty,


### PR DESCRIPTION
…because sudo ignore rules

force_company is used here:
https://github.com/odoo/odoo/blob/a72bb463539bacd4a9414a9b7d178ed84fb9d333/addons/product/models/product.py#L612-L613

@Tecnativa TT41130