### PR TITLE
[15.0][FIX+IMP] product_sequence

### DIFF
--- a/product_sequence/models/ir_sequence.py
+++ b/product_sequence/models/ir_sequence.py
@@ -2,7 +2,8 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
 
 
 class IrSequence(models.Model):
@@ -14,3 +15,24 @@ class IrSequence(models.Model):
             while not category.sequence_id and category.parent_id:
                 category = category.parent_id
         return category.sequence_id or self.env.ref("product_sequence.seq_product_auto")
+
+    @api.constrains("prefix")
+    def _check_prefix_product_category(self):
+        if self.env.context.get("_no_sequence_prefix_check"):
+            return
+        for rec in self:
+            categs = self.env["product.category"].search([("sequence_id", "=", rec.id)])
+            if not categs:
+                continue
+            if any(categ.code_prefix != rec.prefix for categ in categs):
+                raise ValidationError(
+                    _(
+                        "Sequence %(seq_name)s is used on following product "
+                        "categories and prefix cannot be changed here:"
+                        "\n%(categ_names)s"
+                    )
+                    % dict(
+                        seq_name=rec.name,
+                        categ_names="\n -".join(categs.mapped("name")),
+                    )
+                )

--- a/product_sequence/models/product_category.py
+++ b/product_sequence/models/product_category.py
@@ -46,7 +46,7 @@ class ProductCategory(models.Model):
                     rec.sudo().sequence_id.prefix = prefix
                 else:
                     seq_vals = self._prepare_ir_sequence(prefix)
-                    rec.sequence_id = self.env["ir.sequence"].create(seq_vals)
+                    vals["sequence_id"] = self.env["ir.sequence"].create(seq_vals)
         return super().write(vals)
 
     @api.model

--- a/product_sequence/models/product_category.py
+++ b/product_sequence/models/product_category.py
@@ -2,7 +2,8 @@
 #   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductCategory(models.Model):
@@ -20,7 +21,6 @@ class ProductCategory(models.Model):
         help="This field contains the information related to the numbering "
         "of the journal entries of this journal.",
         copy=False,
-        readonly=True,
     )
 
     @api.model
@@ -48,17 +48,27 @@ class ProductCategory(models.Model):
         return sequence
 
     def write(self, vals):
+        sequence_ids_to_check = set()
         if "code_prefix" in vals:
             prefix = vals.get("code_prefix")
             if prefix:
                 for rec in self:
                     if rec.sequence_id:
-                        rec.sudo().sequence_id.prefix = prefix
+                        sequence_sudo = rec.sudo()
+                        sequence_ids_to_check.add(sequence_sudo.id)
+                        sequence_sudo.with_context(
+                            _no_sequence_prefix_check=True
+                        ).sequence_id.prefix = prefix
                     else:
                         vals["sequence_id"] = self._get_or_create_sequence(prefix).id
             else:
                 vals["sequence_id"] = False
-        return super().write(vals)
+        res = super().write(vals)
+        if sequence_ids_to_check:
+            self.env["ir.sequence"].sudo().browse(
+                sequence_ids_to_check
+            )._check_prefix_product_category()
+        return res
 
     @api.model
     def create(self, vals):
@@ -66,3 +76,15 @@ class ProductCategory(models.Model):
         if prefix:
             vals["sequence_id"] = self._get_or_create_sequence(prefix).id
         return super().create(vals)
+
+    @api.constrains("code_prefix", "sequence_id")
+    def _check_prefix_sequence_id(self):
+        for rec in self:
+            if rec.sequence_id and rec.code_prefix != rec.sequence_id.prefix:
+                raise ValidationError(
+                    _(
+                        "The prefix defined on product category %s does not match "
+                        "the prefix of linked sequence"
+                    )
+                    % rec.name
+                )

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -1,6 +1,7 @@
 # Copyright 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase, tagged
 
 from ..hooks import pre_init_hook
@@ -147,3 +148,22 @@ class TestProductSequence(TransactionCase):
             {"name": "Test reuse", "code_prefix": prefix}
         )
         self.assertEqual(category_2.sequence_id, test_sequence)
+
+    def test_sequence_prefix_discrepancies(self):
+        prefix_test = "TEST"
+        category_test = self.product_category.create(
+            {"name": "Test", "code_prefix": prefix_test}
+        )
+        sequence_test = category_test.sequence_id
+        prefix_demo = "DEMO"
+        category_demo = self.product_category.create(
+            {"name": "Demo", "code_prefix": prefix_demo}
+        )
+        with self.assertRaisesRegex(
+            ValidationError, "prefix defined on product category"
+        ):
+            category_demo.sequence_id = sequence_test
+        with self.assertRaisesRegex(
+            ValidationError, "used on following product categories"
+        ):
+            sequence_test.prefix = prefix_demo

--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -132,3 +132,18 @@ class TestProductSequence(TransactionCase):
             {"default_code": "product test sequence"}
         )
         self.assertEqual(copy_product_2.default_code, "product test sequence")
+
+    def test_remove_and_reuse_sequence(self):
+        prefix = "TEST"
+        category = self.product_category.create({"name": "Test", "code_prefix": prefix})
+        test_sequence = category.sequence_id
+        self.assertTrue(test_sequence)
+        self.assertEqual(test_sequence.prefix, prefix)
+        category.write({"code_prefix": ""})
+        self.assertFalse(category.sequence_id)
+        category.write({"code_prefix": prefix})
+        self.assertEqual(category.sequence_id, test_sequence)
+        category_2 = self.product_category.create(
+            {"name": "Test reuse", "code_prefix": prefix}
+        )
+        self.assertEqual(category_2.sequence_id, test_sequence)


### PR DESCRIPTION
If a sequence prefix is defined on the product category, there's
no way through the UI to remove it. If the prefix field is emptied,
the existing sequence will still be defined on the category without
any possibility for the user to change the setting.
With this change, removing the prefix will remove the link between
the product category and the sequence.
Moreover, if an existing prefix is redefined on a product category
a new sequence was created instead of reusing an existing one.

As the product.category.sequence_id field of product.category is
only displayed in debug mode, we can allow its edition to ease
fixing of wrong configuration.
However, we need to make sure the prefix defined on these product
categories always matches the prefix defined on the sequence and
restrict any change that would introduce a discrepancy.