### PR TITLE
[IMP] product_manufacturer: Add pre_init_hook for faster install

### DIFF
--- a/product_manufacturer/README.rst
+++ b/product_manufacturer/README.rst
@@ -68,6 +68,7 @@ Contributors
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Héctor Villarreal <hector.villarreal@forgeflow.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_manufacturer/__init__.py
+++ b/product_manufacturer/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from .hooks import pre_init_hook

--- a/product_manufacturer/__manifest__.py
+++ b/product_manufacturer/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
+# Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Product Manufacturer",
@@ -12,4 +13,5 @@
     "data": ["views/product_manufacturer_view.xml"],
     "auto_install": False,
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/product_manufacturer/hooks.py
+++ b/product_manufacturer/hooks.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tools import sql
+
+
+def pre_init_hook(cr):
+    table_name = "product_template"
+    for field_name, field_type in [
+        ("manufacturer", "int4"),
+        ("manufacturer_pname", "varchar"),
+        ("manufacturer_pref", "varchar"),
+        ("manufacturer_purl", "varchar"),
+    ]:
+        if sql.column_exists(cr, table_name, field_name):
+            continue
+        sql.create_column(cr, table_name, field_name, field_type)

--- a/product_manufacturer/readme/CONTRIBUTORS.rst
+++ b/product_manufacturer/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Héctor Villarreal <hector.villarreal@forgeflow.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>

--- a/product_manufacturer/static/description/index.html
+++ b/product_manufacturer/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product Manufacturer</title>
 <style type="text/css">
 
@@ -415,6 +415,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Guewen Baconnier &lt;<a class="reference external" href="mailto:guewen.baconnier&#64;camptocamp.com">guewen.baconnier&#64;camptocamp.com</a>&gt;</li>
 <li>Héctor Villarreal &lt;<a class="reference external" href="mailto:hector.villarreal&#64;forgeflow.com">hector.villarreal&#64;forgeflow.com</a>&gt;</li>
+<li>Michael Tietz (MT Software) &lt;<a class="reference external" href="mailto:mtietz&#64;mt-software.de">mtietz&#64;mt-software.de</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
The performance while installing this module is for a huge amount of products and product templates bad. 
The problem is the  _compute_manufacturer_info this gets called for all product template's, 
because odoo creates the missing columns of product.template and tries to get the record values from the compute method. 
Since the method _compute_manufacturer_info returns only empty values on installing,
it is more performant to create the columns with a pre_init hook. 
Because then odoo does not create the columns and doesn't call the compute method.