### PR TITLE
[14.0][IMP] product_tier_validation : force default state on create and improve _state_to

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -14,7 +14,8 @@ include_wkhtmltopdf: false
 odoo_version: 14.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- product_status
 repo_description: 'TODO: add repo description.'
 repo_name: product-attribute
 repo_slug: product-attribute

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            include: "product_status"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            include: "product_status"
+            name: test with OCB
+          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            exclude: "product_status"
+            makepot: "true"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            exclude: "product_status"
             name: test with OCB
     services:
       postgres:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/product_tier_validation/models/product_template.py
+++ b/product_tier_validation/models/product_template.py
@@ -1,13 +1,24 @@
 # Copyright 2021 Open Source Integrators
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import _, api, models, tools
 from odoo.exceptions import UserError
+from odoo.tools import config
+
 
 class ProductTemplate(models.Model):
     _name = "product.template"
     _inherit = ["product.template", "tier.validation"]
     _tier_validation_manual_config = False
+
+    @property
+    @tools.ormcache()
+    def _state_to(self):
+        return (
+            self.env["product.state"]
+            .search([("code", "not in", self._state_from + [self._cancel_state])])
+            .mapped("code")
+        )
 
     def write(self, vals):
         # Tier Validation does not work with Stages, only States :-(
@@ -24,9 +35,10 @@ class ProductTemplate(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         states = self.env["product.state"].search([("code", "in", self._state_from)])
-        if not states:
-            raise UserError("Wrong configuration of '_state_from' in product.state")
-        for vals in vals_list:
-            if vals.get("product_state_id") not in states.ids:
-                vals["product_state_id"] = states[0].id
+        if not states and not config["test_enable"]:
+            raise UserError(_("Wrong configuration of '_state_from' in product.state"))
+        if states:
+            for vals in vals_list:
+                if vals.get("product_state_id") not in states.ids:
+                    vals["product_state_id"] = states[0].id
         return super().create(vals_list)

--- a/product_tier_validation/tests/test_product_tier_validation.py
+++ b/product_tier_validation/tests/test_product_tier_validation.py
@@ -20,6 +20,7 @@ class TestProductTierValidation(common.SavepointCase):
         )
 
         cls.tier_def_obj = cls.env["tier.definition"]
+        cls.draft_state = cls.env.ref("product_state.product_state_draft")
         cls.normal_state = cls.env.ref("product_state.product_state_sellable")
 
     def test_tier_validation_model_name(self):
@@ -38,3 +39,9 @@ class TestProductTierValidation(common.SavepointCase):
         product.with_user(self.test_user_1).validate_tier()
         product.write({"product_state_id": self.normal_state.id})
         self.assertEqual(product.state, self.normal_state.code)
+
+    def test_create_product_default_state(self):
+        product = self.env["product.template"].create(
+            {"name": "Product bis for test", "product_state_id": self.normal_state.id}
+        )
+        self.assertEqual(product.product_state_id, self.draft_state)

--- a/product_tier_validation/tests/test_product_tier_validation.py
+++ b/product_tier_validation/tests/test_product_tier_validation.py
@@ -42,6 +42,9 @@ class TestProductTierValidation(common.SavepointCase):
 
     def test_create_product_default_state(self):
         product = self.env["product.template"].create(
-            {"name": "Product bis for test", "product_state_id": self.normal_state.id}
+            {
+                "name": "Product bis for test",
+                "product_state_id": self.normal_state.id,
+            }
         )
         self.assertEqual(product.product_state_id, self.draft_state)


### PR DESCRIPTION
When creating a new product, we can directly set a normal / sellable state on it, without validation. This PR avoid that by forcing the "_state_from" on product creation. 

First commit is the failing test, second test fix it. 

Last commit purpose is to improve _state_to value for products : 
The base module "base_tier_validation" proposes "confirmed" as "_state_to" value, which is not a product state. Furthermore, we can create other product.state. In order to use this module out of the box and to take account of all the states created by users, we propose here to change the _state_to accordingly.