### PR TITLE
[14.0][IMP] product_tier_validation state_to default values

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.12.0
+_commit: v1.14.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
@@ -13,7 +13,8 @@ include_wkhtmltopdf: false
 odoo_version: 14.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- product_status
 repo_description: 'TODO: add repo description.'
 repo_name: product-attribute
 repo_slug: product-attribute

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:
@@ -36,9 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            include: "product_status"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            include: "product_status"
+            name: test with OCB
+          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            exclude: "product_status"
+            makepot: "true"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            exclude: "product_status"
             name: test with OCB
     services:
       postgres:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/product_tier_validation/models/product_template.py
+++ b/product_tier_validation/models/product_template.py
@@ -1,13 +1,25 @@
 # Copyright 2021 Open Source Integrators
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, models, tools
 from odoo.exceptions import UserError
 
 class ProductTemplate(models.Model):
     _name = "product.template"
     _inherit = ["product.template", "tier.validation"]
     _tier_validation_manual_config = False
+
+    @property
+    @tools.ormcache()
+    def _state_to(self):
+        return (
+            self.env["product.state"]
+            .search([])
+            .filtered(
+                lambda x, s=self: x.code not in (s._state_from + [s._cancel_state])
+            )
+            .mapped("code")
+        )
 
     def write(self, vals):
         # Tier Validation does not work with Stages, only States :-(

--- a/product_tier_validation/tests/test_product_tier_validation.py
+++ b/product_tier_validation/tests/test_product_tier_validation.py
@@ -20,6 +20,7 @@ class TestProductTierValidation(common.SavepointCase):
         )
 
         cls.tier_def_obj = cls.env["tier.definition"]
+        cls.draft_state = cls.env.ref("product_state.product_state_draft")
         cls.normal_state = cls.env.ref("product_state.product_state_sellable")
 
     def test_tier_validation_model_name(self):
@@ -38,3 +39,9 @@ class TestProductTierValidation(common.SavepointCase):
         product.with_user(self.test_user_1).validate_tier()
         product.write({"product_state_id": self.normal_state.id})
         self.assertEqual(product.state, self.normal_state.code)
+
+    def test_create_product_default_state(self):
+        product = self.env["product.template"].create(
+            {"name": "Product bis for test", "product_state_id": self.normal_state.id}
+        )
+        self.assertEqual(product.product_state_id, self.draft_state)

--- a/product_tier_validation/tests/test_product_tier_validation.py
+++ b/product_tier_validation/tests/test_product_tier_validation.py
@@ -42,6 +42,9 @@ class TestProductTierValidation(common.SavepointCase):
 
     def test_create_product_default_state(self):
         product = self.env["product.template"].create(
-            {"name": "Product bis for test", "product_state_id": self.normal_state.id}
+            {
+                "name": "Product bis for test",
+                "product_state_id": self.normal_state.id,
+            }
         )
         self.assertEqual(product.product_state_id, self.draft_state)


### PR DESCRIPTION
The base module "base_tier_validation" proposes "confirmed" as "_state_to" value, which is not a product state. Furthermore, we can create other product.state. In order to use this module out of the box and to take account of all the states created by users, we propose here to change the _state_to accordingly. 
