### PR TITLE
[15.0][FIX] product_supplierinfo_for_customer: Use supplierinfo also for child contacts

### DIFF
--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -132,4 +132,13 @@ class ProductProduct(models.Model):
             .sorted(lambda s: (s.sequence, s.min_qty, s.price, s.id))
         )
         res_1 = res.sorted("product_tmpl_id")[:1]
-        return res_1
+        if res_1 or not partner.parent_id:
+            return res_1
+        else:
+            return self._select_customerinfo(
+                partner=partner.parent_id,
+                params=params,
+                _quantity=_quantity,
+                _date=_date,
+                _uom_id=_uom_id,
+            )

--- a/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
+++ b/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
@@ -98,6 +98,16 @@ class TestProductSupplierinfoForCustomer(TransactionCase):
             res[self.product.id], 750.0, "Error: price does not match list price"
         )
 
+    def test_product_supplierinfo_price_parent(self):
+        child = self._create_customer("child")
+        child.parent_id = self.customer
+        price = self.product._get_price_from_customerinfo(partner_id=child.id)
+        self.assertEqual(
+            price,
+            100.0,
+            "Error: Price not found for product and customer (set on parent)",
+        )
+
     def test_variant_supplierinfo_price(self):
         """
         This test check the price for a customer with a product with variants.


### PR DESCRIPTION
Often in a sale order a specific sub contact of a customer is selected as the partner. Currently the sub contact does not inherit the supplier info records of the parent. With this patch when there is no supplier info record on the sub contact it will try to fall back to the parent.