### PR TITLE
[13.0][FIX] product_pricelist_direct_print: Invalid field 'message_ids' on model 'product.pricelist.print' when opening notification from odoo

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -11,6 +11,7 @@ from odoo.osv import expression
 
 class ProductPricelistPrint(models.TransientModel):
     _name = "product.pricelist.print"
+    _inherit = "mail.thread"
     _description = "Product Pricelist Print"
 
     pricelist_id = fields.Many2one(comodel_name="product.pricelist", string="Pricelist")


### PR DESCRIPTION
Steps to reproduce:
- Send by email to some user with notification -> Handle in Odoo
- Try to open the notification on the reciever view

cc @Tecnativa TT41838

ping @sergio-teruel @carlosdauden 