### PR TITLE
[15.0][FIX] product_abc_classification_sale: Flush data in tests

### DIFF
--- a/product_abc_classification_sale/tests/test_sale_product_classification.py
+++ b/product_abc_classification_sale/tests/test_sale_product_classification.py
@@ -57,7 +57,8 @@ class TestSaleProductClassification(TestSaleProductClassificationCase):
         )
         self._test_product_classification(product_classification)
         # Product 1 gets an A!
-        self._create_sale("2021-04-01", self.partner, self.prod_1, 20000)
+        order = self._create_sale("2021-04-01", self.partner, self.prod_1, 20000)
+        order.flush()  # make sure data are dumped to DB
         cron_classify()
         product_classification.update({self.prod_1: self.a})
         self._test_product_classification(product_classification)

--- a/product_abc_classification_sale/tests/test_sale_product_classification_common.py
+++ b/product_abc_classification_sale/tests/test_sale_product_classification_common.py
@@ -83,6 +83,7 @@ class TestSaleProductClassificationCase(common.TransactionCase):
         sale_order.action_done()
         # Force the date so to reproduce the calendar
         sale_order.date_order = date
+        return sale_order
 
     def _test_product_classification(self, classifications):
         """Helper to assert classifications in batch. It's expected to come


### PR DESCRIPTION
Using models that rely on an SQL view (like sale.report) requires that data are already dumped to DB before querying it, which is not always the case depending on the ORM stack and installed modules.

We should ensure that dump using flush before operating with such data at SQL level.

@Tecnativa 