### PR TITLE
product_supplierinfo_group: fix deleting product_supplierinfo_group

### DIFF
--- a/product_supplierinfo_group/models/product_supplierinfo.py
+++ b/product_supplierinfo_group/models/product_supplierinfo.py
@@ -21,7 +21,11 @@ _logger = logging.getLogger(__name__)
 class ProductSupplierinfo(models.Model):
     _inherit = "product.supplierinfo"
 
-    group_id = fields.Many2one("product.supplierinfo.group", required=True)
+    group_id = fields.Many2one(
+        "product.supplierinfo.group",
+        required=True,
+        ondelete="cascade",
+    )
     company_id = fields.Many2one(related="group_id.company_id", store=True)
     product_tmpl_id = fields.Many2one(related="group_id.product_tmpl_id", store=True)
     name = fields.Many2one(related="group_id.partner_id", store=True, required=False)


### PR DESCRIPTION
The delete cascade was missing so it was not possible to delete a product_supplierinfo_group
@Kev-Roche 