### PR TITLE
[15.0][FW][IMP] product_variant_attribute_name_manager: option to display/hide attribute value in product name

### DIFF
--- a/product_variant_attribute_name_manager/__manifest__.py
+++ b/product_variant_attribute_name_manager/__manifest__.py
@@ -10,5 +10,5 @@
     "license": "AGPL-3",
     "auto_install": False,
     "installable": True,
-    "maintainers": ["oriolvforgeflow"],
+    "maintainers": ["JordiMForgeFlow"],
 }

--- a/product_variant_attribute_name_manager/models/product_attribute.py
+++ b/product_variant_attribute_name_manager/models/product_attribute.py
@@ -5,8 +5,13 @@ class ProductAttribute(models.Model):
     _inherit = "product.attribute"
 
     short_name = fields.Char(help="Displayed as the variant attribute name.")
+    display_attribute_value = fields.Boolean(
+        "Display Attribute Value on Product Variant",
+        default=True,
+        help="If checked, it will display the variant attribute value in the product name.",
+    )
     display_attribute_name = fields.Boolean(
-        "Display Attribute Name on Product Variant",
+        "Display Attribute Name/Short Name on Product Variant",
         help="If checked, it will display the variant attribute name before its value.",
     )
 
@@ -29,6 +34,8 @@ class ProductTemplateAttributeValue(models.Model):
             self._without_no_variant_attributes()._filter_single_value_lines(),
             key=lambda seq: seq.attribute_line_id.sequence,
         ):
+            if not ptav.attribute_id.display_attribute_value:
+                continue
             if ptav.attribute_id.display_attribute_name:
                 if ptav.attribute_id.short_name:
                     display_ptav_list.append(

--- a/product_variant_attribute_name_manager/models/product_attribute.py
+++ b/product_variant_attribute_name_manager/models/product_attribute.py
@@ -15,6 +15,11 @@ class ProductAttribute(models.Model):
         help="If checked, it will display the variant attribute name before its value.",
     )
 
+    display_no_variant_attribute = fields.Boolean(
+        "Display No Variant Attributes on Product Variant",
+        help="If checked, it will display the no variant attribute.",
+    )
+
 
 class ProductTemplateAttributeLine(models.Model):
     _inherit = "product.template.attribute.line"
@@ -31,11 +36,14 @@ class ProductTemplateAttributeValue(models.Model):
         The order of the attributes is defined by the user"""
         display_ptav_list = []
         for ptav in sorted(
-            self._without_no_variant_attributes()._filter_single_value_lines(),
+            self._filter_single_value_lines(),
             key=lambda seq: seq.attribute_line_id.sequence,
         ):
             if not ptav.attribute_id.display_attribute_value:
                 continue
+            if not ptav.attribute_id.display_no_variant_attribute:
+                if not ptav._without_no_variant_attributes():
+                    continue
             if ptav.attribute_id.display_attribute_name:
                 if ptav.attribute_id.short_name:
                     display_ptav_list.append(

--- a/product_variant_attribute_name_manager/models/product_attribute.py
+++ b/product_variant_attribute_name_manager/models/product_attribute.py
@@ -20,6 +20,11 @@ class ProductAttribute(models.Model):
         help="If checked, it will display the no variant attribute.",
     )
 
+    display_single_variant_attribute = fields.Boolean(
+        "Display Single Variant Attributes on Product Variant",
+        help="If checked, it will display the single variant attribute.",
+    )
+
 
 class ProductTemplateAttributeLine(models.Model):
     _inherit = "product.template.attribute.line"
@@ -35,12 +40,12 @@ class ProductTemplateAttributeValue(models.Model):
         If active, it will display the name or short name before its value.
         The order of the attributes is defined by the user"""
         display_ptav_list = []
-        for ptav in sorted(
-            self._filter_single_value_lines(),
-            key=lambda seq: seq.attribute_line_id.sequence,
-        ):
+        for ptav in sorted(self, key=lambda seq: seq.attribute_line_id.sequence):
             if not ptav.attribute_id.display_attribute_value:
                 continue
+            if not ptav.attribute_id.display_single_variant_attribute:
+                if not ptav._filter_single_value_lines():
+                    continue
             if not ptav.attribute_id.display_no_variant_attribute:
                 if not ptav._without_no_variant_attributes():
                     continue

--- a/product_variant_attribute_name_manager/readme/CONTRIBUTORS.rst
+++ b/product_variant_attribute_name_manager/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Oriol Villamayor <oriol.villamayor@forgeflow.com>
+* Jordi Masvidal <jordi.masvidal@forgeflow.com>

--- a/product_variant_attribute_name_manager/readme/DESCRIPTION.rst
+++ b/product_variant_attribute_name_manager/readme/DESCRIPTION.rst
@@ -1,5 +1,6 @@
 Manage how to display the attributes on the product variant name.
 
 * Choose if you want to display the name of the attribute before its value.
+* Choose if you want to display the attribute value in the product name.
 * Set a short name to be displayed as the attribute's name.
 * Set the order of the attributes for each product.

--- a/product_variant_attribute_name_manager/readme/DESCRIPTION.rst
+++ b/product_variant_attribute_name_manager/readme/DESCRIPTION.rst
@@ -4,3 +4,4 @@ Manage how to display the attributes on the product variant name.
 * Choose if you want to display the attribute value in the product name.
 * Set a short name to be displayed as the attribute's name.
 * Set the order of the attributes for each product.
+* Choose if you want to display attribute value name for Single Variant Attribute

--- a/product_variant_attribute_name_manager/tests/test_product_variant_attribute_name_manager.py
+++ b/product_variant_attribute_name_manager/tests/test_product_variant_attribute_name_manager.py
@@ -17,6 +17,7 @@ class TestProductTemplateAttributeValue(TransactionCase):
         self._add_ssd_attribute()
         self._add_ram_attribute()
         self._add_hdd_attribute()
+        self._add_color_attribute()
 
     def _add_ssd_attribute(self):
         self.ssd_attribute = self.env["product.attribute"].create(
@@ -91,6 +92,29 @@ class TestProductTemplateAttributeValue(TransactionCase):
             }
         )
 
+    def _add_color_attribute(self):
+        self.color_attribute = self.env["product.attribute"].create(
+            {
+                "name": "COLOR",
+                "sequence": 4,
+                "display_attribute_name": True,
+            }
+        )
+        self.color_white = self.env["product.attribute.value"].create(
+            {"name": "White", "attribute_id": self.color_attribute.id, "sequence": 1}
+        )
+
+        self.computer_color_attribute_lines = self.env[
+            "product.template.attribute.line"
+        ].create(
+            {
+                "product_tmpl_id": self.computer.id,
+                "attribute_id": self.color_attribute.id,
+                "value_ids": [(6, 0, [self.color_white.id])],
+                "sequence": 4,
+            }
+        )
+
     def test_display_attribute_name(self):
         variant_names = [
             variant.product_template_attribute_value_ids._get_combination_name()
@@ -116,6 +140,21 @@ class TestProductTemplateAttributeValue(TransactionCase):
             "Mem: 256 GB, 1 To, RAM: 8 GB",
             variant_names,
             "Variant name extension not correct",
+        )
+
+        self.color_attribute.display_single_variant_attribute = True
+
+        variant_names = [
+            variant.product_template_attribute_value_ids._get_combination_name()
+            for variant in self.env["product.product"].search(
+                [("product_tmpl_id", "=", self.computer.id)]
+            )
+        ]
+
+        self.assertIn(
+            "1 To, Mem: 256 GB, RAM: 8 GB, COLOR: White",
+            variant_names,
+            "Variant name extension not found",
         )
 
     def test_display_attribute_value(self):

--- a/product_variant_attribute_name_manager/tests/test_product_variant_attribute_name_manager.py
+++ b/product_variant_attribute_name_manager/tests/test_product_variant_attribute_name_manager.py
@@ -91,7 +91,7 @@ class TestProductTemplateAttributeValue(TransactionCase):
             }
         )
 
-    def test_get_combination_name(self):
+    def test_display_attribute_name(self):
         variant_names = [
             variant.product_template_attribute_value_ids._get_combination_name()
             for variant in self.env["product.product"].search(
@@ -114,6 +114,37 @@ class TestProductTemplateAttributeValue(TransactionCase):
         )
         self.assertNotIn(
             "Mem: 256 GB, 1 To, RAM: 8 GB",
+            variant_names,
+            "Variant name extension not correct",
+        )
+
+    def test_display_attribute_value(self):
+        # Do not display RAM Attribute value
+        self.ram_attribute.write({"display_attribute_value": False})
+        variant_names = [
+            variant.product_template_attribute_value_ids._get_combination_name()
+            for variant in self.env["product.product"].search(
+                [("product_tmpl_id", "=", self.computer.id)]
+            )
+        ]
+
+        self.assertIn(
+            "1 To, Mem: 256 GB",
+            variant_names,
+            "Variant name extension not found",
+        )
+        self.assertIn(
+            "2 To, Mem: 512 GB",
+            variant_names,
+            "Variant name extension not found",
+        )
+        self.assertNotIn(
+            "1 To, Mem: 256 GB, RAM: 8 GB",
+            variant_names,
+            "Variant name extension not correct",
+        )
+        self.assertNotIn(
+            "2 To, Mem: 512 GB, RAM: 8 GB",
             variant_names,
             "Variant name extension not correct",
         )

--- a/product_variant_attribute_name_manager/views/product_variant_attribute_name_manager_view.xml
+++ b/product_variant_attribute_name_manager/views/product_variant_attribute_name_manager_view.xml
@@ -34,6 +34,7 @@
                         name="display_no_variant_attribute"
                         attrs="{'invisible': [('create_variant','!=','no_variant')]}"
                     />
+                    <field name="display_single_variant_attribute" />
                 </group>
             </group>
         </field>

--- a/product_variant_attribute_name_manager/views/product_variant_attribute_name_manager_view.xml
+++ b/product_variant_attribute_name_manager/views/product_variant_attribute_name_manager_view.xml
@@ -23,9 +23,15 @@
             <xpath expr="//field[@name='name']" position="after">
               <field name="short_name" />
             </xpath>
-            <xpath expr="//field[@name='create_variant']" position="after">
-              <field name="display_attribute_name" />
-            </xpath>
+            <group name="main_fields" position="after">
+                <group name="product_variant_name" class="o_label_nowrap">
+                    <field name="display_attribute_value" />
+                    <field
+                        name="display_attribute_name"
+                        attrs="{'invisible': [('display_attribute_value','=',False)]}"
+                    />
+                </group>
+            </group>
         </field>
     </record>
 

--- a/product_variant_attribute_name_manager/views/product_variant_attribute_name_manager_view.xml
+++ b/product_variant_attribute_name_manager/views/product_variant_attribute_name_manager_view.xml
@@ -30,6 +30,10 @@
                         name="display_attribute_name"
                         attrs="{'invisible': [('display_attribute_value','=',False)]}"
                     />
+                    <field
+                        name="display_no_variant_attribute"
+                        attrs="{'invisible': [('create_variant','!=','no_variant')]}"
+                    />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
FW of https://github.com/OCA/product-attribute/pull/1290 and https://github.com/OCA/product-attribute/pull/1048 (including the partial port in V14 on https://github.com/OCA/product-attribute/pull/1194)