### PR TITLE
[16.0][FIX] product_logistics_uom: Store value in system UOM

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -14,7 +14,8 @@ include_wkhtmltopdf: false
 odoo_version: 16.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- product_dimension
 repo_description: 'TODO: add repo description.'
 repo_name: product-attribute
 repo_slug: product-attribute

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            include: "product_dimension"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            include: "product_dimension"
+            name: test with OCB
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            exclude: "product_dimension"
+            makepot: "true"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            exclude: "product_dimension"
             name: test with OCB
     services:
       postgres:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/product_logistics_uom/README.rst
+++ b/product_logistics_uom/README.rst
@@ -23,7 +23,7 @@ Product logistics UoM
     :target: https://runbot.odoo-community.org/runbot/135/16.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows to choose an Unit Of Measure (UoM) for products weight and volume.
 It can be set product per product for users in group_uom.
@@ -32,6 +32,19 @@ Without this module, you only have the choice between Kg or Lb(s) and m³ for al
 
 For some business cases, you need to express in more precise UoM than default ones like Liters
 instead of M³.
+
+Even if you choose another UoM for the weight or volume, the system will still
+store the value for these fields in the Odoo default UoM (Kg or Lb(s) and m³).
+This ensures that the arithmetic operations on these fields are correct and
+consistent with the rest of the addons.
+
+Once this addon is installed values stored into the initial Volume and Weight fields
+on the product and product template models are no more rounded to the decimal
+precision defined for these fields. This could lead to some side effects into
+reportss where these fields are used. You can replace the fields by the new
+ones provided by this addon to avoid this problem (product_volume and product_weight).
+In any cases, since you use different UoM by product, you should most probably
+modify your reportss to display the right UoM.
 
 **Table of contents**
 
@@ -57,6 +70,18 @@ To change on a specific product
 
 #. Go the product form you can change the UoM directly.
 
+Usage
+=====
+
+Once installed and the 'Sell and purchase products in different units of measure'
+option is enabled, the 'Unit of Measure' field will become updatable on the
+'Product' form for users with the permission 'Manage Multiple Units of Measure'.
+
+If the displayed value is 0.00 and a warning icon is displayed in front of the
+unit of measure, it means that the value is too small to be displayed in the
+current unit of measure. You should change the unit of measure to a larger one
+to see the value.
+
 Bug Tracker
 ===========
 
@@ -74,12 +99,14 @@ Authors
 ~~~~~~~
 
 * Akretion
+* ACSONE SA/NV
 
 Contributors
 ~~~~~~~~~~~~
 
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Fernando La Chica <fernandolachica@gmail.com>
+* Laurent Mignon <laurent.mignon@acsone.eu>
 
 Other credits
 ~~~~~~~~~~~~~
@@ -108,7 +135,7 @@ promote its widespread use.
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-hparfr| 
+|maintainer-hparfr|
 
 This module is part of the `OCA/product-attribute <https://github.com/OCA/product-attribute/tree/16.0/product_logistics_uom>`_ project on GitHub.
 

--- a/product_logistics_uom/__init__.py
+++ b/product_logistics_uom/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/product_logistics_uom/__manifest__.py
+++ b/product_logistics_uom/__manifest__.py
@@ -3,11 +3,11 @@
 {
     "name": "Product logistics UoM",
     "summary": "Configure product weights and volume UoM",
-    "version": "16.0.1.0.0",
+    "version": "16.0.2.0.0",
     "development_status": "Beta",
     "category": "Product",
     "website": "https://github.com/OCA/product-attribute",
-    "author": " Akretion, Odoo Community Association (OCA)",
+    "author": " Akretion, ACSONE SA/NV, Odoo Community Association (OCA)",
     "maintainers": ["hparfr"],
     "license": "AGPL-3",
     "installable": True,
@@ -18,4 +18,5 @@
         "views/res_config_settings.xml",
         "views/product.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/product_logistics_uom/hooks.py
+++ b/product_logistics_uom/hooks.py
@@ -1,0 +1,119 @@
+# Copyright 2023 ACSONE SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo.tools import sql
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):  # pragma: nocover
+    """Recompute the volume and weight column on product and template
+    by converting the value from the uom defined on the product to the default uom
+    """
+    if sql.column_exists(cr, "product_template", "volume_uom_id"):
+        _logger.info("Recompute volume on product.product")
+        # get default m3 uom
+        cr.execute(
+            """
+            SELECT res_id
+            FROM ir_model_data
+            WHERE module = 'uom' AND name = 'product_uom_cubic_meter'
+            """
+        )
+        m3_uom_id = cr.fetchone()[0]
+        # get uom factor
+        cr.execute(
+            """
+            SELECT factor
+            FROM uom_uom
+            WHERE id = %s
+            """,
+            (m3_uom_id,),
+        )
+        m3_uom_factor = cr.fetchone()[0]
+        # update volume where volume_uom_id is not null and not m3
+        cr.execute(
+            """
+            UPDATE product_product
+            SET volume = product_product.volume / product_uom.factor  * %s
+            FROM uom_uom product_uom,
+            product_template pt
+            WHERE product_uom.id = volume_uom_id
+                AND pt.id = product_product.product_tmpl_id
+                AND volume_uom_id IS NOT NULL AND pt.volume_uom_id != %s
+            """,
+            (m3_uom_factor, m3_uom_id),
+        )
+        _logger.info(f"{cr.rowcount} product_product rows updated")
+        # update product_template with 1 product_product
+        cr.execute(
+            """
+            UPDATE product_template
+            SET Volume = unique_product.volume
+            FROM (
+                SELECT product_tmpl_id, volume
+                FROM product_product
+                WHERE volume is not null
+                GROUP BY product_tmpl_id, volume
+                HAVING COUNT(*) = 1
+            ) unique_product
+            WHERE product_template.id = unique_product.product_tmpl_id
+            AND product_template.volume_uom_id != %s
+            """,
+            (m3_uom_id,),
+        )
+        _logger.info(f"{cr.rowcount} product_template rows updated")
+    if sql.column_exists(cr, "product_template", "weight_uom_id"):
+        _logger.info("Recompute weight on product.product")
+        # get default kg uom
+        cr.execute(
+            """
+            SELECT res_id
+            FROM ir_model_data
+            WHERE module = 'uom' AND name = 'product_uom_kgm'
+            """
+        )
+        kg_uom_id = cr.fetchone()[0]
+        # get uom factor
+        cr.execute(
+            """
+            SELECT factor
+            FROM uom_uom
+            WHERE id = %s
+            """,
+            (kg_uom_id,),
+        )
+        kg_uom_factor = cr.fetchone()[0]
+        # update weight where weight_uom_id is not null and not kg
+        cr.execute(
+            """
+            UPDATE product_product
+            SET weight = product_product.weight / product_uom.factor  * %s
+            FROM uom_uom product_uom, product_template pt
+            WHERE product_uom.id = weight_uom_id
+                AND pt.id = product_product.product_tmpl_id
+                AND weight_uom_id IS NOT NULL AND pt.weight_uom_id != %s
+            """,
+            (kg_uom_factor, kg_uom_id),
+        )
+        _logger.info(f"{cr.rowcount} product_product rows updated")
+        # update product_template with 1 product_product
+        cr.execute(
+            """
+            UPDATE product_template
+            SET weight = unique_product.weight
+            FROM (
+                SELECT product_tmpl_id, weight
+                FROM product_product
+                WHERE volume is not null
+                GROUP BY product_tmpl_id, weight
+                HAVING COUNT(*) = 1
+            ) unique_product
+            WHERE product_template.id = unique_product.product_tmpl_id
+            AND product_template.weight_uom_id != %s
+            """,
+            (kg_uom_id,),
+        )
+        _logger.info(f"{cr.rowcount} product_template rows updated")

--- a/product_logistics_uom/migrations/16.0.2.0.0/post-migrate.py
+++ b/product_logistics_uom/migrations/16.0.2.0.0/post-migrate.py
@@ -1,0 +1,10 @@
+# Copyright 2023 ACSONE SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+# pylint: disable=odoo-addons-relative-import
+from odoo.addons.product_logistics_uom.hooks import pre_init_hook
+
+
+def migrate(cr, version):
+    """Migrate data from product_logistics_uom module."""
+    pre_init_hook(cr)

--- a/product_logistics_uom/models/__init__.py
+++ b/product_logistics_uom/models/__init__.py
@@ -1,2 +1,3 @@
+from . import product_product
 from . import product_template
 from . import res_config_settings

--- a/product_logistics_uom/models/product_product.py
+++ b/product_logistics_uom/models/product_product.py
@@ -1,0 +1,117 @@
+# Copyright 2023 ACSONE SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import api, fields, models
+from odoo.tools import float_is_zero
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    # remove rounding from volume and weight
+    # this is needed to avoid rounding errors when converting between units
+    # and is safe since we display the volume and weight in the product's
+    # volume and weight UOM. In the same time, we need to keep the volume
+    # we ensure that no information is lost by storing the volume and weight
+    # without rounding.
+    volume = fields.Float(digits=False)
+    weight = fields.Float(digits=False)
+
+    product_volume = fields.Float(
+        "Volume in product UOM",
+        digits="Volume",
+        help="The volume in the product's volume UOM.",
+        compute="_compute_product_volume",
+        inverse="_inverse_product_volume",
+    )
+    product_weight = fields.Float(
+        "Weight in product UOM",
+        digits="Stock Weight",
+        help="The weight in the product's weight UOM.",
+        compute="_compute_product_weight",
+        inverse="_inverse_product_weight",
+    )
+
+    show_volume_uom_warning = fields.Boolean(
+        help="Technical field used to warn the user to change the volume"
+        "uom since the value for product_volume is too small and has been"
+        "rounded.",
+        compute="_compute_show_volume_uom_warning",
+    )
+
+    show_weight_uom_warning = fields.Boolean(
+        help="Technical field used to warn the user to change the weight"
+        "uom since the value for product_weight is too small and has been"
+        "rounded.",
+        compute="_compute_show_weight_uom_warning",
+    )
+
+    @api.depends("product_volume", "product_tmpl_id.volume_uom_id")
+    def _compute_product_volume(self):
+        odoo_volume_uom = (
+            self.product_tmpl_id._get_volume_uom_id_from_ir_config_parameter()
+        )
+        for product in self:
+            product.product_volume = odoo_volume_uom._compute_quantity(
+                qty=product.volume,
+                to_unit=product.volume_uom_id,
+                round=False,  # avoid losing information
+            )
+
+    def _inverse_product_volume(self):
+        odoo_volume_uom = (
+            self.product_tmpl_id._get_volume_uom_id_from_ir_config_parameter()
+        )
+        for product in self:
+            product.volume = product.volume_uom_id._compute_quantity(
+                qty=product.product_volume,
+                to_unit=odoo_volume_uom,
+                round=False,  # avoid losing information
+            )
+
+    @api.depends("product_weight", "product_tmpl_id.weight_uom_id")
+    def _compute_product_weight(self):
+        odoo_weight_uom = (
+            self.product_tmpl_id._get_weight_uom_id_from_ir_config_parameter()
+        )
+        for product in self:
+            product.product_weight = odoo_weight_uom._compute_quantity(
+                qty=product.weight,
+                to_unit=product.weight_uom_id,
+                round=False,  # avoid losing information
+            )
+
+    def _inverse_product_weight(self):
+        odoo_weight_uom = (
+            self.product_tmpl_id._get_weight_uom_id_from_ir_config_parameter()
+        )
+        for product in self:
+            product.weight = product.weight_uom_id._compute_quantity(
+                qty=product.product_weight, to_unit=odoo_weight_uom, round=False
+            )
+
+    @api.depends("product_volume", "product_tmpl_id.volume_uom_id", "volume")
+    def _compute_show_volume_uom_warning(self):
+        odoo_volume_uom = (
+            self.product_tmpl_id._get_volume_uom_id_from_ir_config_parameter()
+        )
+        for product in self:
+            product.show_volume_uom_warning = (
+                float_is_zero(
+                    product.product_volume, precision_rounding=odoo_volume_uom.rounding
+                )
+                and product.volume != 0.0
+            )
+
+    @api.depends("product_weight", "product_tmpl_id.weight_uom_id", "weight")
+    def _compute_show_weight_uom_warning(self):
+        odoo_weight_uom = (
+            self.product_tmpl_id._get_weight_uom_id_from_ir_config_parameter()
+        )
+        for product in self:
+            product.show_weight_uom_warning = (
+                float_is_zero(
+                    product.product_weight, precision_rounding=odoo_weight_uom.rounding
+                )
+                and product.weight != 0.0
+            )

--- a/product_logistics_uom/readme/CONTRIBUTORS.rst
+++ b/product_logistics_uom/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Fernando La Chica <fernandolachica@gmail.com>
+* Laurent Mignon <laurent.mignon@acsone.eu>

--- a/product_logistics_uom/readme/DESCRIPTION.rst
+++ b/product_logistics_uom/readme/DESCRIPTION.rst
@@ -5,3 +5,16 @@ Without this module, you only have the choice between Kg or Lb(s) and m³ for al
 
 For some business cases, you need to express in more precise UoM than default ones like Liters
 instead of M³.
+
+Even if you choose another UoM for the weight or volume, the system will still
+store the value for these fields in the Odoo default UoM (Kg or Lb(s) and m³).
+This ensures that the arithmetic operations on these fields are correct and
+consistent with the rest of the addons.
+
+Once this addon is installed values stored into the initial Volume and Weight fields
+on the product and product template models are no more rounded to the decimal
+precision defined for these fields. This could lead to some side effects into
+reportss where these fields are used. You can replace the fields by the new
+ones provided by this addon to avoid this problem (product_volume and product_weight).
+In any cases, since you use different UoM by product, you should most probably
+modify your reportss to display the right UoM.

--- a/product_logistics_uom/readme/USAGE.rst
+++ b/product_logistics_uom/readme/USAGE.rst
@@ -1,0 +1,8 @@
+Once installed and the 'Sell and purchase products in different units of measure'
+option is enabled, the 'Unit of Measure' field will become updatable on the
+'Product' form for users with the permission 'Manage Multiple Units of Measure'.
+
+If the displayed value is 0.00 and a warning icon is displayed in front of the
+unit of measure, it means that the value is too small to be displayed in the
+current unit of measure. You should change the unit of measure to a larger one
+to see the value.

--- a/product_logistics_uom/static/description/index.html
+++ b/product_logistics_uom/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product logistics UoM</title>
 <style type="text/css">
 
@@ -373,17 +373,29 @@ It can be set product per product for users in group_uom.</p>
 <p>Without this module, you only have the choice between Kg or Lb(s) and m³ for all the products.</p>
 <p>For some business cases, you need to express in more precise UoM than default ones like Liters
 instead of M³.</p>
+<p>Even if you choose another UoM for the weight or volume, the system will still
+store the value for these fields in the Odoo default UoM (Kg or Lb(s) and m³).
+This ensures that the arithmetic operations on these fields are correct and
+consistent with the rest of the addons.</p>
+<p>Once this addon is installed values stored into the initial Volume and Weight fields
+on the product and product template models are no more rounded to the decimal
+precision defined for these fields. This could lead to some side effects into
+reportss where these fields are used. You can replace the fields by the new
+ones provided by this addon to avoid this problem (product_volume and product_weight).
+In any cases, since you use different UoM by product, you should most probably
+modify your reportss to display the right UoM.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
 <li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="id7">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="id8">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -405,8 +417,18 @@ instead of M³.</p>
 <li>Go the product form you can change the UoM directly.</li>
 </ol>
 </div>
+<div class="section" id="usage">
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
+<p>Once installed and the ‘Sell and purchase products in different units of measure’
+option is enabled, the ‘Unit of Measure’ field will become updatable on the
+‘Product’ form for users with the permission ‘Manage Multiple Units of Measure’.</p>
+<p>If the displayed value is 0.00 and a warning icon is displayed in front of the
+unit of measure, it means that the value is too small to be displayed in the
+current unit of measure. You should change the unit of measure to a larger one
+to see the value.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/product-attribute/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -414,22 +436,24 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
+<li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li>Raphaël Reverdy &lt;<a class="reference external" href="mailto:raphael.reverdy&#64;akretion.com">raphael.reverdy&#64;akretion.com</a>&gt;</li>
 <li>Fernando La Chica &lt;<a class="reference external" href="mailto:fernandolachica&#64;gmail.com">fernandolachica&#64;gmail.com</a>&gt;</li>
+<li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#id7">Other credits</a></h2>
+<h2><a class="toc-backref" href="#id8">Other credits</a></h2>
 <p>The development of this module has been financially supported by:</p>
 <ul class="simple">
 <li>Akretion &lt;<a class="reference external" href="https://akretion.com">https://akretion.com</a>&gt;</li>
@@ -437,7 +461,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/product_logistics_uom/tests/__init__.py
+++ b/product_logistics_uom/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_logistics_uom

--- a/product_logistics_uom/tests/test_product_logistics_uom.py
+++ b/product_logistics_uom/tests/test_product_logistics_uom.py
@@ -1,0 +1,113 @@
+# Copyright 2023 ACSONE SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProductLogisticsUom(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestProductLogisticsUom, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+            }
+        )
+        cls.weigh_uom_kg = cls.env.ref("uom.product_uom_kgm")
+        cls.weigh_uom_g = cls.env.ref("uom.product_uom_gram")
+        cls.volume_uom_m3 = cls.env.ref("uom.product_uom_cubic_meter")
+        cls.volume_uom_l = cls.env.ref("uom.product_uom_litre")
+        # set volume in m3 and weight in kg
+        cls.env["ir.config_parameter"].set_param("product.weight_in_lbs", "0")
+        cls.env["ir.config_parameter"].set_param("product.volume_in_cubic_feet", "0")
+
+    def test_product_volume(self):
+        self.product.volume_uom_id = self.volume_uom_l
+        self.product.volume = 1
+        self.assertEqual(self.product.product_volume, 1000)
+        self.product.product_volume = 10
+        self.assertEqual(self.product.volume, 0.01)
+        self.product.volume_uom_id = self.volume_uom_m3
+        self.assertEqual(self.product.product_volume, self.product.volume)
+
+    def test_product_show_product_uom_warning(self):
+        self.product.volume_uom_id = self.volume_uom_m3
+        self.product.volume = 0.0001
+        self.assertTrue(self.product.show_volume_uom_warning)
+        self.product.volume_uom_id = self.volume_uom_l
+        self.assertFalse(self.product.show_volume_uom_warning)
+
+    def test_product_weight(self):
+        self.product.weight_uom_id = self.weigh_uom_g
+        self.product.weight = 1
+        self.assertEqual(self.product.product_weight, 1000)
+        self.product.product_weight = 10
+        self.assertEqual(self.product.weight, 0.01)
+        self.product.weight_uom_id = self.weigh_uom_kg
+        self.assertEqual(self.product.product_weight, self.product.weight)
+
+    def test_product_show_product_weight_warning(self):
+        self.product.weight_uom_id = self.weigh_uom_kg
+        self.product.weight = 0.0001
+        self.assertTrue(self.product.show_weight_uom_warning)
+        self.product.weight_uom_id = self.weigh_uom_g
+        self.assertFalse(self.product.show_weight_uom_warning)
+
+    def test_template_volume(self):
+        template = self.product.product_tmpl_id
+        template.volume_uom_id = self.volume_uom_l
+        template.volume = 1
+        self.assertEqual(template.product_volume, 1000)
+        template.product_volume = 10
+        self.assertEqual(template.volume, 0.01)
+        template.volume_uom_id = self.volume_uom_m3
+        self.assertEqual(template.product_volume, template.volume)
+
+    def test_template_show_volume_uom_warning(self):
+        template = self.product.product_tmpl_id
+        template.volume_uom_id = self.volume_uom_m3
+        template.volume = 0.0001
+        self.assertTrue(template.show_volume_uom_warning)
+        template.volume_uom_id = self.volume_uom_l
+        self.assertFalse(template.show_volume_uom_warning)
+
+    def test_template_weight(self):
+        template = self.product.product_tmpl_id
+        template.weight_uom_id = self.weigh_uom_g
+        template.weight = 1
+        self.assertEqual(template.product_weight, 1000)
+        template.product_weight = 10
+        self.assertEqual(template.weight, 0.01)
+        template.weight_uom_id = self.weigh_uom_kg
+        self.assertEqual(template.product_weight, template.weight)
+
+    def test_template_show_weight_uom_warning(self):
+        template = self.product.product_tmpl_id
+        template.weight_uom_id = self.weigh_uom_kg
+        template.weight = 0.0001
+        self.assertTrue(template.show_weight_uom_warning)
+        template.weight_uom_id = self.weigh_uom_g
+        self.assertFalse(template.show_weight_uom_warning)
+
+    def test_template_with_variant(self):
+        variant = self.product.create(
+            {"name": "Test Variant", "product_tmpl_id": self.product.product_tmpl_id.id}
+        )
+        template = self.product.product_tmpl_id
+        variant.product_volume = 10
+        variant.product_weight = 10
+        self.product.product_volume = 10
+        self.product.product_weight = 10
+        self.assertEqual(template.volume, 0.0)
+        self.assertEqual(template.volume, 0.0)
+        self.assertEqual(template.product_volume, 0.0)
+        self.assertEqual(template.product_weight, 0.0)
+        self.assertFalse(template.show_volume_uom_warning)  # for coverage
+        self.assertFalse(template.show_weight_uom_warning)  # for coverage
+        variant.unlink()
+        self.assertEqual(template.volume, 10.0)
+        self.assertEqual(template.weight, 10.0)
+        self.assertEqual(template.product_volume, 10.0)
+        self.assertEqual(template.product_weight, 10.0)

--- a/product_logistics_uom/views/product.xml
+++ b/product_logistics_uom/views/product.xml
@@ -5,30 +5,91 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <field name="volume" position="after">
-                <field name="product_uom_readonly" invisible="1" />
-                <field
-                    name="volume_uom_id"
-                    options="{'no_open': True, 'no_create': True}"
-                    groups="uom.group_uom"
-                />
+            <!-- weight -->
+            <field name="weight" position="attributes">
+                <attribute name="invisible">1</attribute>
             </field>
+            <label for="weight" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </label>
+            <label for="weight" position="after">
+                <label
+                    for="product_weight"
+                    attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"
+                />
+            </label>
             <field name="weight" position="after">
+                <field name="show_weight_uom_warning" invisible="1" />
+                <field name="product_weight" string="Weight" class="oe_inline" />
+                <span attrs="{'invisible':[('show_weight_uom_warning', '=', False)]}">
+                    <i
+                        class="fa fa-fw fa-warning text-warning"
+                        title="Value too small for the selected uom. Select another uom to display the value."
+                    />
+                </span>
                 <field
                     name="weight_uom_id"
                     options="{'no_open': True, 'no_create': True}"
                     groups="uom.group_uom"
                 />
             </field>
+            <field name="weight_uom_name" position="before">
+                <span
+                    attrs="{'invisible':[('show_weight_uom_warning', '=', False)]}"
+                    groups="!uom.group_uom"
+                >
+                    <i
+                        class="fa fa-fw fa-warning text-warning"
+                        title="Value too small for the selected uom. Select another uom to display the value."
+                    />
+                </span>
+            </field>
             <field name="weight_uom_name" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'invisible': [('product_uom_readonly', '=', False)]}</attribute>
+                <attribute name="groups">!uom.group_uom</attribute>
+            </field>
+
+            <!-- volume -->
+            <field name="volume" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <label for="volume" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </label>
+            <label for="volume" position="after">
+                <label
+                    for="product_volume"
+                    string="Volume"
+                    attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"
+                />
+            </label>
+            <field name="volume" position="after">
+                <field name="show_volume_uom_warning" invisible="1" />
+                <field name="product_volume" class="oe_inline" />
+                <span attrs="{'invisible':[('show_volume_uom_warning', '=', False)]}">
+                    <i
+                        class="fa fa-fw fa-warning text-warning"
+                        title="Value too small for the selected uom. Select another uom to display the value."
+                    />
+                </span>
+                <field
+                    name="volume_uom_id"
+                    options="{'no_open': True, 'no_create': True}"
+                    groups="uom.group_uom"
+                />
+            </field>
+            <field name="volume_uom_name" position="before">
+                <span
+                    attrs="{'invisible':[('show_volume_uom_warning', '=', False)]}"
+                    groups="!uom.group_uom"
+                >
+                    <i
+                        class="fa fa-fw fa-warning text-warning"
+                        title="Value too small for the selected uom. Select another uom to display the value."
+                    />
+                </span>
             </field>
             <field name="volume_uom_name" position="attributes">
-                 <attribute
-                    name="attrs"
-                >{'invisible': [('product_uom_readonly', '=', False)]}</attribute>
+                 <attribute name="groups">!uom.group_uom</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Before this change, the volume and weight values on product were no more stored into the expected kg and m3 uoms. To know the effective value you had to convert the value using the specified uom on the record. As side effect the arithmetic operations done on these fields in others addon as for exemple in 'delivery' were not correct.

This change restore the default behavior by always storing the values into the default uoms whatever the uom specified on the product. 2 new fields are added on the product to allows the user to see and managed these values in the specified uom. When values are updated through an update of these new fields, the new values are converted into the default uoms and the result stored into the original fields.

fixes #1312