### PR TITLE
[15.0[FIX] product_lot_sequence: Fix sequence incrementation opening detailed operations

### DIFF
--- a/product_lot_sequence/models/__init__.py
+++ b/product_lot_sequence/models/__init__.py
@@ -1,2 +1,3 @@
 from . import product
 from . import stock_production_lot
+from . import stock_move

--- a/product_lot_sequence/models/stock_move.py
+++ b/product_lot_sequence/models/stock_move.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def action_show_details(self):
+        """Avoid calling and incrementing the sequence if not needed or already done"""
+        seq_policy = self.env["stock.production.lot"]._get_sequence_policy()
+        if seq_policy in ("product", "global"):
+            # If move is not supposed to assign serial pass empty string for next serial
+            if not self.display_assign_serial:
+                return super(
+                    StockMove, self.with_context(force_next_serial="")
+                ).action_show_details()
+            # If the sequence was already called once, avoid calling it another time
+            elif self.next_serial:
+                return super(
+                    StockMove, self.with_context(force_next_serial=self.next_serial)
+                ).action_show_details()
+        return super().action_show_details()

--- a/product_lot_sequence/models/stock_production_lot.py
+++ b/product_lot_sequence/models/stock_production_lot.py
@@ -56,6 +56,8 @@ class ProductionLot(models.Model):
 
     @api.model
     def _get_next_serial(self, company, product):
+        if "force_next_serial" in self.env.context:
+            return self.env.context.get("force_next_serial")
         seq_policy = self._get_sequence_policy()
         if seq_policy == "product":
             seq = product.product_tmpl_id.lot_sequence_id

--- a/product_lot_sequence/readme/ROADMAP.rst
+++ b/product_lot_sequence/readme/ROADMAP.rst
@@ -1,0 +1,11 @@
+* There is an issue with the use of ir.sequence with the newer version of Odoo.
+
+Mostly, when opening the detailed operations of an assigned picking for a product
+tracked by serial numbers, Odoo systematically calls `_get_next_serial` even
+if there is not any serial number to generate.
+Moreover, the widget allowing to generate the serial numbers will not call
+the sequence but only increment the number according to the next serial,
+potentially leading to a sequence that is not in sync anymore with the created
+serial numbers.
+
+cf https://github.com/OCA/product-attribute/issues/1326


### PR DESCRIPTION
When opening the detailed operations view of a stock move, Odoo is calling stock.production.lot._get_next_serial to set stock.move.next_serial field anytime the product is tracked by serial and the move is assigned.

If we use this module with product or global policy, the respective sequence will therefore be called and incremented anytime this view is open, even if the picking is not creating lots (e.g. delivery orders or internal transfers)

To avoid incrementing the sequence unnecessarily, we only allow to get the next sequence number the first time this view is opened and if the move has to create new serial numbers.
Otherwise, we force the value to be set to stock.move.next_serial field to an empty string if no serial has to be created through this move, or to the next_serial value assigned on the first opening of the view.