### PR TITLE
product_supplierinfo_group: give the possibility to import supplier group from product.product

### DIFF
--- a/product_supplierinfo_group/models/__init__.py
+++ b/product_supplierinfo_group/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_supplierinfo
 from . import product_supplierinfo_group
 from . import product_template
+from . import product_product

--- a/product_supplierinfo_group/models/product_product.py
+++ b/product_supplierinfo_group/models/product_product.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Akretion France (http://www.akretion.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    specific_supplierinfo_group_ids = fields.One2many(
+        "product.supplierinfo.group",
+        "product_id",
+        name="Specific Supplier",
+        help="This supplier group only apply to the current variante",
+    )

--- a/product_supplierinfo_group/models/product_supplierinfo_group.py
+++ b/product_supplierinfo_group/models/product_supplierinfo_group.py
@@ -60,6 +60,17 @@ class ProductSupplierinfoGroup(models.Model):
         )
     ]
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("product_tmpl_id") and vals.get("product_id"):
+                vals["product_tmpl_id"] = (
+                    self.env["product.product"]
+                    .browse(vals["product_id"])
+                    .product_tmpl_id.id
+                )
+        return super().create(vals_list)
+
     @api.depends("product_tmpl_id")
     def _compute_has_variants(self):
         for rec in self:


### PR DESCRIPTION
Allow to import supplier group from product.product
- autofill product_tmpl_id when product_id is define
- add a field to see only specific variant supplier group