### PR TITLE
[14.0][FIX] product_pricelist_supplierinfo: Use given partner to get relevant supplier infos

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -46,3 +46,8 @@ class ProductPricelistItem(models.Model):
         string="Supplier filter",
         help="Only match prices from the selected supplier",
     )
+
+    def get_supplier_id(self):
+        self.ensure_one()
+        supplier_id = self._context.get("supplier") or self.filter_supplier_id.id
+        return self.env["res.partner"].browse(supplier_id)

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -34,7 +34,7 @@ class ProductTemplate(models.Model):
             )._select_seller(
                 # For a public user this record could be not accessible, but we
                 # need to get the price anyway
-                partner_id=rule.sudo().filter_supplier_id,
+                partner_id=rule.sudo().get_supplier_id(),
                 quantity=quantity,
                 date=date,
             )

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -130,6 +130,22 @@ class TestProductSupplierinfo(common.SavepointCase):
             10,
         )
 
+    def test_pricelist_select_supplier(self):
+        supplier3 = self.partner_obj.create({"name": "Supplier #3"})
+        self.product.write(
+            {"seller_ids": [(0, 0, {"name": supplier3.id, "min_qty": 1, "price": 9})]}
+        )
+        for seller_id in self.product.seller_ids:
+            price = self.pricelist.with_context(
+                supplier=seller_id.name.id
+            ).get_product_price(
+                product=seller_id.product_id or seller_id.product_tmpl_id,
+                quantity=seller_id.min_qty,
+                partner=False,
+                uom_id=seller_id.product_uom.id,
+            )
+            self.assertEqual(price, seller_id.price)
+
     def test_pricelist_dates(self):
         """Test pricelist and supplierinfo dates"""
         self.product.seller_ids.filtered(lambda x: x.min_qty == 5)[


### PR DESCRIPTION
Because the current implementation ignore the existing partner from the `products_qty_partner` tuple used to get the pricelist rule when calling `_select_sellers`