### PR TITLE
product_assortment: add hard link between product and assortment

### DIFF
--- a/product_assortment/__manifest__.py
+++ b/product_assortment/__manifest__.py
@@ -11,6 +11,10 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["base", "product"],
-    "data": ["views/product_assortment.xml", "views/res_partner_view.xml"],
+    "data": [
+        "data/ir_cron.xml",
+        "views/product_assortment.xml",
+        "views/res_partner_view.xml",
+    ],
     "installable": True,
 }

--- a/product_assortment/data/ir_cron.xml
+++ b/product_assortment/data/ir_cron.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_update_product_list" model="ir.cron">
+        <field
+            name="name"
+        >Product Assortment: Update product assortment and notify</field>
+        <field name="active" eval="False" />
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False" />
+        <field name="model_id" ref="base.model_ir_filters" />
+        <field name="state">code</field>
+        <field name="code">model._cron_update_product_list()</field>
+    </record>
+</odoo>

--- a/product_assortment/models/__init__.py
+++ b/product_assortment/models/__init__.py
@@ -1,2 +1,3 @@
 from . import ir_filters
 from . import res_partner
+from . import product_product

--- a/product_assortment/models/product_product.py
+++ b/product_assortment/models/product_product.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    assortment_ids = fields.Many2many("ir.filters", readonly=True)
+
+    # The following two method can be inherited
+    # in order to add special action after adding or removing
+    # a product from an assortment
+    def _add_product_in_assortment(self, assortment):
+        self.write({"assortment_ids": [fields.Command.link(assortment.id)]})
+
+    def _remove_product_from_assortment(self, assortment):
+        self.write({"assortment_ids": [fields.Command.unlink(assortment.id)]})

--- a/product_assortment/tests/test_product_assortment.py
+++ b/product_assortment/tests/test_product_assortment.py
@@ -132,3 +132,16 @@ class TestProductAssortment(TransactionCase):
             assortment._get_eval_domain()
         )
         self.assertNotIn(excluded_product, allowed_products)
+
+    def test_update_product_list(self):
+        products = self.product_obj.search([])
+        self.assortment.update_product_list()
+        self.assertEqual(products, self.assortment.product_ids)
+
+        # reduce assortment to services products
+        domain = [("type", "=", "service")]
+        self.assortment.domain = domain
+
+        products = self.product_obj.search(domain)
+        self.assortment.update_product_list()
+        self.assertEqual(products, self.assortment.product_ids)


### PR DESCRIPTION
Hi all

The aim is to store the information of the result of the link between the product and the assortment.

This allow to have "hook" when a product is added/removed automatically

@lmignon @sbidoul 

Feel free to fork it if needed
