### PR TITLE
[14.0] product_pricelist_supplierinfo: Refactoring

### DIFF
--- a/product_pricelist_supplierinfo/models/__init__.py
+++ b/product_pricelist_supplierinfo/models/__init__.py
@@ -1,6 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_supplierinfo
-from . import product_pricelist
+from . import product_pricelist_item
 from . import product_product
 from . import product_template

--- a/product_pricelist_supplierinfo/models/__init__.py
+++ b/product_pricelist_supplierinfo/models/__init__.py
@@ -1,6 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_supplierinfo
+from . import product_pricelist
 from . import product_pricelist_item
 from . import product_product
 from . import product_template

--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -1,0 +1,19 @@
+# Copyright 2018 Tecnativa - Vicent Cubells
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    def _compute_price_rule(self, products_qty_partner, date=False, uom_id=False):
+        """Adding date to context in order to retrieve it from the rule as this value
+        is not passed as a variable in `_compute_price`
+        """
+        if date and "date" not in self._context:
+            self = self.with_context(date=date)
+        return super(ProductPricelist, self)._compute_price_rule(
+            products_qty_partner, date, uom_id
+        )

--- a/product_pricelist_supplierinfo/models/product_pricelist.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist.py
@@ -46,3 +46,8 @@ class ProductPricelistItem(models.Model):
         string="Supplier filter",
         help="Only match prices from the selected supplier",
     )
+
+    def get_supplier_id(self):
+        self.ensure_one()
+        supplier_id = self._context.get("supplier") or self.filter_supplier_id.id
+        return self.env["res.partner"].browse(supplier_id)

--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -2,6 +2,8 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from datetime import datetime
+
 from odoo import fields, models
 
 
@@ -27,14 +29,59 @@ class ProductPricelistItem(models.Model):
         return self.env["res.partner"].browse(supplier_id)
 
     def _compute_price(self, price, price_uom, product, quantity=1.0, partner=False):
+        """Inherits rule computation to get price from supplierinfo"""
         if self.compute_price == "formula" and self.base == "supplierinfo":
             context = self.env.context
-            price = product.sudo()._get_supplierinfo_pricelist_price(
-                self,
-                date=context.get("date", fields.Date.today()),
+            price = self._compute_price_from_supplierinfo(
+                price_uom=price_uom,
+                product=product,
                 quantity=quantity,
                 partner=partner,
+                date=context.get("date", fields.Date.today()),
             )
         # Re-use existing method that will apply discount/rounding/surcharge/margin
         price = super()._compute_price(price, price_uom, product, quantity, partner)
+        return price
+
+    def _compute_price_from_supplierinfo(
+        self, price_uom, product, quantity, partner=False, date=False
+    ):
+        """Method for getting the price from supplier info.
+        Please note that product could be a template or a variant
+        """
+        if product._name == "product.template":
+            product = product.product_variant_id
+        product.ensure_one()
+        price = 0.0
+        if self.no_supplierinfo_min_quantity:
+            # No matter which minimum qty, we'll get every seller. We set a
+            # number absurdidly high
+            quantity = 1e9
+        if type(date) == datetime:
+            date = date.date()
+        seller = product.with_context(
+            override_min_qty=self.no_supplierinfo_min_quantity
+        )._select_seller(
+            # For a public user this record could be not accessible, but we
+            # need to get the price anyway
+            partner_id=self.sudo().get_supplier_id(),
+            quantity=quantity,
+            date=date,
+        )
+        if seller:
+            # Get seller price in product's purchase UoM
+            price = seller._get_supplierinfo_pricelist_price()
+            # Convert the price if wanted in another UoM
+            if price_uom.id != seller.product_uom.id:
+                price = seller.product_uom._compute_price(price, price_uom)
+            if price:
+                # Also convert the price if the pricelist and seller have
+                # different currencies so the price have the pricelist currency
+                if self.currency_id != seller.currency_id:
+                    convert_date = date or self.env.context.get(
+                        "date", fields.Date.today()
+                    )
+                    price = seller.currency_id._convert(
+                        price, self.currency_id, seller.company_id, convert_date
+                    )
         return price

--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -5,10 +5,6 @@
 from odoo import fields, models
 
 
-class ProductPricelist(models.Model):
-    _inherit = "product.pricelist"
-
-
 class ProductPricelistItem(models.Model):
     _inherit = "product.pricelist.item"
 

--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -49,8 +49,6 @@ class ProductPricelistItem(models.Model):
         """Method for getting the price from supplier info.
         Please note that product could be a template or a variant
         """
-        if product._name == "product.template":
-            product = product.product_variant_id
         product.ensure_one()
         price = 0.0
         if self.no_supplierinfo_min_quantity:

--- a/product_pricelist_supplierinfo/models/product_product.py
+++ b/product_pricelist_supplierinfo/models/product_product.py
@@ -20,11 +20,6 @@ class ProductProduct(models.Model):
             sellers = sellers.sorted("min_qty")
         return sellers
 
-    def _get_supplierinfo_pricelist_price(self, rule, date=None, quantity=None):
-        return self.product_tmpl_id._get_supplierinfo_pricelist_price(
-            rule, date=date, quantity=quantity, product_id=self.id
-        )
-
     def price_compute(self, price_type, uom=False, currency=False, company=False):
         """Return dummy not falsy prices when computation is done from supplier
         info for avoiding error on super method. We will later fill these with

--- a/product_pricelist_supplierinfo/models/product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/models/product_supplierinfo.py
@@ -8,10 +8,12 @@ class ProductSupplierinfo(models.Model):
     _inherit = "product.supplierinfo"
 
     sale_margin = fields.Float(
-        string="Sale Margin",
+        string="Sale Margin (%)",
         default=0,
         digits=(16, 2),
-        help="Margin to apply on price to obtain sale price",
+        help="Margin to apply on price to obtain sale price.\n"
+        "Note that a pricelist rule based on supplier info must exists to use this "
+        "functionality",
     )
 
     def _get_supplierinfo_pricelist_price(self):

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -34,7 +34,7 @@ class ProductTemplate(models.Model):
             )._select_seller(
                 # For a public user this record could be not accessible, but we
                 # need to get the price anyway
-                partner_id=rule.sudo().filter_supplier_id,
+                partner_id=rule.sudo().get_supplier_id(),
                 quantity=quantity,
                 date=date,
             )

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -3,59 +3,12 @@
 # Copyright 2019 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from datetime import datetime
 
-from odoo import fields, models
+from odoo import models
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
-
-    def _get_supplierinfo_pricelist_price(
-        self, rule, date=None, quantity=None, product_id=None
-    ):
-        """Method for getting the price from supplier info."""
-        self.ensure_one()
-        price = 0.0
-        product = self.product_variant_id
-        if product_id:
-            product = product.browse(product_id)
-        if rule.no_supplierinfo_min_quantity:
-            # No matter which minimum qty, we'll get every seller. We set a
-            # number absurdidly high
-            quantity = 1e9
-        # The product_variant_id returns empty recordset if template is not
-        # active, so we must ensure variant exists or _select_seller fails.
-        if product:
-            if type(date) == datetime:
-                date = date.date()
-            seller = product.with_context(
-                override_min_qty=rule.no_supplierinfo_min_quantity
-            )._select_seller(
-                # For a public user this record could be not accessible, but we
-                # need to get the price anyway
-                partner_id=rule.sudo().get_supplier_id(),
-                quantity=quantity,
-                date=date,
-            )
-            if seller:
-                price = seller._get_supplierinfo_pricelist_price()
-        if price:
-            # We need to convert the price if the pricelist and seller have
-            # different currencies so the price have the pricelist currency
-            if rule.currency_id != seller.currency_id:
-                convert_date = date or self.env.context.get("date", fields.Date.today())
-                price = seller.currency_id._convert(
-                    price, rule.currency_id, seller.company_id, convert_date
-                )
-            # We need to convert the price to the uom used on the sale, if the
-            # uom on the seller is a different one that the one used there.
-            if seller:
-                qty_uom_id = self._context.get("uom") or self.uom_id.id
-                price_uom = self.env["uom.uom"].browse([qty_uom_id])
-                if seller.product_uom != price_uom:
-                    price = seller.product_uom._compute_price(price, price_uom)
-        return price
 
     def price_compute(self, price_type, uom=False, currency=False, company=False):
         """Return dummy not falsy prices when computation is done from supplier

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -4,11 +4,74 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import models
+from odoo import fields, models
+from odoo.tools import float_compare
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+
+    def _prepare_sellers(self, params=False):
+        """This function is a reimplementation of the builtin-one made for
+        `product.product` (variant), excepts that:
+        - if override_min_qty is enabled, there is no sort on quantity.
+        """
+        if self.env.context.get("override_min_qty"):
+            return self.seller_ids.filtered(lambda s: s.name.active).sorted(
+                lambda s: (s.sequence, s.price, s.id)
+            )
+        else:
+            return self.seller_ids.filtered(lambda s: s.name.active).sorted(
+                lambda s: (s.sequence, -s.min_qty, s.price, s.id)
+            )
+
+    def _select_seller(
+        self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False
+    ):
+        """This function is a reimplementation of the builtin-one made for
+        `product.product` (variant), excepts that:
+        - if product_id (variant) is set, the seller is ignored
+        - if override_min_qty is enabled, quantity filtering is ignored
+        """
+        self.ensure_one()
+        if date is None:
+            date = fields.Date.context_today(self)
+        precision = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+
+        res = self.env["product.supplierinfo"]
+        sellers = self._prepare_sellers(params)
+        sellers = sellers.filtered(
+            lambda s: not s.company_id or s.company_id.id == self.env.company.id
+        )
+        for seller in sellers:
+            # Set quantity in UoM of seller
+            quantity_uom_seller = quantity
+            if quantity_uom_seller and uom_id and uom_id != seller.product_uom:
+                quantity_uom_seller = uom_id._compute_quantity(
+                    quantity_uom_seller, seller.product_uom
+                )
+
+            if seller.date_start and seller.date_start > date:
+                continue
+            if seller.date_end and seller.date_end < date:
+                continue
+            if partner_id and seller.name not in [partner_id, partner_id.parent_id]:
+                continue
+            if not self.env.context.get("override_min_qty") and (
+                quantity is not None
+                and float_compare(
+                    quantity_uom_seller, seller.min_qty, precision_digits=precision
+                )
+                == -1
+            ):
+                continue
+            if seller.product_id:
+                continue
+            if not res or res.name == seller.name:
+                res |= seller
+        return res.sorted("price")[:1]
 
     def price_compute(self, price_type, uom=False, currency=False, company=False):
         """Return dummy not falsy prices when computation is done from supplier

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -143,6 +143,22 @@ class TestProductSupplierinfo(common.SavepointCase):
             10,
         )
 
+    def test_pricelist_select_supplier(self):
+        supplier3 = self.partner_obj.create({"name": "Supplier #3"})
+        self.product.write(
+            {"seller_ids": [(0, 0, {"name": supplier3.id, "min_qty": 1, "price": 9})]}
+        )
+        for seller_id in self.product.seller_ids:
+            price = self.pricelist.with_context(
+                supplier=seller_id.name.id
+            ).get_product_price(
+                product=seller_id.product_id or seller_id.product_tmpl_id,
+                quantity=seller_id.min_qty,
+                partner=False,
+                uom_id=seller_id.product_uom.id,
+            )
+            self.assertEqual(price, seller_id.price)
+
     def test_pricelist_dates(self):
         """Test pricelist and supplierinfo dates"""
         self.product.seller_ids.filtered(lambda x: x.min_qty == 5)[

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -86,6 +86,10 @@ class TestProductSupplierinfo(common.SavepointCase):
             }
         )
         self.assertAlmostEqual(
+            self.pricelist.get_product_price(self.product.product_tmpl_id, 1, False),
+            10.0,
+        )
+        self.assertAlmostEqual(
             self.pricelist.get_product_price(self.product, 1, False),
             10.0,
         )


### PR DESCRIPTION
This module has been migrated without taking odoo base code changes into account.
This PR is a proposal to re-use existing implementation.
All major changes are made in separate commits to clearly understand all edits.

- The main method used to compute price form supplier info has been moved from `product.template` to `product.pricelist.item` and renamed to `_compute_price_from_supplierinfo`
- We now override the built-in `_compute_price` from `product.pricelist.item` to get and compute our "supplierinfo" price.
- As a parameter, you can now pass a single product whatever it is (`product.product`/`product.template`)
- Better date support

Note that the first commit (Add supplier support) already has its own PR https://github.com/OCA/product-attribute/pull/1345

@pedrobaeza @victoralmau , can you review this PR as you were contributors on this module ?
