### PR TITLE
[14.0][IMP] product_pricelist_assortment: sales administrator access

### DIFF
--- a/product_pricelist_assortment/__manifest__.py
+++ b/product_pricelist_assortment/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
-    "depends": ["product_assortment"],
+    "depends": ["product_assortment", "sales_team"],
     "data": [
         "security/product_pricelist_assortment_item.xml",
         "data/ir_cron.xml",

--- a/product_pricelist_assortment/security/product_pricelist_assortment_item.xml
+++ b/product_pricelist_assortment/security/product_pricelist_assortment_item.xml
@@ -14,7 +14,7 @@
     <record model="ir.model.access" id="product_pricelist_assortment_item_manager">
         <field name="name">product.pricelist.assortment pricelist manager</field>
         <field name="model_id" ref="model_product_pricelist_assortment_item" />
-        <field name="group_id" ref="base.group_system" />
+        <field name="group_id" ref="sales_team.group_sale_manager" />
         <field name="perm_read" eval="1" />
         <field name="perm_create" eval="1" />
         <field name="perm_write" eval="1" />


### PR DESCRIPTION
Let Sales administrator modify assortment items. In order to get it had to include sales_team module into dependency.
Before you had to have system admin to modify it, which is too much.
