### PR TITLE
[IMP] product_packaging_dimension: Don't use max_weight anymore

### DIFF
--- a/product_packaging_dimension/__manifest__.py
+++ b/product_packaging_dimension/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Product Packaging Dimension",
     "summary": "Manage packaging dimensions and weight",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.1.0",
     "category": "Product",
     "author": "Camptocamp, Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/product_packaging_dimension/migrations/16.0.1.1.0/post-migrate.py
+++ b/product_packaging_dimension/migrations/16.0.1.1.0/post-migrate.py
@@ -1,0 +1,22 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+def _move_max_weight(env):
+    """
+    Move max_weight value to weight if not defined
+    """
+    query = """
+        UPDATE product_packaging
+            SET weight = max_weight
+            WHERE weight IS NULL OR weight = 0.0
+            AND max_weight IS NOT NULL
+            AND product_id IS NOT NULL
+    """
+    openupgrade.logged_query(env.cr, query)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _move_max_weight(env)

--- a/product_packaging_dimension/models/product_packaging.py
+++ b/product_packaging_dimension/models/product_packaging.py
@@ -21,7 +21,7 @@ class ProductPackaging(models.Model):
     ]
     height = fields.Integer()
     width = fields.Integer()
-    packaging_length = fields.Integer()
+    packaging_length = fields.Integer(string="Length")
 
     length_uom_id = fields.Many2one(
         "uom.uom",

--- a/product_packaging_dimension/models/product_packaging.py
+++ b/product_packaging_dimension/models/product_packaging.py
@@ -14,9 +14,9 @@ class ProductPackaging(models.Model):
         ("positive_width", "CHECK(width>=0)", "Width must be positive"),
         ("positive_length", "CHECK(packaging_length>=0)", "Length must be positive"),
         (
-            "positive_max_weight",
-            "CHECK(max_weight>=0)",
-            "Max Weight must be positive",
+            "positive_weight",
+            "CHECK(weight>=0)",
+            "Weight must be positive",
         ),
     ]
     height = fields.Integer()
@@ -41,7 +41,6 @@ class ProductPackaging(models.Model):
     )
 
     weight = fields.Float()
-    max_weight = fields.Float("Maximum Weight")
     weight_uom_id = fields.Many2one(
         "uom.uom",
         string="Weight Units of Measure",

--- a/product_packaging_dimension/views/product_packaging.xml
+++ b/product_packaging_dimension/views/product_packaging.xml
@@ -37,13 +37,6 @@
                     </group>
                 </group>
                 <group string="Weight">
-                    <group id="group_max_weight">
-                        <label for="max_weight" />
-                        <div class="o_row" name="max_weight">
-                            <field name="max_weight" />
-                            <span><field name="weight_uom_name" /></span>
-                        </div>
-                    </group>
                     <group id="group_weight">
                         <label for="weight" />
                         <div class="o_row" name="weight">


### PR DESCRIPTION
As max_weight is defined now on stock.package.type, rely on that one.

Migrate data that was filled in to weight field.

Added string label to packaging_length too.