### PR TITLE
[16.0][FIX] product_pricelist_revision: use compute_sudo

### DIFF
--- a/product_pricelist_revision/models/pricelist.py
+++ b/product_pricelist_revision/models/pricelist.py
@@ -8,7 +8,7 @@ class ProductPricelistItem(models.Model):
     _inherit = "product.pricelist.item"
     _rec_names_search = ["name"]  # Initialize here to be able to extend
 
-    name = fields.Char(store=True)
+    name = fields.Char(store=True, compute_sudo=True)
 
     previous_item_id = fields.Many2one(
         comodel_name="product.pricelist.item",

--- a/product_pricelist_revision/models/pricelist.py
+++ b/product_pricelist_revision/models/pricelist.py
@@ -8,7 +8,8 @@ class ProductPricelistItem(models.Model):
     _inherit = "product.pricelist.item"
     _rec_names_search = ["name"]  # Initialize here to be able to extend
 
-    name = fields.Char(store=True, compute_sudo=True)
+    name = fields.Char(store=True)
+    price = fields.Char(compute_sudo=True)
 
     previous_item_id = fields.Many2one(
         comodel_name="product.pricelist.item",


### PR DESCRIPTION
The name field is changed to be stored, however the compute function is multi with an unstored field. Therefore to keep consistent behaviour we add compute_sudo to name field.