### PR TITLE
[15.0][FIX] product_secondary_unit: Don't reassign old value

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -89,13 +89,7 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
     def _compute_helper_target_field_qty(self):
         """Set the target qty field defined in model"""
         default_qty_field_value = self._get_default_value_for_qty_field()
-        for rec in self:
-            if not rec.secondary_uom_id:
-                rec[rec._secondary_unit_fields["qty_field"]] = (
-                    rec._origin[rec._secondary_unit_fields["qty_field"]]
-                    or default_qty_field_value
-                )
-                continue
+        for rec in self.filtered("secondary_uom_id"):
             if rec.secondary_uom_id.dependency_type == "independent":
                 if rec[rec._secondary_unit_fields["qty_field"]] == 0.0:
                     rec[


### PR DESCRIPTION
**Steps to reproduce the problem:**

- Have `sale_product_matrix` installed.
- Add a line with a product with variants in a sales order. It shouldn't have secondary units.
- Save the sales order.
- Use the matrix popup to change the quantity and confirm.

**Current behavior:**

The quantity is reset to the original one.

**Expected behavior:**

The quantity is set to the new value.

**Explanation:**

Using `_origin` for resetting the value is taking the old value previously saved before starting to edit again, and anyway, that was a needed hack for v13 for avoiding cache miss error, but now it's not needed.

Thus, we remove such artifact and just act on lines with secondary unit set.

@Tecnativa TT45028