### PR TITLE
[16.0][FIX] product_pricelist_direct_print: add missing dependency in compute

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -81,6 +81,7 @@ class ProductPricelistPrint(models.TransientModel):
 
     product_price = fields.Float(compute="_compute_product_price")
 
+    @api.depends_context("product")
     def _compute_product_price(self):
         product = self.env.context["product"]
         price = self.get_pricelist_to_print()._get_product_price(


### PR DESCRIPTION
closes https://github.com/OCA/product-attribute/issues/1421
The `_compute_product_price ` method is missing the depends line, causing it not to be recomputed during the same report, thus all products result in the same price