### PR TITLE
[16.0][FIX] product_secondary_unit: precompute secondary_uom_qty

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -43,6 +43,7 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
         store=True,
         readonly=False,
         compute="_compute_secondary_uom_qty",
+        precompute=True,
     )
     secondary_uom_id = fields.Many2one(
         comodel_name="product.secondary.unit",


### PR DESCRIPTION
The field `secondary_uom_qty` is defined in the mixin class `product.secondary.unit.mixin` as being computed, but without precomputation. This makes that when this field is used in the variable `_secondary_unit_fields` for classes using the mixing, it ends up as a dependency of other fields that are computed and do require precomputation. But, not being the field `secondary_uom_qty` precomputed, it disables the precomputation of those other fields.

This has an impact when installing the module `sale` along with the module `product_secondary_unit`, which causes the module `sale_order_secondary_unit` to be auto-installed. As a result, the following errors appear in the log, disabling the precomputation of 11 other fields:

```text
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.product_uom_qty cannot be precomputed as it depends on non-precomputed field sale.order.line.secondary_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_unit cannot be precomputed as it depends on non-precomputed field sale.order.line.product_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.discount cannot be precomputed as it depends on non-precomputed field sale.order.line.product_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_reduce cannot be precomputed as it depends on non-precomputed field sale.order.line.price_unit
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_subtotal cannot be precomputed as it depends on non-precomputed field sale.order.line.product_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_tax cannot be precomputed as it depends on non-precomputed field sale.order.line.product_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_total cannot be precomputed as it depends on non-precomputed field sale.order.line.product_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_reduce_taxexcl cannot be precomputed as it depends on non-precomputed field sale.order.line.price_subtotal
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.price_reduce_taxinc cannot be precomputed as it depends on non-precomputed field sale.order.line.price_total
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.product_packaging_id cannot be precomputed as it depends on non-precomputed field sale.order.line.product_uom_qty
/opt/project/repos/odoo/odoo/fields.py:802: UserWarning: Field sale.order.line.product_packaging_qty cannot be precomputed as it depends on non-precomputed field sale.order.line.product_packaging_id
```

Making `secondary_uom_qty` precomputed solves these warnings.