### PR TITLE
[16.0][FIX] product_packaging_dimension: post-migrate script should only apply query if column max_weight exists

### DIFF
--- a/product_packaging_dimension/migrations/16.0.1.1.0/post-migrate.py
+++ b/product_packaging_dimension/migrations/16.0.1.1.0/post-migrate.py
@@ -7,14 +7,15 @@ def _move_max_weight(env):
     """
     Move max_weight value to weight if not defined
     """
-    query = """
-        UPDATE product_packaging
-            SET weight = max_weight
-            WHERE weight IS NULL OR weight = 0.0
-            AND max_weight IS NOT NULL
-            AND product_id IS NOT NULL
-    """
-    openupgrade.logged_query(env.cr, query)
+    if openupgrade.column_exists(env.cr, "product_packaging", "max_weight"):
+        query = """
+            UPDATE product_packaging
+                SET weight = max_weight
+                WHERE weight IS NULL OR weight = 0.0
+                AND max_weight IS NOT NULL
+                AND product_id IS NOT NULL
+        """
+        openupgrade.logged_query(env.cr, query)
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
This column is no longer defined in 16.0

cc @rousseldenis 