### PR TITLE
[15.0][IMP] product_pricelist_direct_print, product_pricelist_direct_print_website_sale, allow use parent as filter on categories

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -293,7 +293,9 @@ class ProductPricelistPrint(models.TransientModel):
                     )
             domain = expression.AND([domain, aux_domain])
         if self.categ_ids:
-            domain = expression.AND([domain, [("categ_id", "in", self.categ_ids.ids)]])
+            domain = expression.AND(
+                [domain, [("categ_id", "child_of", self.categ_ids.ids)]]
+            )
         return domain
 
     def get_products_to_print(self):

--- a/product_pricelist_direct_print_website_sale/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print_website_sale/wizards/product_pricelist_print.py
@@ -16,7 +16,7 @@ class ProductPricelistPrint(models.TransientModel):
     def get_products_domain(self):
         domain = super().get_products_domain()
         if self.public_categ_ids:
-            domain.append(("public_categ_ids", "in", self.public_categ_ids.ids))
+            domain.append(("public_categ_ids", "child_of", self.public_categ_ids.ids))
         return domain
 
     def get_group_key(self, product):


### PR DESCRIPTION
By default you should select all categories to filter products, but with this change you can select only parent and all children will be added on data retrieve