### PR TITLE
[15.0][IMP] product_pricelist_direct_print, allow field breakage_per_category works on pdf printing

### DIFF
--- a/product_pricelist_direct_print/views/report_product_pricelist.xml
+++ b/product_pricelist_direct_print/views/report_product_pricelist.xml
@@ -75,7 +75,7 @@
                                     t-set="category_products"
                                     t-value="category_group['products']"
                                 />
-                                <td colspan="100">
+                                <td colspan="100" t-if="o.breakage_per_category">
                                     <strong t-esc="category_group['group_name']" />
                                 </td>
                                 <tr t-foreach="category_products" t-as="product">

--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -312,6 +312,8 @@ class ProductPricelistPrint(models.TransientModel):
         return products
 
     def get_group_key(self, product):
+        if not self.breakage_per_category:
+            return _("Products")
         max_level = self.max_categ_level or 99
         return " / ".join(product.categ_id.complete_name.split(" / ")[:max_level])
 


### PR DESCRIPTION
Field breakage_per_category works only on xls generation, with this change pdf can have same behavior