### PR TITLE
[14.0][IMP] p_sale_manufactured_for: imp when customer is archived

### DIFF
--- a/product_sale_manufactured_for/__manifest__.py
+++ b/product_sale_manufactured_for/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Product Manufactured for Customer",
     "summary": "Allows to indicate in products that they were made "
     "specifically for some customers.",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.2.0",
     "category": "Sales",
     "website": "https://github.com/OCA/product-attribute",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/product_sale_manufactured_for/migrations/14.0.1.2.0/post-migrate.py
+++ b/product_sale_manufactured_for/migrations/14.0.1.2.0/post-migrate.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    api.Environment(cr, SUPERUSER_ID, {})
+    query = """
+        DELETE FROM product_product_manuf_for_partner_rel
+            WHERE partner_id IN (
+                SELECT id FROM res_partner WHERE active = false
+            );
+    """
+    cr.execute(query)
+    _logger.info("Cleanup archived users from Manufactured For field.")

--- a/product_sale_manufactured_for/models/__init__.py
+++ b/product_sale_manufactured_for/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_product
+from . import res_partner

--- a/product_sale_manufactured_for/models/res_partner.py
+++ b/product_sale_manufactured_for/models/res_partner.py
@@ -1,0 +1,59 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+from collections import defaultdict
+
+from odoo import _, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("active") is False:
+            self._clean_product_manufactured_for()
+        return res
+
+    def _clean_product_manufactured_for(self):
+        """Update product manufactured for when a partner is archived.
+
+        When a partner being archived is used on the Manufactured For field
+        that information is not visible anymore on the product form, although it
+        is still set.
+        And that product can still not be ordered by any other customers.
+
+        Removing this relation when a partner is being archived solves the issue.
+
+        The change is also being logged in the chatter of the related product.
+
+        """
+        query = (
+            "DELETE FROM product_product_manuf_for_partner_rel "
+            "WHERE partner_id IN %s"
+            "RETURNING "
+            "    product_product_manuf_for_partner_rel.product_id, "
+            "    product_product_manuf_for_partner_rel.partner_id;"
+        )
+        self.env.cr.execute(query, (tuple(self.ids),))
+        result = self.env.cr.fetchall()
+        if result:
+            product_to_update = defaultdict(list)
+            for row in result:
+                product_to_update[row[0]].append(row[1])
+            products = self.env["product.product"].browse(product_to_update.keys())
+            customer_ids = {
+                id for values in product_to_update.values() for id in values
+            }
+            all_customers = self.env["res.partner"].browse(customer_ids)
+            for product in products:
+                customers = all_customers.filtered(
+                    lambda customer: customer.id in product_to_update[product.id]
+                )
+                customers_name = ", ".join(customers.mapped("name"))
+                product.message_post(
+                    body=_(
+                        "The product was manufactured for %(customers_name)s "
+                        "but the customer(s) has been archived."
+                    )
+                    % {"customers_name": customers_name}
+                )

--- a/product_sale_manufactured_for/tests/__init__.py
+++ b/product_sale_manufactured_for/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_sale_manufactured_for

--- a/product_sale_manufactured_for/tests/test_product_sale_manufactured_for.py
+++ b/product_sale_manufactured_for/tests/test_product_sale_manufactured_for.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestProductSaleManufacturedFor(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.customer1 = cls.env.ref("base.res_partner_4")
+        cls.customer2 = cls.env.ref("base.res_partner_3")
+        cls.product = cls.env.ref("product.product_product_4")
+        cls.product2 = cls.env.ref("product.product_product_5")
+
+    def test_archiving_customer(self):
+        """Check archiving a customer cleans the product manufactured for field."""
+        self.product.manufactured_for_partner_ids = [(4, self.customer1.id, 0)]
+        self.product2.manufactured_for_partner_ids = [
+            (4, self.customer1.id, 0),
+            (4, self.customer2.id, 0),
+        ]
+        self.assertTrue(self.customer1 in self.product.manufactured_for_partner_ids)
+        self.customer1.active = False
+        self.assertFalse(self.customer1 in self.product.manufactured_for_partner_ids)
+        self.assertFalse(self.customer1 in self.product2.manufactured_for_partner_ids)
+        self.assertTrue(self.customer2 in self.product2.manufactured_for_partner_ids)

--- a/product_sale_manufactured_for/views/product_product.xml
+++ b/product_sale_manufactured_for/views/product_product.xml
@@ -10,7 +10,6 @@
                         name="manufactured_for_partner_ids"
                         widget="many2many_tags"
                         options="{'no_create_edit': True}"
-                        context="{'active_test': False}"
                     />
               </group>
           </page>


### PR DESCRIPTION
When a partner being archived is used on the Manufactured For field That information is not visible anymore on the product form, although it is set. And that product can still not be ordered by any other customers.

Removing the assignation when a customer is archived, fixes both problems.