### PR TITLE
[16.0][FIX] product_pricelist_simulation: switch tests to TransactionCase

### DIFF
--- a/product_pricelist_simulation/tests/test_product_pricelist_simulation.py
+++ b/product_pricelist_simulation/tests/test_product_pricelist_simulation.py
@@ -5,7 +5,7 @@
 from odoo.tests import Form, common
 
 
-class TestProductPricelistSimulation(common.SavepointCase):
+class TestProductPricelistSimulation(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
SavepointCase is deprecated and it was making CI fail.