### PR TITLE
[16.0][FIX] product_pricelist_simulation: change price label to "Unit Price"

### DIFF
--- a/product_pricelist_simulation/wizards/wizard_preview_pricelist.py
+++ b/product_pricelist_simulation/wizards/wizard_preview_pricelist.py
@@ -99,6 +99,7 @@ class PricelistSimulationLine(models.TransientModel):
         readonly=True,
     )
     price = fields.Monetary(
+        string="Unit Price",
         digits="Price",
         readonly=True,
         currency_field="currency_id",


### PR DESCRIPTION
It reduces the confusion specially when changing the qty to a value greater than 1.

Before:
![Peek 2023-10-30 11-37](https://github.com/OCA/product-attribute/assets/23449160/6c2ffed1-5bff-4d5e-8ca1-1f19a975e1dc)


After:
![2023-10-30_11-38](https://github.com/OCA/product-attribute/assets/23449160/ce4f351b-4dd3-4fbd-85db-6986351c1b91)

@ForgeFlow
