### PR TITLE
[16.0][FIX] product_template_tags: Keep depends on 'product' module

### DIFF
--- a/product_template_tags/__manifest__.py
+++ b/product_template_tags/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "ACSONE SA/NV, Odoo Community Association (OCA), Numigi",
     "website": "https://github.com/OCA/product-attribute",
-    "depends": ["stock"],
+    "depends": ["product"],
     "data": [
         "security/product_template_rule.xml",
         "security/product_template_tag.xml",


### PR DESCRIPTION
During https://github.com/OCA/product-attribute/pull/1319 migration main dependency change from product to stock module. 
Undo this change to depend on product module

CC @ForgeFlow @JordiBForgeFlow 