### PR TITLE
[16.0] product_packaging_container_deposit: fix deletion of lines

### DIFF
--- a/product_packaging_container_deposit/models/container_deposit_order_mixin.py
+++ b/product_packaging_container_deposit/models/container_deposit_order_mixin.py
@@ -1,7 +1,11 @@
 # Copyright 2023 Camptocamp (<https://www.camptocamp.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from functools import partial
 
-from odoo import Command, models
+from odoo import Command, _, models
+
+_logger = logging.getLogger(__name__)
 
 
 class OrderMixin(models.AbstractModel):
@@ -30,6 +34,7 @@ class OrderMixin(models.AbstractModel):
         if self.env.context.get("skip_update_container_deposit"):
             return
         self = self.with_context(skip_update_container_deposit=True)
+        line_ids_to_delete = []
         for order in self:
             # Lines to compute container deposit
             lines_to_comp_deposit = order[self._get_order_line_field()].filtered(
@@ -49,17 +54,21 @@ class OrderMixin(models.AbstractModel):
                     line["product_id"], [False, False]
                 )
                 if not qty:
+                    new_vals = {
+                        line._get_product_qty_field(): 0,
+                    }
                     if order.state == "draft":
-                        values_lst.append(Command.delete(line.id))
-                    else:
-                        values_lst.append(
-                            Command.update(
-                                line.id,
-                                {
-                                    line._get_product_qty_field(): 0,
-                                },
-                            )
+                        # values_lst.append(Command.delete(line.id))
+                        line_ids_to_delete.append(line.id)
+                        # TODO: check if it is needed for UI only
+                        new_vals["name"] = _("[DEL] %(name)s", name=line.name)
+                    # else:
+                    values_lst.append(
+                        Command.update(
+                            line.id,
+                            new_vals,
                         )
+                    )
 
                 else:
                     values_lst.append(
@@ -78,6 +87,22 @@ class OrderMixin(models.AbstractModel):
                     )
                     values_lst.append(Command.create(values))
             order.write({self._get_order_line_field(): values_lst})
+        # Schedule line to delete after commit to avoid caching issue w/ UI
+        if line_ids_to_delete:
+            self.env.cr.postcommit.add(
+                partial(
+                    self._order_container_deposit_delete_lines_after_commit,
+                    sorted(line_ids_to_delete),
+                )
+            )
+
+    def _order_container_deposit_delete_lines_after_commit(self, line_ids):
+        line_model = self._fields[self._get_order_line_field()].comodel_name
+        recs = self.env[line_model].browse(line_ids).exists()
+        recs.unlink()
+        _logger.debug("%s deleted after commit", recs)
+        # Needs an explicit commit as it runs after the original commit is done
+        self.env.cr.commit()  # pylint: disable=invalid-commit
 
     def copy(self, default=None):
         return super(

--- a/product_packaging_container_deposit/readme/CONTRIBUTORS.rst
+++ b/product_packaging_container_deposit/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Telmo Santos <telmo.santos@camptocamp.com>
 * Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/product_packaging_container_deposit/tests/__init__.py
+++ b/product_packaging_container_deposit/tests/__init__.py
@@ -1,4 +1,2 @@
-from . import common
-from . import fake_models
 from . import test_product_packaging_container_deposit
 from . import test_container_deposit_order_mixin

--- a/product_packaging_container_deposit/tests/fake_models.py
+++ b/product_packaging_container_deposit/tests/fake_models.py
@@ -11,6 +11,7 @@ class ContainerDepositOrderTest(models.Model):
     name = fields.Char()
     partner_id = fields.Many2one("res.partner")
     company_id = fields.Many2one("res.company")
+    state = fields.Char()
     order_line = fields.One2many(
         "container.deposit.order.line.test", inverse_name="order_id"
     )

--- a/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
+++ b/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
@@ -22,26 +22,25 @@ class TestProductPackagingContainerDepositMixin(Common):
                 ContainerDepositOrderLineTest,
             )
         )
-
-    def setUp(self):
-        super().setUp()
-        self.order = self.env["container.deposit.order.test"].create(
+        cls.order_model = cls.env[ContainerDepositOrderTest._name]
+        cls.line_model = cls.env[ContainerDepositOrderLineTest._name]
+        cls.order = cls.order_model.create(
             {
-                "company_id": self.env.company.id,
-                "partner_id": self.env.ref("base.res_partner_12").id,
+                "company_id": cls.env.company.id,
+                "partner_id": cls.env.ref("base.res_partner_12").id,
                 "state": "draft",
             }
         )
 
     def test_implemented_get_order_line_field(self):
         self.assertEqual(
-            self.env["container.deposit.order.test"]._get_order_line_field(),
+            self.order_model._get_order_line_field(),
             "order_line",
         )
 
     def test_implemented_get_product_qty_field(self):
         self.assertEqual(
-            self.env["container.deposit.order.line.test"]._get_product_qty_field(),
+            self.line_model._get_product_qty_field(),
             "product_qty",
         )
 
@@ -50,7 +49,7 @@ class TestProductPackagingContainerDepositMixin(Common):
             self.order.order_line._get_order_lines_container_deposit_quantities()
         )
         self.assertEqual(deposit_product_qties, {})
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             {
                 "order_id": self.order.id,
                 "name": self.product_a.name,
@@ -72,7 +71,7 @@ class TestProductPackagingContainerDepositMixin(Common):
         )
 
     def test_product_container_deposit_order(self):
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             {
                 "order_id": self.order.id,
                 "name": self.product_a.name,
@@ -94,7 +93,7 @@ class TestProductPackagingContainerDepositMixin(Common):
                 280 // 240 = 1 => add order line for 1 Pallet
                 280 // 24 (biggest PACK) => add order line for 11 boxes of 24
         """
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             [
                 {
                     "order_id": self.order.id,
@@ -124,7 +123,7 @@ class TestProductPackagingContainerDepositMixin(Common):
             280 // 240 = 1 => add order line for 1 Pallet
             280 // 12 (forced packaging for Boxes) => add order line for 23 boxes of 12
         """
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             {
                 "order_id": self.order.id,
                 "name": self.product_a.name,
@@ -143,7 +142,7 @@ class TestProductPackagingContainerDepositMixin(Common):
         Case 3: Product A & Product B. Both have a deposit of 1 box of 24. Result:
                 Only one line for 2 boxes of 24
         """
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             [
                 {
                     "order_id": self.order.id,
@@ -172,7 +171,7 @@ class TestProductPackagingContainerDepositMixin(Common):
                 1 order line with 2 boxes of 24 (System added)
                 + 1 order line with 1 box (manually added)
         """
-        order_line = self.env["container.deposit.order.line.test"].create(
+        order_line = self.line_model.create(
             {
                 "order_id": self.order.id,
                 "name": self.product_a.name,
@@ -191,7 +190,7 @@ class TestProductPackagingContainerDepositMixin(Common):
         self.assertEqual(deposit_line.product_qty, 2.0)
 
         # Add manually 1 box
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             {
                 "order_id": self.order.id,
                 "name": self.package_type_box.container_deposit_product_id.name,
@@ -215,7 +214,7 @@ class TestProductPackagingContainerDepositMixin(Common):
                 Received 200 // 280 = 0 Pallet
                 Received 200 // 24 = 5 Boxes
         """
-        self.env["container.deposit.order.line.test"].create(
+        self.line_model.create(
             [
                 {
                     "order_id": self.order.id,
@@ -240,7 +239,7 @@ class TestProductPackagingContainerDepositMixin(Common):
 
     def test_confirmed_sale_product_packaging_container_deposit_quantities6(self):
         """Test deposit line is added deleted after reduce product_a quantity"""
-        order_line = self.env["container.deposit.order.line.test"].create(
+        order_line = self.line_model.create(
             {
                 "order_id": self.order.id,
                 "name": self.product_a.name,

--- a/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
+++ b/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
@@ -29,6 +29,7 @@ class TestProductPackagingContainerDepositMixin(Common):
             {
                 "company_id": self.env.company.id,
                 "partner_id": self.env.ref("base.res_partner_12").id,
+                "state": "draft",
             }
         )
 
@@ -236,3 +237,20 @@ class TestProductPackagingContainerDepositMixin(Common):
         self.order.order_line[0].qty_delivered = 200
         self.assertEqual(pallet_line.qty_delivered, 0)
         self.assertEqual(box_line.qty_delivered, 8)
+
+    def test_confirmed_sale_product_packaging_container_deposit_quantities6(self):
+        """Test deposit line is added deleted after reduce product_a quantity"""
+        order_line = self.env["container.deposit.order.line.test"].create(
+            {
+                "order_id": self.order.id,
+                "name": self.product_a.name,
+                "product_id": self.product_a.id,
+                "product_qty": 240,
+            },
+        )
+        order_line.write({"product_qty": 10})
+
+        pallet_line = self.order.order_line.filtered(
+            lambda ol: ol.product_id == self.pallet
+        )
+        self.assertFalse(pallet_line)


### PR DESCRIPTION
Continues the work of #1470  and replaces it.

Lines deletion cannot be done in the same transaction or you'll get a broken cache.
See atomic commits for details.