### PR TITLE
[16.0][FIX] product_print_category fix a security issue

### DIFF
--- a/product_print_category/models/product_print_category_mixin.py
+++ b/product_print_category/models/product_print_category_mixin.py
@@ -58,7 +58,7 @@ class ProductPrintCategoryMixin(models.AbstractModel):
             category = ProductPrintCategory.browse(
                 product_group["print_category_id"][0]
             )
-            triggering_fields = category.field_ids.mapped("name")
+            triggering_fields = category.field_ids.sudo().mapped("name")
             if len(list(set(vals.keys()) & set(triggering_fields))):
                 # Value present in the label changed
                 products_to_update |= ProductProduct.search(product_group["__domain"])


### PR DESCRIPTION
Odoo V16 does not allow 'regular' users (ie users with no Admin/Access Right group) to acces to ir.model.fields at all, therefore i added a sudo to allow users with no such right to be able to actually write to products.
Did not find a more elegant solution.