### PR TITLE
[16.0][IMP] product_packaging_container_deposit process negative quantities

### DIFF
--- a/product_packaging_container_deposit/models/container_deposit_order_mixin.py
+++ b/product_packaging_container_deposit/models/container_deposit_order_mixin.py
@@ -81,7 +81,7 @@ class OrderMixin(models.AbstractModel):
                         )
                     )
             for product in deposit_container_qties:
-                if deposit_container_qties[product][0] > 0:
+                if deposit_container_qties[product][0]:
                     values = order.prepare_deposit_container_line(
                         product, deposit_container_qties[product][0]
                     )

--- a/product_packaging_container_deposit/models/product_product.py
+++ b/product_packaging_container_deposit/models/product_product.py
@@ -27,7 +27,7 @@ class ProductProduct(models.Model):
             )
 
         pack_qties = {}
-        if qty > 0:
+        if qty:
             # Sort by forced_packaging, fitting packagings, biggest packaging
             packagings = self.packaging_ids.sorted(key=get_sort_key)
             for plevel, packs in groupby(packagings, lambda p: p.packaging_level_id):
@@ -38,6 +38,6 @@ class ProductProduct(models.Model):
                     continue
                 pack_qties[plevel] = (
                     container_deposit,
-                    qty // packs[0].qty,
+                    qty * (abs(qty) // packs[0].qty) / abs(qty),
                 )
         return pack_qties

--- a/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
+++ b/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
@@ -290,3 +290,28 @@ class TestProductPackagingContainerDepositMixin(Common):
             self.order._order_container_deposit_delete_lines_after_commit(line.ids)
             self.assertFalse(line.exists())
             mocked.assert_called()
+
+    def test_order_product_packaging_container_deposit_negative_quantity(self):
+        self.line_model.create(
+            [
+                {
+                    "order_id": self.order.id,
+                    "name": self.product_a.name,
+                    "product_id": self.product_a.id,
+                    "product_qty": -280,
+                },
+                {
+                    "order_id": self.order.id,
+                    "name": self.product_c.name,
+                    "product_id": self.product_c.id,
+                    "product_qty": -1,
+                },
+            ]
+        )
+
+        pallet_line = self.order.order_line.filtered(
+            lambda ol: ol.product_id == self.pallet
+        )
+        box_line = self.order.order_line.filtered(lambda ol: ol.product_id == self.box)
+        self.assertEqual(pallet_line.product_qty, -1)
+        self.assertEqual(box_line.product_qty, -11)

--- a/product_packaging_container_deposit/tests/test_product_packaging_container_deposit.py
+++ b/product_packaging_container_deposit/tests/test_product_packaging_container_deposit.py
@@ -27,3 +27,19 @@ class TestProductPackagingContainerDeposit(Common):
                 ),
             },
         )
+
+    def test_product_container_deposit_negative_quantity(self):
+        packaging_qties = self.product_a.get_product_container_deposit_quantities(-280)
+        self.assertEqual(
+            packaging_qties,
+            {
+                self.product_packaging_level_box: (
+                    self.package_type_box.container_deposit_product_id,
+                    -11,
+                ),
+                self.product_packaging_level_pallet: (
+                    self.package_type_pallet.container_deposit_product_id,
+                    -1,
+                ),
+            },
+        )


### PR DESCRIPTION
Allows negative quantities of product container deposit to be processed. This is particularly important if the user wants to process the return to the customer or product supplier.