### PR TITLE
[14.0][IMP] product_supplierinfo_for_customer: better _select_customerinfo

### DIFF
--- a/product_supplierinfo_for_customer/README.rst
+++ b/product_supplierinfo_for_customer/README.rst
@@ -112,6 +112,20 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-aleuffre| image:: https://github.com/aleuffre.png?size=40px
+    :target: https://github.com/aleuffre
+    :alt: aleuffre
+.. |maintainer-renda-dev| image:: https://github.com/renda-dev.png?size=40px
+    :target: https://github.com/renda-dev
+    :alt: renda-dev
+.. |maintainer-PicchiSeba| image:: https://github.com/PicchiSeba.png?size=40px
+    :target: https://github.com/PicchiSeba
+    :alt: PicchiSeba
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-aleuffre| |maintainer-renda-dev| |maintainer-PicchiSeba| 
+
 This module is part of the `OCA/product-attribute <https://github.com/OCA/product-attribute/tree/14.0/product_supplierinfo_for_customer>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/product_supplierinfo_for_customer/README.rst
+++ b/product_supplierinfo_for_customer/README.rst
@@ -40,26 +40,35 @@ allowing to define prices per customer and product.
 Configuration
 =============
 
-For these prices to be used in sale prices calculations, you will have
-to create a pricelist with a rule with option "Based on" with the value
-"Partner Prices: Take the price from the customer info on the 'product form')".
+There's a new section in the *Sales* tab of the product form called "Customers",
+where you can define pricelist-like records for customers with the same
+structure as the suppliers:
+
+- custom price for a specific customer
+- minimum quantity to purchase for this price to apply
+- when the price is valid (start and end)
+- custom product name and code for a specific customer
+
+There's a new option on pricelist items that allows to get the prices from the
+supplierinfo at the product form. These prices will only apply through a pricelist using such rule.
 
 Usage
 =====
 
-There's a new section on *Sales* tab of the product form called "Customers",
-where you can define records for customers with the same structure of the
-suppliers.
+#. Navigate to a product page. In the *Sales* tab, add a new line to the table labelled "Customers" to add a specify a custom price for a given customer
+#. Create a new pricelist, and a pricelist item that applies to the product. In the "price computation" section, choose "Formula" and then for "Based on" pick "Partner Prices on Product form"
+#. Create a Sales Order for the customer you chose, and use the pricelist you chose. Add a line with the product: the price will reflect the one added in the product form. Additionally, if they were added, the custom product name and code will also be used in the description of the Sales Order Line.
 
-There's a new option on pricelist items that allows to get the prices from the
-supplierinfo at the product form.
+Note: the customer price defined on the product form will only be used if the correct pricelist is used.
 
 Known issues / Roadmap
 ======================
 
 * Product prices through this method are only guaranteed on the standard sale
-  order workflow. Other custom flows maybe don't reflect the price.
-* The minimum quantity will neither apply on sale orders.
+  order workflow. Other custom flows may not reflect the price.
+  * Additionally, only custom product prices with no minimum quantity set will be used on the Sales Order
+* Custom name and description will be used on Sales Order Lines regardless of pricelist.
+
 
 Bug Tracker
 ===========
@@ -88,6 +97,7 @@ Contributors
 * Aaron Henriquez <ahenriquez@forgeflow.com>
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Tecnativa - Sergio Teruel <sergio.teruel@tecnativa.com>
+* PyTech SRL - Alessandro Uffreduzzi <alessandro.uffreduzzi@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_supplierinfo_for_customer/__manifest__.py
+++ b/product_supplierinfo_for_customer/__manifest__.py
@@ -12,6 +12,7 @@
     "website": "https://github.com/OCA/product-attribute",
     "category": "Sales Management",
     "license": "AGPL-3",
+    "maintainers": ["aleuffre", "renda-dev", "PicchiSeba"],
     "depends": ["product", "sales_team"],
     "data": [
         "security/ir.model.access.csv",

--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -4,7 +4,9 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 import datetime
 
-from odoo import api, models
+from odoo import api, fields, models
+from odoo.osv import expression
+from odoo.tools import float_compare
 
 
 class ProductProduct(models.Model):
@@ -107,30 +109,88 @@ class ProductProduct(models.Model):
             price_type, uom, currency, company
         )
 
+    def _prepare_customers(self, params=False):
+        return self.env["product.customerinfo"].search(
+            params.get("domain", []),
+            order="sequence, min_qty desc, price, id",
+        )
+
     def _prepare_domain_customerinfo(self, params):
         self.ensure_one()
-        partner_id = params.get("partner_id")
-        return [
-            ("name", "=", partner_id),
+        date = fields.Date.to_string(
+            params.get("date") or fields.Date.context_today(self)
+        )
+        domain = [
+            "|",
+            ("company_id", "=", False),
+            ("company_id", "=", self.env.company.id),
             "|",
             ("product_id", "=", self.id),
             "&",
             ("product_tmpl_id", "=", self.product_tmpl_id.id),
             ("product_id", "=", False),
+            "|",
+            ("date_start", "=", False),
+            ("date_start", "<=", date),
+            "|",
+            ("date_end", "=", False),
+            ("date_end", ">=", date),
         ]
+        partner_id = params.get("partner_id")
+        if partner_id:
+            domain = expression.AND(
+                [domain, [("name", "in", (partner_id + partner_id.parent_id).ids)]]
+            )
+        return domain
+
+    def _customers_filter_by_quantity(self, customers, quantity, uom_id, precision):
+        res = self.env["product.customerinfo"]
+        # Set quantity in UoM of customer
+        if quantity:
+            if uom_id and self.uom_id and uom_id != self.uom_id:
+                quantity = uom_id._compute_quantity(quantity, self.uom_id)
+        for customer in customers:
+            if quantity:
+                if (
+                    float_compare(
+                        quantity,
+                        customer.min_qty,
+                        precision_digits=precision,
+                    )
+                    == -1
+                ):
+                    continue
+            else:
+                if customer.min_qty:
+                    continue
+            res |= customer
+        return res
 
     def _select_customerinfo(
-        self, partner=False, _quantity=0.0, _date=None, _uom_id=False, params=False
+        self, partner=False, quantity=0.0, date=None, uom_id=False, params=False
     ):
         """Customer version of the standard `_select_seller`."""
-        # TODO: For now it is just the function name with same arguments, but
-        #  can be changed in future migrations to be more in line Odoo
-        #  standard way to select supplierinfo's.
+        self.ensure_one()
         if not params:
-            params = dict()
-        params.update({"partner_id": partner.id})
+            params = {}
+        params.update({"date": date, "partner_id": partner})
         domain = self._prepare_domain_customerinfo(params)
-        res = self.env["product.customerinfo"].search(
-            domain, order="product_id, sequence", limit=1
+        params["domain"] = domain
+
+        customers = self._prepare_customers(params)
+        precision = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
         )
-        return res
+        res = self._customers_filter_by_quantity(
+            customers, quantity=quantity, uom_id=uom_id, precision=precision
+        )
+        if res:
+            customer_name = res[0].name
+            res = res.filtered(lambda x, name=customer_name: x.name == name)
+
+        # Prefer matching specific variants over templates if possible
+        variant_res = res.filtered(lambda x: x.product_id)
+        if variant_res:
+            res = variant_res
+
+        return res.sorted("price")[:1]

--- a/product_supplierinfo_for_customer/readme/CONFIGURE.rst
+++ b/product_supplierinfo_for_customer/readme/CONFIGURE.rst
@@ -1,3 +1,11 @@
-For these prices to be used in sale prices calculations, you will have
-to create a pricelist with a rule with option "Based on" with the value
-"Partner Prices: Take the price from the customer info on the 'product form')".
+There's a new section in the *Sales* tab of the product form called "Customers",
+where you can define pricelist-like records for customers with the same
+structure as the suppliers:
+
+- custom price for a specific customer
+- minimum quantity to purchase for this price to apply
+- when the price is valid (start and end)
+- custom product name and code for a specific customer
+
+There's a new option on pricelist items that allows to get the prices from the
+supplierinfo at the product form. These prices will only apply through a pricelist using such rule.

--- a/product_supplierinfo_for_customer/readme/CONTRIBUTORS.rst
+++ b/product_supplierinfo_for_customer/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Aaron Henriquez <ahenriquez@forgeflow.com>
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Tecnativa - Sergio Teruel <sergio.teruel@tecnativa.com>
+* PyTech SRL - Alessandro Uffreduzzi <alessandro.uffreduzzi@pytech.it>

--- a/product_supplierinfo_for_customer/readme/ROADMAP.rst
+++ b/product_supplierinfo_for_customer/readme/ROADMAP.rst
@@ -1,3 +1,5 @@
 * Product prices through this method are only guaranteed on the standard sale
-  order workflow. Other custom flows maybe don't reflect the price.
-* The minimum quantity will neither apply on sale orders.
+  order workflow. Other custom flows may not reflect the price.
+  * Additionally, only custom product prices with no minimum quantity set will be used on the Sales Order
+* Custom name and description will be used on Sales Order Lines regardless of pricelist.
+

--- a/product_supplierinfo_for_customer/readme/USAGE.rst
+++ b/product_supplierinfo_for_customer/readme/USAGE.rst
@@ -1,6 +1,5 @@
-There's a new section on *Sales* tab of the product form called "Customers",
-where you can define records for customers with the same structure of the
-suppliers.
+#. Navigate to a product page. In the *Sales* tab, add a new line to the table labelled "Customers" to add a specify a custom price for a given customer
+#. Create a new pricelist, and a pricelist item that applies to the product. In the "price computation" section, choose "Formula" and then for "Based on" pick "Partner Prices on Product form"
+#. Create a Sales Order for the customer you chose, and use the pricelist you chose. Add a line with the product: the price will reflect the one added in the product form. Additionally, if they were added, the custom product name and code will also be used in the description of the Sales Order Line.
 
-There's a new option on pricelist items that allows to get the prices from the
-supplierinfo at the product form.
+Note: the customer price defined on the product form will only be used if the correct pricelist is used.

--- a/product_supplierinfo_for_customer/static/description/index.html
+++ b/product_supplierinfo_for_customer/static/description/index.html
@@ -390,24 +390,34 @@ allowing to define prices per customer and product.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p>For these prices to be used in sale prices calculations, you will have
-to create a pricelist with a rule with option “Based on” with the value
-“Partner Prices: Take the price from the customer info on the ‘product form’)”.</p>
+<p>There’s a new section in the <em>Sales</em> tab of the product form called “Customers”,
+where you can define pricelist-like records for customers with the same
+structure as the suppliers:</p>
+<ul class="simple">
+<li>custom price for a specific customer</li>
+<li>minimum quantity to purchase for this price to apply</li>
+<li>when the price is valid (start and end)</li>
+<li>custom product name and code for a specific customer</li>
+</ul>
+<p>There’s a new option on pricelist items that allows to get the prices from the
+supplierinfo at the product form. These prices will only apply through a pricelist using such rule.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<p>There’s a new section on <em>Sales</em> tab of the product form called “Customers”,
-where you can define records for customers with the same structure of the
-suppliers.</p>
-<p>There’s a new option on pricelist items that allows to get the prices from the
-supplierinfo at the product form.</p>
+<ol class="arabic simple">
+<li>Navigate to a product page. In the <em>Sales</em> tab, add a new line to the table labelled “Customers” to add a specify a custom price for a given customer</li>
+<li>Create a new pricelist, and a pricelist item that applies to the product. In the “price computation” section, choose “Formula” and then for “Based on” pick “Partner Prices on Product form”</li>
+<li>Create a Sales Order for the customer you chose, and use the pricelist you chose. Add a line with the product: the price will reflect the one added in the product form. Additionally, if they were added, the custom product name and code will also be used in the description of the Sales Order Line.</li>
+</ol>
+<p>Note: the customer price defined on the product form will only be used if the correct pricelist is used.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Product prices through this method are only guaranteed on the standard sale
-order workflow. Other custom flows maybe don’t reflect the price.</li>
-<li>The minimum quantity will neither apply on sale orders.</li>
+order workflow. Other custom flows may not reflect the price.
+* Additionally, only custom product prices with no minimum quantity set will be used on the Sales Order</li>
+<li>Custom name and description will be used on Sales Order Lines regardless of pricelist.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -435,6 +445,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Aaron Henriquez &lt;<a class="reference external" href="mailto:ahenriquez&#64;forgeflow.com">ahenriquez&#64;forgeflow.com</a>&gt;</li>
 <li>Miquel Raïch &lt;<a class="reference external" href="mailto:miquel.raich&#64;forgeflow.com">miquel.raich&#64;forgeflow.com</a>&gt;</li>
 <li>Tecnativa - Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
+<li>PyTech SRL - Alessandro Uffreduzzi &lt;<a class="reference external" href="mailto:alessandro.uffreduzzi&#64;pytech.it">alessandro.uffreduzzi&#64;pytech.it</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/product_supplierinfo_for_customer/static/description/index.html
+++ b/product_supplierinfo_for_customer/static/description/index.html
@@ -455,6 +455,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/aleuffre"><img alt="aleuffre" src="https://github.com/aleuffre.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/renda-dev"><img alt="renda-dev" src="https://github.com/renda-dev.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/PicchiSeba"><img alt="PicchiSeba" src="https://github.com/PicchiSeba.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/product-attribute/tree/14.0/product_supplierinfo_for_customer">OCA/product-attribute</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Improve method `_select_customerinfo` to better mirror `_select_seller` and use all its parameters

As stated in the previous `_select_customerinfo`'s docstring, the method didn't make use of most of its parameters, and only looked at partner_id, really.

What it was missing, compared to `select_seller`:

- didn't select a line according to start and end dates
- didn't select a line according to min qty
- didn't consider the parent contact, in addition to the contact itself
- didn't order by lowest price
- didn't support UoM conversion

Now, the implementation as it relates to the SO, through the method `compute_price` still doesn't use most of these. However, it does benefit from some of these changes (for example, it will now look at the parent contact, and it will take start and end dates into account). 

My work also lays the foundation for future improvements, and provides a good hook for other modules extending this one. For example: https://github.com/OCA/stock-logistics-workflow/pull/1478 Here, the delivery address is often a child of the main SO contact, and now it can make use of `_select_customerinfo` to select the correct Customer Product Code and Customer Product Name.


The second commit adds maintainers for the module.

To do:
  - [x] Add test coverage