### PR TITLE
[13.0][IMP]product_exception: various improvements

### DIFF
--- a/product_exception/__manifest__.py
+++ b/product_exception/__manifest__.py
@@ -12,5 +12,9 @@
     "installable": True,
     "depends": ["stock", "base_exception"],
     "demo": ["demo/product_exception.xml"],
-    "data": ["data/data.xml", "views/product.xml"],
+    "data": [
+        "data/data.xml",
+        "views/exception_rule_views.xml",
+        "views/product_template_views.xml",
+    ],
 }

--- a/product_exception/models/product_product.py
+++ b/product_exception/models/product_product.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
+from odoo.tools import config
 
 
 class ProductProduct(models.Model):
@@ -14,9 +15,63 @@ class ProductProduct(models.Model):
         return self.mapped("product_tmpl_id")
 
     @api.model
+    def _fields_trigger_check_exception(self):
+        return ["ignore_exception"]
+
+    @api.model
     def _reverse_field(self):
         return "product_tmpl_ids"
 
     def _detect_exceptions(self, rule):
+        """
+        Return the Product Templates from the Product Variants that have
+        Exceptions
+        """
         records = super()._detect_exceptions(rule)
         return records.mapped("product_tmpl_id")
+
+    def action_product_detect_exceptions(self):
+        """
+        Manually trigger to calculate the Exceptions. For Variants
+        calculate for them only
+        """
+        self.detect_exceptions()
+        return {"type": "ir.actions.act_window_close"}
+
+    @api.model
+    def create(self, vals):
+        """
+        Upon creation, check if the Product Variant has any Exception, if so,
+        raise a Validation Error
+        """
+        record = super(ProductProduct, self).create(vals)
+        check_exceptions = any(
+            field in vals for field in self._fields_trigger_check_exception()
+        )
+        if check_exceptions:
+            record.product_check_exception()
+        return record
+
+    def write(self, vals):
+        """
+        When changing one of the trigger fields, check if the Product Variant
+        has any Exception, if so, raise a Validation Error
+        """
+        result = super(ProductProduct, self).write(vals)
+        check_exceptions = any(
+            field in vals for field in self._fields_trigger_check_exception()
+        )
+        if check_exceptions:
+            self.product_check_exception()
+        return result
+
+    def product_check_exception(self):
+        if (
+            self
+            and not self.env.context.get("skip_product_check_exception", False)
+            and (
+                not config["test_enable"]
+                or self.env.context.get("test_product_check_exception", False)
+            )
+        ):
+            self._check_exception()

--- a/product_exception/models/product_template.py
+++ b/product_exception/models/product_template.py
@@ -3,29 +3,75 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
+from odoo.tools import config
 
 
 class ProductTemplate(models.Model):
     _inherit = ["product.template", "base.exception"]
     _name = "product.template"
 
+    @api.model
     def check_product_template_cron(self):
         products = self.env["product.template"].search([])
         for product in products:
             product.detect_exceptions()
 
-    def test_button(self):
-        products = self.env["product.template"].search([])
-        for product in products:
-            product.detect_exceptions()
+    @api.model
+    def _fields_trigger_check_exception(self):
+        return ["ignore_exception"]
 
     @api.model
     def _reverse_field(self):
         return "product_tmpl_ids"
 
-    @api.depends("name")
     def detect_exceptions(self):
         all_exceptions = super(ProductTemplate, self).detect_exceptions()
         products = self.mapped("product_variant_ids")
         all_exceptions += products.detect_exceptions()
         return all_exceptions
+
+    def action_product_detect_exceptions(self):
+        """
+        Manually trigger to calculate the Exceptions. For Templates, calculate
+        for them and for their respective Product Variants
+        """
+        self.detect_exceptions()
+        return {"type": "ir.actions.act_window_close"}
+
+    @api.model
+    def create(self, vals):
+        """
+        Upon creation, check if the Product Template has any Exception, if so,
+        raise a Validation Error
+        """
+        record = super(ProductTemplate, self).create(vals)
+        check_exceptions = any(
+            field in vals for field in self._fields_trigger_check_exception()
+        )
+        if check_exceptions:
+            record.product_check_exception()
+        return record
+
+    def write(self, vals):
+        """
+        When changing one of the trigger fields, check if the Product Template
+        has any Exception, if so, raise a Validation Error
+        """
+        result = super(ProductTemplate, self).write(vals)
+        check_exceptions = any(
+            field in vals for field in self._fields_trigger_check_exception()
+        )
+        if check_exceptions:
+            self.product_check_exception()
+        return result
+
+    def product_check_exception(self):
+        if (
+            self
+            and not self.env.context.get("skip_product_check_exception", False)
+            and (
+                not config["test_enable"]
+                or self.env.context.get("test_product_check_exception", False)
+            )
+        ):
+            self._check_exception()

--- a/product_exception/tests/test_product_exception.py
+++ b/product_exception/tests/test_product_exception.py
@@ -1,3 +1,4 @@
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -25,3 +26,36 @@ class TestProductException(TransactionCase):
         self.assertTrue(len(product.exception_ids) == 0)
         product.check_product_template_cron()
         self.assertTrue(len(product.exception_ids) == 1)
+
+    def test_check_error_raises_on_create_with_field_to_check(self):
+        exception = self.env.ref("product_exception.excep_no_dump")
+        exception.active = True
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].with_context(
+                test_product_check_exception=True
+            ).create(
+                {
+                    "name": "Test Product",
+                    "type": "product",
+                    "lst_price": 5,
+                    "standard_price": 10,
+                    "ignore_exception": False,
+                }
+            )
+
+    def test_check_error_raises_on_write_with_field_to_check(self):
+        exception = self.env.ref("product_exception.excep_no_dump")
+        exception.active = True
+        product = self.env.ref("product.product_product_6").product_tmpl_id
+        with self.assertRaises(ValidationError):
+            product.with_context(test_product_check_exception=True).write(
+                {"ignore_exception": False, "standard_price": 10000}
+            )
+
+    def test_check_skip_error_on_write_with_context(self):
+        exception = self.env.ref("product_exception.excep_no_dump")
+        exception.active = True
+        product = self.env.ref("product.product_product_6").product_tmpl_id
+        product.with_context(skip_product_check_exception=True).write(
+            {"standard_price": 100}
+        )

--- a/product_exception/views/exception_rule_views.xml
+++ b/product_exception/views/exception_rule_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- ACTION AND MENU ITEM -->
+    <record id="action_product_exception_rule" model="ir.actions.act_window">
+        <field name="name">Product Exception Rules</field>
+        <field name="res_model">exception.rule</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="base_exception.view_exception_rule_tree" />
+        <field
+            name="domain"
+        >[('model', 'in', ['product.template', 'product.product'])]</field>
+        <field
+            name="context"
+        >{'active_test': False, 'default_model' : 'product.template'}</field>
+    </record>
+    <menuitem
+        id="menu_product_exception_rule"
+        name="Product Exceptions Rules"
+        action="action_product_exception_rule"
+        sequence="90"
+        parent="stock.menu_product_in_config_stock"
+        groups="base_exception.group_exception_rule_manager"
+    />
+</odoo>

--- a/product_exception/views/product_template_views.xml
+++ b/product_exception/views/product_template_views.xml
@@ -1,35 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
-    <record id="action_product_test_tree" model="ir.actions.act_window">
-        <field name="name">Product Exception Rules</field>
-        <field name="res_model">exception.rule</field>
-        <field name="view_mode">tree,form</field>
-        <field name="view_id" ref="base_exception.view_exception_rule_tree" />
-        <field
-            name="domain"
-        >[('model', 'in', ['product.template', 'product.product'])]</field>
-        <field
-            name="context"
-        >{'active_test': False, 'default_model' : 'product.template'}</field>
-    </record>
-
-    <menuitem
-        id="menu_product_test_parent"
-        name="Product Exceptions Rules"
-        action="action_product_test_tree"
-        sequence="90"
-        parent="stock.menu_product_in_config_stock"
-        groups="base_exception.group_exception_rule_manager"
-    />
-
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product_template_form_view - product_exception</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <header position="inside">
-                <button name="test_button" type="object" string="Test button" />
+                <button
+                    type="object"
+                    name="action_product_detect_exceptions"
+                    string="Detect Exceptions"
+                />
             </header>
             <sheet position="before">
                 <div
@@ -63,19 +44,17 @@
             </field>
         </field>
     </record>
-
     <record id="product_template_search_view" model="ir.ui.view">
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_search_view" />
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='consumable']" position="after">
-                <separator />
+            <filter name="activities_exception" position="after">
                 <filter
-                    string="With exception"
+                    string="With Exception"
                     name="with_exception"
                     domain="[('exception_ids','!=',False)]"
                 />
-            </xpath>
+            </filter>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Raise Validation Error on Creation/Write if there is one Exception for the Product Template/Variant.
- Adapt tests to include new cases
- Rename Exception Rules view file and improve structure + namings
- Remove `test_button` method which was pointless to have, and replace it with button to manually trigger the Exceptions detection

cc @ForgeFlow