### PR TITLE
[15.0][FIX] product_supplierinfo_for_customer: Get first variants than templates

### DIFF
--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -131,7 +131,7 @@ class ProductProduct(models.Model):
             .search(domain)
             .sorted(lambda s: (s.sequence, s.min_qty, s.price, s.id))
         )
-        res_1 = res.sorted("product_tmpl_id")[:1]
+        res_1 = res.sorted("product_id", reverse=True)[:1]
         if res_1 or not partner.parent_id:
             return res_1
         else:


### PR DESCRIPTION
cc @Tecnativa

With the changes introduced in this commit https://github.com/odoo/odoo/commit/93a10378ca11063468e0674692c75e12df75c268 when trying to get the price set to a variant the system is returning the price set to the template. 

With this change, we get first the customerinfos that have product_id selected.

ping @carlosdauden @chienandalu 