### PR TITLE
[14.0][FIX] product_supplierinfo_for_customer: get customerinfo price quantity

### DIFF
--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -69,7 +69,7 @@ class ProductProduct(models.Model):
         if not partner_id:
             return 0.0
         partner = self.env["res.partner"].browse(partner_id)
-        customerinfo = self._select_customerinfo(partner=partner)
+        customerinfo = self._select_customerinfo(partner=partner, quantity=None)
         if customerinfo:
             return customerinfo.price
         return 0.0


### PR DESCRIPTION
`_get_price_from_customerinfo` doesn't properly work after the fixes made in https://github.com/OCA/product-attribute/pull/1506

With the recent changes, `_select_customerinfo` uses the `quantity` parameter properly, which is not expected by `_get_price_from_customerinfo`

`price_compute` also rely on this, and doesn't work as expected right now

This also fixes tests in https://github.com/OCA/e-commerce/pull/863