### PR TITLE
[16.0][IMP]product_packaging_level: recover name_get policy flow

### DIFF
--- a/product_packaging_level/models/product_packaging.py
+++ b/product_packaging_level/models/product_packaging.py
@@ -10,6 +10,7 @@ class ProductPackaging(models.Model):
     _inherit = "product.packaging"
     _order = "product_id, level_sequence"
 
+    name = fields.Char(compute="_compute_name", store=True, readonly=False)
     packaging_level_id = fields.Many2one(
         "product.packaging.level",
         required=True,
@@ -126,11 +127,30 @@ class ProductPackaging(models.Model):
         if package_type_level_id:
             self.packaging_level_id = package_type_level_id
 
-    @api.onchange("packaging_level_id", "package_type_id", "name", "name_policy")
-    def _onchange_name(self):
+    @api.depends(
+        "package_type_id",
+        "name_policy",
+        "packaging_level_id",
+    )
+    def _compute_name(self):
+        for rec in self:
+            rec.name = rec._get_name_from_policy()
+
+    # Keep this method to respect translations on level name
+    @api.depends("product_id", "packaging_level_id", "name_policy")
+    def _compute_display_name(self):
+        for record in self:
+            if record.product_id and record.packaging_level_id:
+                record.display_name = record._get_name_from_policy(lang=self.env.lang)
+            else:
+                return super()._compute_display_name()
+
+    def _get_name_from_policy(self, lang=None):
         new_name = self.name
         if self.name_policy == "by_package_level":
+            lang = lang or self.packaging_level_id.default_lang_id.code
+            self = self.with_context(lang=lang)
             new_name = self.packaging_level_id.display_name
         elif self.name_policy == "by_package_type":
             new_name = self.package_type_id.name
-        self.name = new_name
+        return new_name

--- a/product_packaging_level/models/product_packaging_level.py
+++ b/product_packaging_level/models/product_packaging_level.py
@@ -9,12 +9,24 @@ class ProductPackagingLevel(models.Model):
     _description = "Level management for product.packaging"
     _order = "sequence, code"
 
+    def _default_language(self):
+        lang_code = self.env["ir.default"].get("res.partner", "lang")
+        def_lang_id = self.env["res.lang"]._lang_get_id(lang_code)
+        return def_lang_id or self._active_languages()[0]
+
     name = fields.Char(required=True, translate=True)
     code = fields.Char(required=True)
     sequence = fields.Integer(required=True)
     has_gtin = fields.Boolean()
     active = fields.Boolean(default=True)
     is_default = fields.Boolean()
+    default_lang_id = fields.Many2one(
+        "res.lang",
+        string="Default Language",
+        default=lambda self: self._default_language(),
+        required=True,
+    )
+
     name_policy = fields.Selection(
         selection=[
             ("by_package_level", "Package Level Name"),

--- a/product_packaging_level/views/product_packaging_level_view.xml
+++ b/product_packaging_level/views/product_packaging_level_view.xml
@@ -30,6 +30,10 @@
                             <field name="code" />
                             <field name="has_gtin" />
                             <field name="name_policy" />
+                            <field
+                                name="default_lang_id"
+                                help="Language option for packaging names used in case policy names is packaging by levels"
+                            />
                         </group>
                         <group name="misc">
                             <field name="sequence" />

--- a/product_packaging_level/views/product_packaging_view.xml
+++ b/product_packaging_level/views/product_packaging_view.xml
@@ -31,6 +31,12 @@
         <field name="model">product.packaging</field>
         <field name="inherit_id" ref="stock.product_packaging_form_view" />
         <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="display_name" string="Packaging" />
+            </field>
+            <field name="name" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
             <xpath expr="//field[@name='product_id']" position="before">
                 <field name="name_policy" invisible="1" />
             </xpath>


### PR DESCRIPTION
As suggested in: **https://github.com/OCA/product-attribute/pull/1427#discussion_r1500818061**

No need to update `_onchange_package_type` so I keep it

