### PR TITLE
[16.0][FIX] product_supplierinfo_for_customer: Avoid returning None

### DIFF
--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -134,7 +134,7 @@ class ProductProduct(models.Model):
         any_match = self.env["product.customerinfo"].search(
             domain, order="sequence,min_qty,price,id"
         )
-        first_template_match = None
+        first_template_match = self.env["product.customerinfo"]
         # return the first customer_info matching the variant
         # otherwise the first one matching the template
         for customer_info in any_match:


### PR DESCRIPTION
Fix for errors in `sale-workflow` repo 
```
  File "/__w/sale-workflow/sale-workflow/product_supplierinfo_for_customer_sale/models/sale_order_line.py", line 23, in _compute_product_customer_code
    code = supplierinfo.product_code
AttributeError: 'NoneType' object has no attribute 'product_code'
```