### PR TITLE
[16.0][FIX] product_secondary_unit: use existing value

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -99,7 +99,7 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
         for rec in self:
             if not rec.secondary_uom_id:
                 rec[rec._secondary_unit_fields["qty_field"]] = (
-                    rec._origin[rec._secondary_unit_fields["qty_field"]]
+                    rec[rec._secondary_unit_fields["qty_field"]]
                     or default_qty_field_value
                 )
                 continue


### PR DESCRIPTION
The `rec._origin[rec._secondary_unit_fields["qty_field"]]` will still be used via https://github.com/odoo/odoo/blob/f9054640f8640d4449df5f7ea5fb7b4e8de4d89a/odoo/fields.py#L1197-L1201:

```
            elif self.store and record._origin and not (self.compute and self.readonly):
                # new record with origin: fetch from origin
                value = self.convert_to_cache(record._origin[self.name], record, validate=False)
                env.cache.set(record, self, value)
```