### PR TITLE
[14.0][IMP] ``product_template_tags``: use tags on both templates and variants

### DIFF
--- a/product_template_tags/README.rst
+++ b/product_template_tags/README.rst
@@ -81,6 +81,7 @@ Contributors
 * `Camptocamp <https://www.camptocamp.com>`_
 
   * Iván Todorovich <ivan.todorovich@gmail.com>
+  * Silvio Gregorini <silvio.gregorini@camptocamp.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_template_tags/models/__init__.py
+++ b/product_template_tags/models/__init__.py
@@ -1,2 +1,3 @@
+from . import product_product
 from . import product_template
 from . import product_template_tag

--- a/product_template_tags/models/product_product.py
+++ b/product_template_tags/models/product_product.py
@@ -1,0 +1,17 @@
+# Copyright 2017 ACSONE SA/NV
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    tag_ids = fields.Many2many(
+        comodel_name="product.template.tag",
+        string="Tags",
+        relation="product_product_product_tag_rel",
+        column1="product_id",
+        column2="tag_id",
+    )

--- a/product_template_tags/models/product_template.py
+++ b/product_template_tags/models/product_template.py
@@ -1,12 +1,16 @@
 # Copyright 2017 ACSONE SA/NV
+# Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
-
     _inherit = "product.template"
+
+    @api.model
+    def _get_default_tag_propagation(self):
+        return "tmpl2prod"
 
     tag_ids = fields.Many2many(
         comodel_name="product.template.tag",
@@ -14,4 +18,32 @@ class ProductTemplate(models.Model):
         relation="product_template_product_tag_rel",
         column1="product_tmpl_id",
         column2="tag_id",
+        compute="_compute_tag_ids",
+        inverse="_inverse_tag_ids",
+        store=True,
     )
+    tag_propagation = fields.Selection(
+        string="Tag Propagation",
+        selection=[
+            ("tmpl2prod", "From template to variants"),
+            ("prod2tmpl", "From variants to template"),
+        ],
+        default=lambda self: self._get_default_tag_propagation(),
+        required=True,
+        help="Defines how tags are propagated among templates and variants.\n"
+        "- From template to variants: variants' tags are read-only, and copied"
+        " from their template\n"
+        "- From variants to template: template's tags are read-only, and are"
+        " defined as a full list of all its variants' tags\n",
+    )
+
+    @api.depends("product_variant_ids.tag_ids", "tag_propagation")
+    def _compute_tag_ids(self):
+        # Update only templates whose tags are read from variants
+        for tmpl in self.filtered(lambda x: x.tag_propagation == "prod2tmpl"):
+            tmpl.tag_ids = tmpl.product_variant_ids.tag_ids
+
+    def _inverse_tag_ids(self):
+        # Update only variants whose tags are read from templates
+        for tmpl in self.filtered(lambda x: x.tag_propagation == "tmpl2prod"):
+            tmpl.product_variant_ids.tag_ids = tmpl.tag_ids

--- a/product_template_tags/readme/CONTRIBUTORS.rst
+++ b/product_template_tags/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * `Camptocamp <https://www.camptocamp.com>`_
 
   * Iván Todorovich <ivan.todorovich@gmail.com>
+  * Silvio Gregorini <silvio.gregorini@camptocamp.com>

--- a/product_template_tags/static/description/index.html
+++ b/product_template_tags/static/description/index.html
@@ -427,6 +427,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 <li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a><ul>
 <li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;gmail.com">ivan.todorovich&#64;gmail.com</a>&gt;</li>
+<li>Silvio Gregorini &lt;<a class="reference external" href="mailto:silvio.gregorini&#64;camptocamp.com">silvio.gregorini&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/product_template_tags/tests/test_product_template_tags.py
+++ b/product_template_tags/tests/test_product_template_tags.py
@@ -12,29 +12,77 @@ class TestProductTemplateTagBase(SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.product_tmpl = cls.env["product.template"].create({"name": "Test Product"})
+        cls.tag = cls.env["product.template.tag"].create({"name": "Test Tag"})
+        cls.product_attr = cls.env["product.attribute"].create(
+            {
+                "name": "Test Attrib",
+                "value_ids": [
+                    (0, 0, {"name": "Test Attrib Value %s" % str(x)}) for x in (1, 2)
+                ],
+            }
+        )
+        cls.product_tmpl = cls.env["product.template"].create(
+            {
+                "name": "Test Product Tmpl",
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": cls.product_attr.id,
+                            "value_ids": [(6, 0, cls.product_attr.value_ids.ids)],
+                        },
+                    )
+                ],
+            }
+        )
 
 
 class TestProductTemplateTag(TestProductTemplateTagBase):
-    def test_product_template_tag(self):
-        product_tmpl_tag = self.env["product.template.tag"].create(
-            {"name": "Test Tag", "product_tmpl_ids": [(6, 0, [self.product_tmpl.id])]}
-        )
-        product_tmpl_tag._compute_products_count()
-        self.assertEqual(product_tmpl_tag.products_count, 1)
-
-    def test_product_template_tag_uniq(self):
-        product_tmpl_tag = self.env["product.template.tag"].create({"name": "Test Tag"})
-        self.assertTrue(product_tmpl_tag)
+    def test_00_product_template_tag_uniq(self):
         # test same tag and same company
         with mute_logger("odoo.sql_db"):
             with self.assertRaises(IntegrityError):
                 with self.cr.savepoint():
                     self.env["product.template.tag"].create({"name": "Test Tag"})
-
         # test same tag and different company
         company = self.env["res.company"].create({"name": "Test"})
-        same_product_tmpl_tag_diff_company = self.env["product.template.tag"].create(
-            {"name": "Test Tag", "company_id": company.id}
-        )
-        self.assertTrue(same_product_tmpl_tag_diff_company)
+        vals = {"name": "Test Tag", "company_id": company.id}
+        self.assertTrue(self.env["product.template.tag"].create(vals))
+
+    def test_01_tag_propagation_tmpl2prod(self):
+        """Test tag propagation from template to products
+
+        On templates where ``tag_propagation = "tmpl2prod"``, setting tags on the
+        template should propagate them to all the variants
+        """
+        tag = self.tag
+        template = self.product_tmpl
+        variants = template.product_variant_ids
+        template.tag_propagation = "tmpl2prod"
+        template.tag_ids = tag
+        for variant in variants:
+            self.assertEqual(variant.tag_ids, tag)
+        self.assertEqual(tag.product_tmpl_ids, template)
+        self.assertEqual(tag.product_tmpl_count, 1)
+        self.assertEqual(tag.product_prod_ids, variants)
+        self.assertEqual(tag.product_prod_count, 2)
+
+    def test_02_tag_propagation_prod2tmpl(self):
+        """Test tag propagation from products to template
+
+        On templates where ``tag_propagation = "prod2tmpl"``, setting tags on a variant
+        should propagate them to the template, not the other variants
+        """
+        tag = self.tag
+        template = self.product_tmpl
+        variant_1, variant_2 = template.product_variant_ids
+        # Test tag propagation from products to template
+        template.tag_propagation = "prod2tmpl"
+        variant_1.tag_ids = tag
+        self.assertEqual(template.tag_ids, tag)
+        self.assertFalse(variant_2.tag_ids)
+        self.assertEqual(tag.product_tmpl_ids, template)
+        self.assertEqual(tag.product_tmpl_count, 1)
+        self.assertEqual(tag.product_prod_ids, variant_1)
+        self.assertEqual(tag.product_prod_count, 1)

--- a/product_template_tags/views/product_product.xml
+++ b/product_template_tags/views/product_product.xml
@@ -5,6 +5,21 @@
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
+    <record id="product_normal_form_view_inherit" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <group name="group_general" position="inside">
+                <field name="tag_propagation" invisible="1" />
+                <field
+                    name="tag_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color'}"
+                    attrs="{'readonly': [('tag_propagation', '!=', 'prod2tmpl')]}"
+                />
+            </group>
+        </field>
+    </record>
 
     <record id="product_kanban_view" model="ir.ui.view">
         <field name="model">product.product</field>
@@ -18,6 +33,16 @@
                         options="{'color_field': 'color'}"
                     />
                 </span>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_search_form_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_search_form_view" />
+        <field name="arch" type="xml">
+            <field name="categ_id" position="after">
+                <field name="tag_ids" />
             </field>
         </field>
     </record>

--- a/product_template_tags/views/product_template.xml
+++ b/product_template_tags/views/product_template.xml
@@ -1,16 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="product_template_form_view" model="ir.ui.view">
-        <field name="name">product.template.form</field>
+        <field name="name">product.template.form (in product_template_tags)</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <group name="group_general" position="inside">
+                <field name="tag_propagation" />
                 <field
                     name="tag_ids"
                     widget="many2many_tags"
                     options="{'color_field': 'color'}"
+                    attrs="{'readonly': [('tag_propagation', '!=', 'tmpl2prod')]}"
                 />
             </group>
         </field>

--- a/product_template_tags/views/product_template_tag.xml
+++ b/product_template_tags/views/product_template_tag.xml
@@ -18,9 +18,22 @@
                             context="{'search_default_tag_ids': active_id}"
                         >
                             <field
-                                name="products_count"
+                                name="product_tmpl_count"
                                 widget="statinfo"
                                 string="Products"
+                            />
+                        </button>
+                        <button
+                            name="%(product.product_normal_action)d"
+                            type="action"
+                            class="oe_stat_button"
+                            icon="fa-tags"
+                            context="{'search_default_tag_ids': active_id}"
+                        >
+                            <field
+                                name="product_prod_count"
+                                widget="statinfo"
+                                string="Variants"
                             />
                         </button>
                     </div>

--- a/product_template_tags_code/tests/test_product_template_tags.py
+++ b/product_template_tags_code/tests/test_product_template_tags.py
@@ -7,27 +7,24 @@ from odoo.addons.product_template_tags.tests.test_product_template_tags import (
 
 
 class TestProductTemplateTag(TestProductTemplateTagBase):
-    def test_product_template_tag(self):
-        product_tmpl_tag = self.env["product.template.tag"].create(
-            {"name": "Test Tag", "product_tmpl_ids": [(6, 0, [self.product_tmpl.id])]}
-        )
-        self.assertEqual(product_tmpl_tag.code, "test-tag")
+    def test_00_product_template_tag(self):
+        self.assertEqual(self.tag.code, "test-tag")
 
-    def test_product_template_tag_writable(self):
-        product_tmpl_tag = self.env["product.template.tag"].create(
+    def test_01_product_template_tag_writable(self):
+        self.tag.write(
             {
                 "name": "Test Tag",
                 "code": "foo tag !!",
                 "product_tmpl_ids": [(6, 0, [self.product_tmpl.id])],
             }
         )
-        self.assertEqual(product_tmpl_tag.code, "foo-tag")
-        product_tmpl_tag.write({"code": "test tag writable"})
-        self.assertEqual(product_tmpl_tag.code, "test-tag-writable")
-        product_tmpl_tag.write({"name": "test tag name 2"})
-        self.assertEqual(product_tmpl_tag.code, "test-tag-name-2")
+        self.assertEqual(self.tag.code, "foo-tag")
+        self.tag.write({"code": "test tag writable"})
+        self.assertEqual(self.tag.code, "test-tag-writable")
+        self.tag.write({"name": "test tag name 2"})
+        self.assertEqual(self.tag.code, "test-tag-name-2")
 
-    def test_product_template_multi_tags(self):
+    def test_02_product_template_multi_tags(self):
         prods_data = []
         for x in range(3):
             prods_data.append(


### PR DESCRIPTION
This commit allows using tags on both templates and variants.

Tags can be propagated on each template-variants couple in 2 ways:
- from template to variants: in this case, templates tags are copied onto every variant
- from variants to template: in this case, the template inherits all the variants' tags

The propagation behavior is defined at template's level. Default propagation behavior is "from template to variants" to allow full retrocompatibility with module's previous workflow.