### PR TITLE
[14.0] product_supplierinfo_group: do not break native view, keep field editable, some other module can use it

### DIFF
--- a/product_supplierinfo_group/models/product_supplierinfo.py
+++ b/product_supplierinfo_group/models/product_supplierinfo.py
@@ -27,12 +27,22 @@ class ProductSupplierinfo(models.Model):
         ondelete="cascade",
     )
     company_id = fields.Many2one(related="group_id.company_id", store=True)
-    product_tmpl_id = fields.Many2one(related="group_id.product_tmpl_id", store=True)
-    name = fields.Many2one(related="group_id.partner_id", store=True, required=False)
-    product_id = fields.Many2one(related="group_id.product_id", store=True)
-    product_name = fields.Char(related="group_id.product_name", store=True)
-    product_code = fields.Char(related="group_id.product_code", store=True)
-    sequence = fields.Integer(related="group_id.sequence", store=True)
+    product_tmpl_id = fields.Many2one(
+        related="group_id.product_tmpl_id", store=True, readonly=False
+    )
+    name = fields.Many2one(
+        related="group_id.partner_id", store=True, required=False, readonly=False
+    )
+    product_id = fields.Many2one(
+        related="group_id.product_id", store=True, readonly=False
+    )
+    product_name = fields.Char(
+        related="group_id.product_name", store=True, readonly=False
+    )
+    product_code = fields.Char(
+        related="group_id.product_code", store=True, readonly=False
+    )
+    sequence = fields.Integer(related="group_id.sequence", store=True, readonly=False)
 
     _sql_constraints = [
         (

--- a/product_supplierinfo_group/models/product_supplierinfo_group.py
+++ b/product_supplierinfo_group/models/product_supplierinfo_group.py
@@ -65,7 +65,7 @@ class ProductSupplierinfoGroup(models.Model):
         for rec in self:
             rec.has_multiple_variants = len(rec.product_tmpl_id.product_variant_ids) > 1
 
-    @api.depends("supplierinfo_ids")
+    @api.depends("supplierinfo_ids.min_qty", "supplierinfo_ids.price")
     def _compute_unit_price_note(self):
         for rec in self:
             if len(rec.supplierinfo_ids) == 0:


### PR DESCRIPTION
Some other module like purchase_manual_add_supplierinfo can use the native view.
To avoid to break some native behaviour the field are not readonly anymore.

@Kev-Roche 


