### PR TITLE
[14.0][FIX] pos_product_cost_security: multi-company issues

### DIFF
--- a/pos_product_cost_security/models/product_product.py
+++ b/pos_product_cost_security/models/product_product.py
@@ -7,12 +7,23 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     def read(self, fields=None, load="_classic_read"):
-        """Make an exception when loading data to PoS"""
-        if self.env.context.get(
-            "pos_override_cost_security"
-        ) and self.env.user.has_group("point_of_sale.group_pos_user"):
-            fields = fields if fields else []
-            other_fields = [f for f in fields if f != "standard_price"]
-            self.check_field_access_rights("read", other_fields)
-            return super(ProductProduct, self.sudo()).read(fields=fields, load=load)
-        return super().read(fields=fields, load=load)
+        """Make an exception when loading data to PoS. We load the cost price separetly
+        to avoid multi-company issues when doing the call with sudo"""
+        fields = fields or []
+        override_cost_security = (
+            self.env.context.get("pos_override_cost_security")
+            and self.env.user.has_group("point_of_sale.group_pos_user")
+            and not self.env.user.has_group("product_cost_security.group_product_cost")
+            and "standard_price" in fields
+        )
+        if not override_cost_security:
+            return super().read(fields=fields, load=load)
+        other_fields = [f for f in fields if f != "standard_price"]
+        result = super().read(fields=other_fields, load=load)
+        std_price_result = super(ProductProduct, self.sudo()).read(
+            fields=["standard_price"], load=load
+        )
+        # No we zip both results altogether to feed the PoS data load
+        for res_item, std_price_res_item in zip(result, std_price_result):
+            res_item["standard_price"] = std_price_res_item["standard_price"]
+        return result


### PR DESCRIPTION
In a multicompany environment, doing a sudo() to override the security in the PoS data loading could bring us more data than needed. Therefore we just use the sudo to retrieve the cost and then join the data altogether retrived with the user's permissions.

cc @Tecnativa TT48609

please check @pedrobaeza 


fyi @zamberjo 