### PR TITLE
[15.0][FIX] base_product_mass_addition: _complete_quick_line_vals function.

### DIFF
--- a/base_product_mass_addition/models/product_mass_addition.py
+++ b/base_product_mass_addition/models/product_mass_addition.py
@@ -67,7 +67,5 @@ class ProductMassAddition(models.AbstractModel):
             line = lines.filtered(lambda x: x.id == vals["id"])
             return line.play_onchanges(update_vals, list(update_vals.keys()))
         else:
-            line = lines
-            if len(lines) > 1:
-                line = lines[0]
+            line = self.env[lines._name]
             return line.play_onchanges(vals, list(vals.keys()))


### PR DESCRIPTION
There is a bug in the `_complete_quick_line_vals()` function that causes incorrect operation when lines are added with the **purchase_quick** wizard with the same discount as in the first line.


**To reproduce the bug:**

1. Create a purchase quotation.
2. Use the purchase wizard to add a product with one or more discounts -> The line is generated correctly:
![Captura desde 2024-05-03 15-17-25](https://github.com/OCA/product-attribute/assets/101106685/6aea5b4d-985d-44d6-a71c-5d46e4051c3e)

4. Now add another line with the same discount values as line 1 -> The discounts are not added:
![Captura desde 2024-05-03 15-15-36](https://github.com/OCA/product-attribute/assets/101106685/7cf600c3-28df-4b40-9317-2ea881c2cbfe)


**More details:**
When the `_complete_quick_line_vals()` function of the **ProductMassAddition** model of the **base_product_mass_addition** module has more than one line, the line that makes the call to the `play_onchanges()` function of the **onchange_helper** module is the first one. 

https://github.com/OCA/product-attribute/blob/5dd6892879d238330d191cd9b8a16f94cd26b15f/base_product_mass_addition/models/product_mass_addition.py#L71C1-L72C32

This causes the onchange of the discounts not to be executed, since the value coming to it through line 1 is the same as the value of the line being created.

**Proposed solution**
Create an empty `lines_key` record and have this be the one to call the `onchange_helper()` function.

To test this PR -> PR https://github.com/OCA/purchase-workflow/pull/2265 with the reference to this PR 

[T-5877]
