### PR TITLE
[16.0][FIX] product_pricelist_direct_print: Revert commit

### DIFF
--- a/product_pricelist_direct_print/README.rst
+++ b/product_pricelist_direct_print/README.rst
@@ -123,6 +123,10 @@ Contributors
   
   * Juan Carlos Bonilla
 
+* `Trobz <https://trobz.com/>`_:
+  
+  * Tris Doan
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/product_pricelist_direct_print/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_direct_print/readme/CONTRIBUTORS.rst
@@ -17,3 +17,7 @@
 * `FactorLibre <https://factorlibre.com/>`_:
   
   * Juan Carlos Bonilla
+
+* `Trobz <https://trobz.com/>`_:
+  
+  * Tris Doan

--- a/product_pricelist_direct_print/static/description/index.html
+++ b/product_pricelist_direct_print/static/description/index.html
@@ -486,6 +486,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Juan Carlos Bonilla</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://trobz.com/">Trobz</a>:<ul>
+<li>Tris Doan</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -104,11 +104,6 @@ class ProductPricelistPrint(models.TransientModel):
         if not self.partner_count:
             self.last_ordered_products = False
 
-    @api.onchange("show_variants")
-    def _onchange_show_variants(self):
-        if not self.show_variants:
-            self.show_attribute_values = False
-
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)


### PR DESCRIPTION
### Context
- The bug was introduced in [here](https://github.com/OCA/product-attribute/pull/1577/commits/3c7b69908c91a43a37acc230ce8266bc04bb38fa). It references a custom field which is nowhere to be found, except probably in the author's custom code.

### This change
- Purpose of this PR is to revert the commit
- This will fix https://github.com/OCA/product-attribute/issues/1593