### PR TITLE
[IMP] product_print_category: Do not write on 'to_print' when printing on product if 'to_print' is not flagged.

### DIFF
--- a/product_print_category/report/report_pricetag.py
+++ b/product_print_category/report/report_pricetag.py
@@ -15,7 +15,9 @@ class ReportPricetag(models.AbstractModel):
 
         # mark the selected products as Up To Date if print succeed
         lines = WizardLine.browse(docids)
-        lines.mapped("product_id").write({"to_print": False})
+        lines.mapped("product_id").filtered(lambda x: x.to_print).write(
+            {"to_print": False}
+        )
         return docargs
 
     @api.model


### PR DESCRIPTION
it will avoid to change write_uid write_date of product.product model.

CC : @remytms (I think you are using this module in coop it easy).
CC : @quentinDupont 