### PR TITLE
[16.0] write several products without forcing the sequence on non-serialized products

### DIFF
--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -151,7 +151,6 @@ class TestProductLotSequence(TransactionCase):
                 "tracking": "serial",
             }
         )
-        self.assertFalse(pdt_serial.lot_sequence_id)
         pdt_simple = product_template_model.create(
             {
                 "name": "Test Product 2",
@@ -159,7 +158,6 @@ class TestProductLotSequence(TransactionCase):
                 "tracking": "none",
             }
         )
-        self.assertFalse(pdt_simple.lot_sequence_id)
         pdt_service = product_template_model.create(
             {
                 "name": "Test service 3",
@@ -167,11 +165,19 @@ class TestProductLotSequence(TransactionCase):
                 "tracking": "none",
             }
         )
+        pdt_ids = pdt_serial + pdt_simple + pdt_service
+        pdt_ids.write(
+            {
+                "description_picking": "test note",
+            }
+        )
+        self.assertFalse(pdt_serial.lot_sequence_id)
+        self.assertFalse(pdt_simple.lot_sequence_id)
         self.assertFalse(pdt_service.lot_sequence_id)
+
         self.env["ir.config_parameter"].set_param(
             "product_lot_sequence.policy", "product"
         )
-        pdt_ids = pdt_serial + pdt_simple + pdt_service
         pdt_ids.write(
             {
                 "description_picking": "note for picking",

--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -138,3 +138,45 @@ class TestProductLotSequence(TransactionCase):
         self.assertEqual(
             new_next_sequence_number, seq.get_next_char(seq.number_next_actual)
         )
+
+    def test_write_multiple_products(self):
+        self.env["ir.config_parameter"].set_param(
+            "product_lot_sequence.policy", "global"
+        )
+        product_template_model = self.env["product.template"]
+        pdt_serial = product_template_model.create(
+            {
+                "name": "Test Product Serial 1",
+                "type": "product",
+                "tracking": "serial",
+            }
+        )
+        self.assertFalse(pdt_serial.lot_sequence_id)
+        pdt_simple = product_template_model.create(
+            {
+                "name": "Test Product 2",
+                "type": "product",
+                "tracking": "none",
+            }
+        )
+        self.assertFalse(pdt_simple.lot_sequence_id)
+        pdt_service = product_template_model.create(
+            {
+                "name": "Test service 3",
+                "type": "service",
+                "tracking": "none",
+            }
+        )
+        self.assertFalse(pdt_service.lot_sequence_id)
+        self.env["ir.config_parameter"].set_param(
+            "product_lot_sequence.policy", "product"
+        )
+        pdt_ids = pdt_serial + pdt_simple + pdt_service
+        pdt_ids.write(
+            {
+                "description_picking": "note for picking",
+            }
+        )
+        self.assertTrue(pdt_serial.lot_sequence_id)
+        self.assertFalse(pdt_simple.lot_sequence_id)
+        self.assertFalse(pdt_service.lot_sequence_id)

--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -180,3 +180,51 @@ class TestProductLotSequence(TransactionCase):
         self.assertTrue(pdt_serial.lot_sequence_id)
         self.assertFalse(pdt_simple.lot_sequence_id)
         self.assertFalse(pdt_service.lot_sequence_id)
+        self.assertTrue(
+            all(
+                [
+                    "note for picking" == desc
+                    for desc in pdt_ids.mapped("description_picking")
+                ]
+            )
+        )
+
+    def test_write_tracking(self):
+        product_template_model = self.env["product.template"]
+        pdt_simple = product_template_model.create(
+            {
+                "name": "Test Product 2",
+                "type": "product",
+            }
+        )
+        self.assertFalse(pdt_simple.lot_sequence_id)
+        pdt_simple.write(
+            {
+                "tracking": "lot",
+            }
+        )
+        self.assertTrue(pdt_simple.lot_sequence_id)
+        self.assertEqual(pdt_simple.name, pdt_simple.lot_sequence_id.name)
+
+    def test_write_sequence(self):
+        product_template_model = self.env["product.template"]
+        pdt_simple = product_template_model.create(
+            {
+                "name": "Test Product 2",
+                "type": "product",
+            }
+        )
+        self.assertFalse(pdt_simple.lot_sequence_id)
+        sequence = pdt_simple.sudo()._create_lot_sequence(
+            {
+                "name": "Test Sequence",
+            }
+        )
+        pdt_simple.write(
+            {
+                "lot_sequence_id": sequence.id,
+            }
+        )
+        self.assertTrue(pdt_simple.lot_sequence_id)
+        self.assertTrue(pdt_simple.lot_sequence_padding)
+        self.assertNotEqual(pdt_simple.name, pdt_simple.lot_sequence_id.name)


### PR DESCRIPTION
On data where some serialized products do not yet have a sequence, writing on all or part of the products should not assign a sequence to all modified products regardless of their tracking status, but only to those whose tracking is not 'none'. 