### PR TITLE
[16.0][FIX] product_lot_sequence: Fix warning product is not overriding create method in batch

### DIFF
--- a/product_lot_sequence/models/product.py
+++ b/product_lot_sequence/models/product.py
@@ -1,4 +1,5 @@
 # Copyright 2020 ForgeFlow S.L.
+# Copyright 2024 Tecnativa - Carolina Fernandez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -104,16 +105,20 @@ class ProductTemplate(models.Model):
                         vals["lot_sequence_padding"] = lot_sequence_id.padding
         return super().write(vals)
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         seq_policy = self.env["stock.lot"]._get_sequence_policy()
-        if seq_policy == "product" and vals.get("tracking", False) in ["lot", "serial"]:
-            if not vals.get("lot_sequence_id", False):
-                vals["lot_sequence_id"] = self.sudo()._create_lot_sequence(vals).id
-            else:
-                lot_sequence_id = self.env["ir.sequence"].browse(
-                    vals["lot_sequence_id"]
-                )
-                vals["lot_sequence_prefix"] = lot_sequence_id.prefix
-                vals["lot_sequence_padding"] = lot_sequence_id.padding
-        return super().create(vals)
+        for vals in vals_list:
+            if seq_policy == "product" and vals.get("tracking", False) in [
+                "lot",
+                "serial",
+            ]:
+                if not vals.get("lot_sequence_id", False):
+                    vals["lot_sequence_id"] = self.sudo()._create_lot_sequence(vals).id
+                else:
+                    lot_sequence_id = self.env["ir.sequence"].browse(
+                        vals["lot_sequence_id"]
+                    )
+                    vals["lot_sequence_prefix"] = lot_sequence_id.prefix
+                    vals["lot_sequence_padding"] = lot_sequence_id.padding
+        return super().create(vals_list)

--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -42,7 +42,7 @@ class TestProductLotSequence(TransactionCase):
             )
         )
         next_serial = self.env["stock.lot"]._get_next_serial(self.env.company, product)
-        self.assertRegexpMatches(next_serial, r"foo/\d{5}/bar")
+        self.assertRegex(next_serial, r"foo/\d{5}/bar")
 
     def test_lot_onchange_product_id(self):
         self.assertEqual(self.stock_production_lot._get_sequence_policy(), "product")
@@ -55,7 +55,7 @@ class TestProductLotSequence(TransactionCase):
         lot_form.product_id = product
         lot_form.company_id = self.env.company
         lot = lot_form.save()
-        self.assertRegexpMatches(lot.name, r"shiba/\d{4}$")
+        self.assertRegex(lot.name, r"shiba/\d{4}$")
 
     def test_global_sequence(self):
         self.env["ir.config_parameter"].set_param(


### PR DESCRIPTION
- Fix WARNING devel odoo.api.create: The model odoo.addons.product_lot_sequence.models.product is not overriding the create method in batch 
- Fix WARNING devel py.warnings: /opt/odoo/auto/addons/product_lot_sequence/tests/test_product_lot_sequence.py:45: DeprecationWarning: Please use assertRegex instead.



@Tecnativa
TT46599

@pedrobaeza @pilarvargas-tecnativa 
