### PR TITLE
[16.0][FIX] product_optional_product_quantity: Fix warning labels optional products

### DIFF
--- a/product_optional_product_quantity/i18n/es.po
+++ b/product_optional_product_quantity/i18n/es.po
@@ -73,11 +73,15 @@ msgstr "Producto Opcional"
 
 #. module: product_optional_product_quantity
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__optional_product_ids
-#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__product_optional_line_ids
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__optional_product_ids
-#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__product_optional_line_ids
 msgid "Optional Products"
 msgstr "Productos Opcionales"
+
+#. module: product_optional_product_quantity
+#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__product_optional_line_ids
+#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__product_optional_line_ids
+msgid "Optional Products Line"
+msgstr "Línea Productos Opcionales"
 
 #. module: product_optional_product_quantity
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_res_config_settings__group_product_optional_quantity

--- a/product_optional_product_quantity/i18n/it.po
+++ b/product_optional_product_quantity/i18n/it.po
@@ -73,11 +73,15 @@ msgstr "Prodotto opzionale"
 
 #. module: product_optional_product_quantity
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__optional_product_ids
-#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__product_optional_line_ids
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__optional_product_ids
-#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__product_optional_line_ids
 msgid "Optional Products"
 msgstr "Prodotti opzionali"
+
+#. module: product_optional_product_quantity
+#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__product_optional_line_ids
+#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__product_optional_line_ids
+msgid "Optional Products Line"
+msgstr "Linea di Prodotti Opzionale"
 
 #. module: product_optional_product_quantity
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_res_config_settings__group_product_optional_quantity

--- a/product_optional_product_quantity/i18n/product_optional_product_quantity.pot
+++ b/product_optional_product_quantity/i18n/product_optional_product_quantity.pot
@@ -70,10 +70,14 @@ msgstr ""
 
 #. module: product_optional_product_quantity
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__optional_product_ids
-#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__product_optional_line_ids
 #: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__optional_product_ids
-#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__product_optional_line_ids
 msgid "Optional Products"
+msgstr ""
+
+#. module: product_optional_product_quantity
+#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_product__product_optional_line_ids
+#: model:ir.model.fields,field_description:product_optional_product_quantity.field_product_template__product_optional_line_ids
+msgid "Optional Products Line"
 msgstr ""
 
 #. module: product_optional_product_quantity

--- a/product_optional_product_quantity/models/product_template.py
+++ b/product_optional_product_quantity/models/product_template.py
@@ -7,7 +7,7 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     product_optional_line_ids = fields.One2many(
-        string="Optional Products",
+        string="Optional Products Line",
         comodel_name="product.optional.line",
         inverse_name="product_tmpl_id",
     )


### PR DESCRIPTION
- Fix WARNING devel odoo.addons.base.models.ir_model: Two fields (product_optional_line_ids, optional_product_ids) of product.template() have the same label: Optional Products. [Modules: product_optional_product_quantity] 

@Tecnativa
TT46599
@pedrobaeza @pilarvargas-tecnativa