### PR TITLE
[FIX] product_supplierinfo_for_customer: product display name

### DIFF
--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -7,15 +7,15 @@ class ProductSupplierInfo(models.Model):
     _inherit = "product.supplierinfo"
 
     @api.model
-    def search(self, args, offset=0, limit=None, order=None):
-        res = super().search(args, offset=offset, limit=limit, order=order)
+    def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
+        res = super().search_fetch(domain, field_names, offset, limit, order)
         if (
             self.env.context.get("customerinfo")
             and self._name == "product.supplierinfo"
         ):
             limit2 = limit - len(res) if limit else limit
-            res2 = self.env["product.customerinfo"].search(
-                args, offset=offset, limit=limit2, order=order
+            res2 = self.env["product.customerinfo"].search_fetch(
+                domain, field_names, offset, limit=limit2, order=order
             )
             res2 = res2.read(list(self.env["product.supplierinfo"]._fields.keys()))
             for result in res2:


### PR DESCRIPTION
The search method was inherited because it was called in the _name_search that is inherited in the product.product model in this same module, now in v17 the method that is being called by _name_search is search_fetch so this must be fixed in order to correctly display the name of a product.