### PR TITLE
[16.0][IMP] product_attribute_value_menu: Add title to button to avoid warning

### DIFF
--- a/product_attribute_value_menu/views/product_attribute_value_views.xml
+++ b/product_attribute_value_menu/views/product_attribute_value_views.xml
@@ -19,6 +19,7 @@
                 <button
                     type="object"
                     name="action_view_product"
+                    title="Products"
                     class="btn btn-link text-left"
                     icon="fa-wrench"
                     attrs="{'invisible': [('product_count', '=', 0)]}"


### PR DESCRIPTION
Add title to button to avoid warning

`A button with icon attribute (fa-wrench) must have title in its tag, parents, descendants or have text`

@Tecnativa