### PR TITLE
product_supplierinfo_group: fix missing default value when creating a supplierinfo directly

### DIFF
--- a/product_supplierinfo_group/models/product_supplierinfo.py
+++ b/product_supplierinfo_group/models/product_supplierinfo.py
@@ -73,7 +73,8 @@ class ProductSupplierinfo(models.Model):
         if not self.env.context.get("skip_group_specific"):
             for vals in list_vals:
                 if not vals.get("group_id"):
-                    vals["group_id"] = self._get_or_create_group(vals).id
+                    with_default_vals = self._add_missing_default_values(vals)
+                    vals["group_id"] = self._get_or_create_group(with_default_vals).id
                     # remove useless related fields
                     for field_name in self._none_writable_related_fields():
                         vals.pop(field_name, None)

--- a/product_supplierinfo_group/tests/test_product_supplierinfo_group.py
+++ b/product_supplierinfo_group/tests/test_product_supplierinfo_group.py
@@ -90,3 +90,9 @@ class TestProductSupplierinfoGroup(common.SavepointCase):
             '<td class="table_price_note_cell">6.0</td>',
             group.unit_price_note,
         )
+
+    def test_default_company(self):
+        """Creating a product supplierinfo without passing the company_id should
+        use the default value"""
+        supplierinfo = self.env["product.supplierinfo"].create(self.supplierinfo_vals)
+        self.assertTrue(supplierinfo.company_id)


### PR DESCRIPTION
@Kev-Roche default value was missing so if you create a supplier_info directly without explicitly passing the company the default value was not applied and the supplier was shared.