### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Product Dimension",
     "version": "14.0.1.0.0",
     "category": "Product",
-    "author": "brain-tec AG, ADHOC SA, Camptocamp SA, "
+    "author": "brain-tec AG, ADHOC SA, Camptocamp, "
     "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/product-attribute",

--- a/product_template_tags_code/__manifest__.py
+++ b/product_template_tags_code/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": "This addon allow to add code on products tags",
     "version": "14.0.1.0.1",
     "license": "AGPL-3",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["product", "product_template_tags"],
     "data": ["views/product_template_tag.xml"],

--- a/purchase_product_template_tags/__manifest__.py
+++ b/purchase_product_template_tags/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "Show product tags menu in Purchase app",
     "version": "14.0.1.1.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["product_template_tags", "purchase"],
     "data": ["views/product_template_tag.xml"],

--- a/sale_product_template_tags/__manifest__.py
+++ b/sale_product_template_tags/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "Show product tags menu in Sale app",
     "version": "14.0.1.1.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["product_template_tags", "sale"],
     "data": ["views/product_template_tag.xml"],

--- a/stock_product_template_tags/__manifest__.py
+++ b/stock_product_template_tags/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "Show product tags menu in Inventory app",
     "version": "14.0.1.1.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["product_template_tags", "stock"],
     "data": ["views/product_template_tag.xml"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.