### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Product Dimension",
     "version": "17.0.1.0.0",
     "category": "Product",
-    "author": "brain-tec AG, ADHOC SA, Camptocamp SA, "
+    "author": "brain-tec AG, ADHOC SA, Camptocamp, "
     "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/product-attribute",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 17.0.