### PR TITLE
[12.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Product Dimension',
     'version': '12.0.3.0.0',
     'category': 'Product',
-    'author': 'brain-tec AG, ADHOC SA, Camptocamp SA, '
+    'author': 'brain-tec AG, ADHOC SA, Camptocamp, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/product-attribute',


### PR DESCRIPTION
supersedes https://github.com/OCA/product-attribute/pull/1641