### PR TITLE
[FIX] product_cost_security: apply to prices in supplier info too

### DIFF
--- a/product_cost_security/__manifest__.py
+++ b/product_cost_security/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Product Cost Security",
     "summary": "Product cost security restriction view",
-    "version": "16.0.1.2.0",
+    "version": "16.0.2.0.0",
     "development_status": "Production/Stable",
     "maintainers": ["sergio-teruel", "rafaelbn", "yajo"],
     "category": "Product",

--- a/product_cost_security/models/__init__.py
+++ b/product_cost_security/models/__init__.py
@@ -2,3 +2,4 @@
 from . import product_cost_security_mixin
 from . import product_template
 from . import product_product
+from . import product_supplierinfo

--- a/product_cost_security/models/product_supplierinfo.py
+++ b/product_cost_security/models/product_supplierinfo.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+from odoo import fields, models
+
+
+class ProductSupplierinfo(models.Model):
+    _name = "product.supplierinfo"
+    _inherit = ["product.supplierinfo", "product.cost.security.mixin"]
+
+    # Inherited fields
+    price = fields.Float(groups="product_cost_security.group_product_cost")

--- a/product_cost_security/static/description/index.html
+++ b/product_cost_security/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -448,7 +449,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Sales users were able to see costs in the purchase tab of products, if seller info was added there.

https://www.loom.com/share/7219aacbc4804e2dbd2f3a3aee174af1?sid=bace01fe-6f0d-42bf-8b53-e6945c527e15

MT-6508