### PR TITLE
[16.0][FIX] product_pricelist_direct_print: Error when display wizard without administration permision

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
@@ -31,7 +31,11 @@
                     </group>
                     <group string="Order Options">
                         <field name="order_field" />
-                        <field name="group_field_id" nocreate="1" />
+                        <field
+                            name="group_field_id"
+                            nocreate="1"
+                            groups="base.group_erp_manager"
+                        />
                         <field name="max_categ_level" />
                     </group>
                     <group string="Product Options">


### PR DESCRIPTION
Steps to reproduce the problem:

1. Log in with a user without Administration permision
2. Open Pricelist Print wizard

An error about permisions is desplayed

cc @Tecnativa TT49637

ping @pedrobaeza @chienandalu 