### PR TITLE
[16.0][FIX] product_pricelist_direct_print : Prevent access error if a user that doesn't belong to 'Administration/Access Rights'  try to print pricelists. 

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
@@ -31,11 +31,7 @@
                     </group>
                     <group string="Order Options">
                         <field name="order_field" />
-                        <field
-                            name="group_field_id"
-                            nocreate="1"
-                            groups="base.group_erp_manager"
-                        />
+                        <field name="group_field" />
                         <field name="max_categ_level" />
                     </group>
                     <group string="Product Options">


### PR DESCRIPTION
Error explained here  https://github.com/OCA/product-attribute/pull/1655 by @CarlosRoca13.

In #1655, this problem has been temporarily overcome by hiding the functionality if the user is not a member of a group.
In the current PR, the problem is fixed and the feature restored for all user perfiles

CC : @chienandalu, @pedrobaeza 

thanks for your review;