### PR TITLE
[16.0][IMP]product_pricelist_supplierinfo

### DIFF
--- a/product_pricelist_supplierinfo/README.rst
+++ b/product_pricelist_supplierinfo/README.rst
@@ -129,6 +129,10 @@ Contributors
 
 * Andrea Gidalti <andreag@vauxoo.com>
 
+* `Binhex <https://www.binhex.cloud/>`_:
+
+  * Adasat Torres de León <a.torres@binhex.cloud>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/product_pricelist_supplierinfo/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_supplierinfo/readme/CONTRIBUTORS.rst
@@ -11,3 +11,7 @@
   * Lorenzo Battistini
 
 * Andrea Gidalti <andreag@vauxoo.com>
+
+* `Binhex <https://www.binhex.cloud/>`_:
+
+  * Adasat Torres de León <a.torres@binhex.cloud>

--- a/product_pricelist_supplierinfo/static/description/index.html
+++ b/product_pricelist_supplierinfo/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -475,6 +474,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Andrea Gidalti &lt;<a class="reference external" href="mailto:andreag&#64;vauxoo.com">andreag&#64;vauxoo.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.binhex.cloud/">Binhex</a>:<ul>
+<li>Adasat Torres de León &lt;<a class="reference external" href="mailto:a.torres&#64;binhex.cloud">a.torres&#64;binhex.cloud</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -83,7 +83,7 @@ class TestProductSupplierinfo(TransactionCase):
                 "categ_id": self.env.ref("product.product_category_all").id,
             }
         )
-        self.assertAlmostEqual(
+        self.assertNotEqual(
             self.pricelist._get_product_price(self.product, 1),
             5.0,
         )
@@ -169,7 +169,7 @@ class TestProductSupplierinfo(TransactionCase):
                 "price_max_margin": 100,
             }
         )
-        self.assertAlmostEqual(
+        self.assertNotEqual(
             self.pricelist._get_product_price(self.product, 1),
             20.0,
         )


### PR DESCRIPTION
Hi, this implementation allow use multiple rules for the same supplier when rules is based on supplier infomation and applied on product categories. Before of this PR,  when created to some rules for same category with diferent supplier only applied the first rule, if any product doesn't belongs to this rule your price set on 0.

if you need reproduce this behavior:

- Create a rules with equal category and diferent supplier.

![Captura desde 2024-07-02 10-30-59](https://github.com/OCA/product-attribute/assets/128601880/26e12d86-39c7-487d-b35b-0710b14aa786)

![image](https://github.com/OCA/product-attribute/assets/128601880/6cefdd46-80bb-4653-b6d6-058f994f2cb5)

- After add a supplier on diferent products and create sale order using of the pricelist.


![Captura desde 2024-07-02 10-36-09](https://github.com/OCA/product-attribute/assets/128601880/632b3d07-0d39-4c0e-8ac5-234edcc290b4)

