### PR TITLE
[16.0][IMP] product_pricelist_direct_print_xlsx: printing a pricelist and selecting an product category, include its child categories.

### DIFF
--- a/product_pricelist_direct_print_xlsx/README.rst
+++ b/product_pricelist_direct_print_xlsx/README.rst
@@ -74,6 +74,10 @@ Contributors
 
   * Sylvain LE GAL <https://twitter.com/legalsylvain>
 
+* `Trobz <https://trobz.com/>`_:
+
+  * Chau Le
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/product_pricelist_direct_print_xlsx/i18n/product_pricelist_direct_print_xlsx.pot
+++ b/product_pricelist_direct_print_xlsx/i18n/product_pricelist_direct_print_xlsx.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-03 04:32+0000\n"
+"PO-Revision-Date: 2024-07-03 04:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -82,6 +84,11 @@ msgstr ""
 #: code:addons/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py:0
 #, python-format
 msgid "Price List Name:"
+msgstr ""
+
+#. module: product_pricelist_direct_print_xlsx
+#: model:ir.model.fields,field_description:product_pricelist_direct_print_xlsx.field_product_pricelist_print__print_child_categories
+msgid "Print child categories"
 msgstr ""
 
 #. module: product_pricelist_direct_print_xlsx

--- a/product_pricelist_direct_print_xlsx/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_direct_print_xlsx/readme/CONTRIBUTORS.rst
@@ -13,3 +13,7 @@
 * `GRAP <http://www.grap.coop/>`_:
 
   * Sylvain LE GAL <https://twitter.com/legalsylvain>
+
+* `Trobz <https://trobz.com/>`_:
+
+  * Chau Le

--- a/product_pricelist_direct_print_xlsx/static/description/index.html
+++ b/product_pricelist_direct_print_xlsx/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -420,12 +420,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Sylvain LE GAL &lt;<a class="reference external" href="https://twitter.com/legalsylvain">https://twitter.com/legalsylvain</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://trobz.com/">Trobz</a>:<ul>
+<li>Chau Le</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_pricelist_direct_print_xlsx/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print_xlsx/wizards/product_pricelist_print.py
@@ -13,6 +13,18 @@ class ProductPricelistPrint(models.TransientModel):
 
     show_internal_category = fields.Boolean(string="Show internal categories")
 
+    print_child_categories = fields.Boolean(
+        default=True, string="Print child categories"
+    )
+
+    def get_products_to_print(self):
+        products = super().get_products_to_print()
+
+        if self.print_child_categories and self.categ_ids:
+            products |= products.search([("categ_id", "child_of", self.categ_ids.ids)])
+
+        return products
+
     def export_xlsx(self):
         self.ensure_one()
         return self.env.ref("product_pricelist_direct_print_xlsx.report").report_action(

--- a/product_pricelist_direct_print_xlsx/wizards/product_pricelist_print_view.xml
+++ b/product_pricelist_direct_print_xlsx/wizards/product_pricelist_print_view.xml
@@ -16,6 +16,7 @@
                     <group>
                         <field name="breakage_per_category" />
                         <field name="show_internal_category" />
+                        <field name="print_child_categories" />
                     </group>
                 </page>
             </notebook>


### PR DESCRIPTION
-  option `Print child categories` in `XLSX Export Options`, if it's enabled, includes products from child categories when generating price list reports.

    - option `Print child categories`
    
     ![image](https://github.com/chaule97/product-attribute/assets/32189890/1584e0fc-36dd-40c1-8dda-ccf8b8b63d83)
    - result:
    
     ![image](https://github.com/chaule97/product-attribute/assets/32189890/2af8f8f6-b533-43f5-8f44-9bc7d8f67e11)

