### PR TITLE
[FIX] product_state : active_id instead of id in action domain

### DIFF
--- a/product_state/security/ir.model.access.csv
+++ b/product_state/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_product_state_sale_manager","product.state","model_product_state","sales_team.group_sale_manager",1,1,1,1
 "access_product_state_stock_manager","product.state","model_product_state","stock.group_stock_manager",1,1,1,1
-"access_product_state_public","product.state.public","model_product_state",,1,0,0,0
+"access_product_state_public","product.state.public","model_product_state",base.group_user,1,0,0,0

--- a/product_state/views/product_template_views.xml
+++ b/product_state/views/product_template_views.xml
@@ -5,7 +5,7 @@
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,form,tree</field>
         <field name="context">{}</field>
-        <field name="domain">[('product_state_id', '=', id)]</field>
+        <field name="domain">[('product_state_id', '=', active_id)]</field>
     </record>
     <record id="view_product_template_search_state" model="ir.ui.view">
         <field name="name">product.template.search.state</field>


### PR DESCRIPTION
 Fixing `EvalError: Can not evaluate python expression: ([('product_state_id', '=', id)])`