### PR TITLE
[14.0] [IMP] product_packaging_dimension: Volume writable

### DIFF
--- a/product_packaging_dimension/models/product_packaging.py
+++ b/product_packaging_dimension/models/product_packaging.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2021 Camptocamp SA
+# Copyright 2024 Raumschmiede GmbH
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import api, fields, models
 
@@ -65,8 +66,8 @@ class ProductPackaging(models.Model):
         "Volume",
         digits=(8, 4),
         compute="_compute_volume",
-        readonly=True,
-        store=False,
+        readonly=False,
+        store=True,
         help="The Packaging volume",
     )
 

--- a/product_packaging_dimension/tests/test_packaging_volume.py
+++ b/product_packaging_dimension/tests/test_packaging_volume.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021 Akretion (<http://www.akretion.com>).
+# Copyright (C) 2024 Raumschmiede GmbH.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import TransactionCase
@@ -8,9 +9,9 @@ class TestPackagingVolumeCompute(TransactionCase):
     def setUp(self):
         super(TestPackagingVolumeCompute, self).setUp()
 
-        self.packaging = self.env["product.packaging"].new()
-        self.packaging2 = self.env["product.packaging"].new()
-        self.packaging3 = self.env["product.packaging"].new()
+        self.packaging = self.env["product.packaging"].create({"name": "PACK1"})
+        self.packaging2 = self.env["product.packaging"].create({"name": "PACK2"})
+        self.packaging3 = self.env["product.packaging"].create({"name": "PACK3"})
 
         self.uom_m = self.env["uom.uom"].search([("name", "=", "m")])
         self.uom_cm = self.env["uom.uom"].search([("name", "=", "cm")])
@@ -28,7 +29,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging.width = 10.0
         self.packaging.length_uom_id = self.uom_m
         self.packaging.volume_uom_id = self.uom_m3
-        self.packaging._compute_volume()
         self.assertEqual(1000, self.packaging.volume)
 
         #  Initial dimensions in cm
@@ -37,7 +37,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging2.width = 10.0
         self.packaging2.length_uom_id = self.uom_cm
         self.packaging2.volume_uom_id = self.uom_m3
-        self.packaging2._compute_volume()
         self.assertEqual(0.001, self.packaging2.volume)
 
         # Initial dimensions in feet
@@ -46,7 +45,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging3.width = 10.0
         self.packaging3.length_uom_id = self.uom_ft
         self.packaging3.volume_uom_id = self.uom_m3
-        self.packaging3._compute_volume()
         self.assertEqual(28.3168, self.packaging3.volume)
 
     def test_compute_volume(self):
@@ -57,7 +55,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging.width = 10
         self.packaging.length_uom_id = self.uom_m
         self.packaging.volume_uom_id = self.uom_m3
-        self.packaging._compute_volume()
         self.assertEqual(800, self.packaging.volume)
 
         self.packaging2.packaging_length = 6.0
@@ -65,7 +62,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging2.width = 1.0
         self.packaging2.length_uom_id = self.uom_m
         self.packaging2.volume_uom_id = self.uom_m3
-        self.packaging2._compute_volume()
         self.assertEqual(84.0, self.packaging2.volume)
 
         self.packaging3.packaging_length = 100.0
@@ -73,7 +69,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging3.width = 80
         self.packaging3.length_uom_id = self.uom_m
         self.packaging3.volume_uom_id = self.uom_m3
-        self.packaging3._compute_volume()
         self.assertEqual(400000, self.packaging3.volume)
 
     def test_output_uom(self):
@@ -85,7 +80,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging.width = 10.0
         self.packaging.length_uom_id = self.uom_ft
         self.packaging.volume_uom_id = self.uom_L
-        self.packaging._compute_volume()
         self.assertAlmostEqual(28316.8439, self.packaging.volume)
 
         #  cm to cubic feet
@@ -94,7 +88,6 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging2.width = 10.0
         self.packaging2.length_uom_id = self.uom_cm
         self.packaging2.volume_uom_id = self.uom_ft3
-        self.packaging2._compute_volume()
         self.assertAlmostEqual(0.0353, self.packaging2.volume)
 
         # meters to cubic feet
@@ -103,5 +96,21 @@ class TestPackagingVolumeCompute(TransactionCase):
         self.packaging3.width = 10.0
         self.packaging3.length_uom_id = self.uom_m
         self.packaging3.volume_uom_id = self.uom_ft3
-        self.packaging3._compute_volume()
         self.assertAlmostEqual(35314.7248, self.packaging3.volume)
+
+    def test_manual_volume(self):
+        """Test whether volume can be set manually"""
+
+        self.assertEqual(0, self.packaging.volume)
+        self.packaging.volume = 40
+        self.assertEqual(40, self.packaging.volume)
+
+        self.packaging.packaging_length = 10.0
+        self.packaging.height = 10.0
+        self.packaging.width = 10.0
+        self.packaging.length_uom_id = self.uom_m
+        self.packaging.volume_uom_id = self.uom_m3
+        # Overwrites the manually set volume
+        self.packaging._compute_volume()
+
+        self.assertEqual(1000, self.packaging.volume)


### PR DESCRIPTION
We have products that we send only via Dropshipment. The supplier gives us only the volume for the products, not the dimensions. For this case we want to manually set the volume.

I had to fix the tests because with `.new()` the inverse is not called and other things didn't work either. Took some time to find the problem.
Do you want the test fixes in a separate commit?