### PR TITLE
[16.0][FIX] sale_product_template_tags: missing dependency

### DIFF
--- a/sale_product_template_tags/__manifest__.py
+++ b/sale_product_template_tags/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Camptocamp SA, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
-    "depends": ["sale"],
+    "depends": ["sale", "product"],
     "data": ["views/product_template_tag.xml"],
     "maintainers": ["ivantodorovich"],
     "auto_install": True,


### PR DESCRIPTION
The module `sale_product_template_tags` references the `product.product_tag` action, but the `product` module isn't referenced in the depends list.