### PR TITLE
[14.0][FIX]product_assortment: whitelist preserves 'ALL' domain

### DIFF
--- a/product_assortment/models/ir_filters.py
+++ b/product_assortment/models/ir_filters.py
@@ -75,7 +75,7 @@ class IrFilters(models.Model):
     def _get_eval_domain(self):
         res = super()._get_eval_domain()
 
-        if self.whitelist_product_ids:
+        if self.whitelist_product_ids and res:
             result_domain = [("id", "in", self.whitelist_product_ids.ids)]
             res = expression.OR([result_domain, res])
 

--- a/product_assortment/tests/test_product_assortment.py
+++ b/product_assortment/tests/test_product_assortment.py
@@ -91,7 +91,11 @@ class TestProductAssortment(TransactionCase):
         included_product = self.env.ref("product.product_product_7")
         self.assortment.write({"whitelist_product_ids": [(4, included_product.id)]})
         res = self.assortment.show_products()
-        self.assertEqual(res["domain"], [("id", "in", [included_product.id])])
+        domain = res["domain"]
+        self.assertNotEqual(domain, [("id", "in", [included_product.id])])
+        self.assertIn(
+            included_product, self.env[self.assortment.model_id].search(domain)
+        )
 
     def test_record_count(self):
         products = self.product_obj.search([])


### PR DESCRIPTION
Before this PR, having records in the whitelist and no domain specified resulted in the filter being applied only on the items in the whitelist

Before
![Screenshot from 2024-09-03 10-09-36](https://github.com/user-attachments/assets/d730225e-c438-41d7-a9bb-57fcb548e99b)

After
![Screenshot from 2024-09-03 10-09-56](https://github.com/user-attachments/assets/81578269-68d2-426e-8058-7a6876433733)
