### PR TITLE
[FIX] Fixing error External ID not found on country from on click button

### DIFF
--- a/product_country_restriction/models/res_country.py
+++ b/product_country_restriction/models/res_country.py
@@ -43,9 +43,10 @@ class ResCountry(models.Model):
 
     def action_view_country_restrictions(self):
         self.ensure_one()
-        ref = "product_country_restriction." "product_country_restrictionact_window"
+        action_dict = self.env["ir.actions.act_window"]._for_xml_id(
+            "product_country_restriction.product_country_restriction_act_window"
+        )
         country_id = self.id
-        action_dict = self.env.ref(ref).read()[0]
         action_dict["domain"] = [
             "|",
             ("country_group_ids.country_ids", "in", [country_id]),


### PR DESCRIPTION
[FIX] Fixing error "External ID not found in the system: product_country_restriction.product_country_restrictionact_window" on click button on country form