### PR TITLE
[16.0][IMP] product_abc_classification_sale_stock: prevent ambiguous column name

### DIFF
--- a/product_abc_classification_sale_stock/models/abc_classification_profile.py
+++ b/product_abc_classification_sale_stock/models/abc_classification_profile.py
@@ -59,15 +59,15 @@ class AbcClassificationProfile(models.Model):
         self.env.cr.execute(
             """
             SELECT
-                product_id
+                abc_rel.product_id
             FROM
-                abc_classification_profile_product_rel
+                abc_classification_profile_product_rel abc_rel
             JOIN
                 product_product pp
-                ON pp.id = product_id
+                ON pp.id = abc_rel.product_id
             WHERE
                 pp.active
-                AND profile_id = %(profile_id)s
+                AND abc_rel.profile_id = %(profile_id)s
         """,
             {"profile_id": self.id},
         )


### PR DESCRIPTION
When using this module with product_variant_configurator, which adds a `product_id` field in the product_product model due to the inheritance (https://github.com/OCA/product-variant/blob/c133b59be157d48f6a65133432ffde52a1290f27/product_variant_configurator/models/product_product.py#L11), it causes an ambiguous name error.