### PR TITLE
[17.0][FIX] product_supplierinfo_for_customer: fix missing products in comodel search

### DIFF
--- a/product_supplierinfo_for_customer/__manifest__.py
+++ b/product_supplierinfo_for_customer/__manifest__.py
@@ -12,6 +12,7 @@
     "website": "https://github.com/OCA/product-attribute",
     "category": "Sales Management",
     "license": "AGPL-3",
+    "maintainers": ["luisg123v"],
     "depends": ["product"],
     "data": [
         "security/ir.model.access.csv",

--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -16,9 +16,7 @@ class ProductProduct(models.Model):
         )._compute_display_name()
 
     @api.model
-    def _name_search(
-        self, name="", domain=None, operator="ilike", limit=100, order=None
-    ):
+    def _name_search(self, name, domain=None, operator="ilike", limit=None, order=None):
         res = super()._name_search(
             name, domain=domain, operator=operator, limit=limit, order=order
         )


### PR DESCRIPTION
When searching for products in a comodel, the results are obtained via the `_name_search` method over `product.product`. Currently, this search is not retrieving all matching results.

This issue occurs because the parameters for the `_name_search` method changed in Odoo v17, and during the migration, this was not adapted. As a result, when the method is called, it only retrieves 100 results due to the default limit not being handled correctly.

This commit updates the overridden `_name_search` method to match the new method signature in Odoo v17 and properly handle the `limit` parameter. This ensures that all matching products are returned during the search.