### PR TITLE
[FIX] product_pricelist_simulation: provide default access rule, to avoid warning in odoo log

### DIFF
--- a/product_pricelist_simulation/security/ir.model.access.csv
+++ b/product_pricelist_simulation/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_wizard_preview_pricelist","access.wizard.preview.pricelist","model_wizard_preview_pricelist","base.group_system",1,1,1,0
+"access_wizard_preview_pricelist_line","access.wizard.preview.pricelist.line","model_wizard_preview_pricelist_line","base.group_system",1,1,1,0


### PR DESCRIPTION
Trivial.

remove the following log during installation / update of the module

```
2024-09-26 14:16:04,494 102218 WARNING product_pricelist_simulation_16_ww odoo.modules.loading: The models ['wizard.preview.pricelist.line'] have no access rules in module product_pricelist_simulation, consider adding some, like:
id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
product_pricelist_simulation.access_wizard_preview_pricelist_line,access_wizard_preview_pricelist_line,product_pricelist_simulation.model_wizard_preview_pricelist_line,base.group_user,1,0,0,0 

```

