### PR TITLE
[17][FIX] product_state: Fix rule has no group

### DIFF
--- a/product_state/security/ir.model.access.csv
+++ b/product_state/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"access_product_state_manager","product.state","model_product_state","group_product_state_manager",1,1,1,1
-"access_product_state_internal_user","product.state.internal.user","model_product_state","base.group_user",1,0,0,0
+"access_product_state_sale_manager","product.state","model_product_state","sales_team.group_sale_manager",1,1,1,1
+"access_product_state_stock_manager","product.state","model_product_state","stock.group_stock_manager",1,1,1,1
 "access_product_state_public","product.state.public","model_product_state","base.group_public",1,0,0,0


### PR DESCRIPTION
on rule: product state public

```
2024-10-01 10:46:34,453 261 WARNING odoo odoo.addons.base.models.ir_model: Rule product.state.public has no group, this is a deprecated feature. Every access-granting rule should specify a group

```

To silenece warning in odoo logger.