### PR TITLE
[15.0][IMP] nutritional_info_stock_lot: Compute nutritional_value_ids to get initial values from product

### DIFF
--- a/nutritional_info_stock_lot/models/stock_production_lot.py
+++ b/nutritional_info_stock_lot/models/stock_production_lot.py
@@ -10,7 +10,29 @@ class StockProductionLot(models.Model):
     nutritional_value_ids = fields.One2many(
         comodel_name="nutritional.value.lot",
         inverse_name="lot_id",
+        compute="_compute_nutritional_value_ids",
+        store=True,
+        readonly=False,
     )
+
+    @api.depends("product_id")
+    def _compute_nutritional_value_ids(self):
+        for lot in self:
+            nutritional_list = [(5, 0, 0)]
+            for nutritional_line in lot.product_id.nutritional_value_ids:
+                nutritional_list.append(
+                    (
+                        0,
+                        0,
+                        {
+                            "type_id": nutritional_line.type_id.id,
+                            "sequence": nutritional_line.sequence,
+                            "product_id": nutritional_line.product_id.id,
+                            "value": nutritional_line.value,
+                        },
+                    )
+                )
+            lot.nutritional_value_ids = nutritional_list
 
     @api.constrains("nutritional_value_ids", "nutritional_value_ids.type_id")
     def _check_nutritional_type_not_repeated(self):


### PR DESCRIPTION
Before this PR:
When create lot nutritional values are empty

After this PR:
When create lot nutritional values are filled with product nutritional values

@Tecnativa TT51200
ping @sergio-teruel @CarlosRoca13 