### PR TITLE
[16.0][FIX] product_pricelist_alternative: No alternative price in waterfall pricelists

### DIFF
--- a/product_pricelist_alternative/models/product_pricelist.py
+++ b/product_pricelist_alternative/models/product_pricelist.py
@@ -62,7 +62,9 @@ class Pricelist(models.Model):
 
         # In some contexts we want to ignore alternative pricelists
         # and return the original price
-        if self.env.context.get("skip_alternative_pricelist", False):
+        if self.env.context.get(
+            "skip_alternative_pricelist", False
+        ) or self.env.context.get("based_on_other_pricelist", False):
             return res
 
         for product in products:

--- a/product_pricelist_alternative/models/product_pricelist.py
+++ b/product_pricelist_alternative/models/product_pricelist.py
@@ -66,22 +66,27 @@ class Pricelist(models.Model):
             "skip_alternative_pricelist", False
         ) or self.env.context.get("based_on_other_pricelist", False):
             return res
+        pricelist_items_ids = [val[1] for val in res.values()]
+        use_lower_price_item = (
+            self.env["product.pricelist.item"]
+            .browse(pricelist_items_ids)
+            .filtered(lambda rec: rec.alternative_pricelist_policy == "use_lower_price")
+        )
+        use_lower_price_item_ids = set(use_lower_price_item.ids)
 
-        for product in products:
-            reference_pricelist_item = self.env["product.pricelist.item"].browse(
-                res[product.id][1]
+        products_with_use_lower_price = products.filtered(
+            lambda rec: res[rec.id][1] in use_lower_price_item_ids
+        )
+        for alternative_pricelist in self.alternative_pricelist_ids:
+            alternative_res = alternative_pricelist._compute_price_rule(
+                products_with_use_lower_price, qty, uom, date, **kwargs
             )
-            if (
-                reference_pricelist_item.alternative_pricelist_policy
-                == "use_lower_price"
-            ):
-                for alternative_pricelist in self.alternative_pricelist_ids:
-                    alternative_price_rule = alternative_pricelist._compute_price_rule(
-                        product, qty, uom=uom, date=date, **kwargs
-                    )
-                    # use alternative price if lower
-                    if alternative_price_rule[product.id][0] < res[product.id][0]:
-                        res[product.id] = alternative_price_rule[product.id]
+            for product_id, (
+                alternative_price,
+                alternative_item_id,
+            ) in alternative_res.items():
+                if alternative_price < res[product_id][0]:
+                    res[product_id] = (alternative_price, alternative_item_id)
         return res
 
     @api.constrains("alternative_pricelist_ids")

--- a/product_pricelist_alternative/models/product_pricelist_item.py
+++ b/product_pricelist_alternative/models/product_pricelist_item.py
@@ -33,3 +33,8 @@ class PricelistItem(models.Model):
                         " Please change to another type of price computation."
                     )
                 )
+
+    def _compute_price(self, product, quantity, uom, date, currency=None):
+        if self.compute_price == "formula" and self.base == "pricelist":
+            self = self.with_context(based_on_other_pricelist=True)
+        return super()._compute_price(product, quantity, uom, date, currency)

--- a/product_pricelist_alternative/tests/common.py
+++ b/product_pricelist_alternative/tests/common.py
@@ -22,7 +22,7 @@ class CommonProductPricelistAlternative(common.TransactionCase):
 
         cls.alternative_pricelist_01 = cls.env["product.pricelist"].create(
             {
-                "name": "Alternative pricelist 01",
+                "name": "Alternative pricelist_01",
                 "item_ids": [
                     Command.create(
                         {
@@ -37,7 +37,7 @@ class CommonProductPricelistAlternative(common.TransactionCase):
         )
         cls.alternative_pricelist_02 = cls.env["product.pricelist"].create(
             {
-                "name": "Alternative pricelist 02",
+                "name": "Alternative alternative_pricelist_02",
                 "item_ids": [
                     Command.create(
                         {
@@ -51,9 +51,25 @@ class CommonProductPricelistAlternative(common.TransactionCase):
             }
         )
 
+        cls.alternative_pricelist_03 = cls.env["product.pricelist"].create(
+            {
+                "name": "Alternative alternative_pricelist_03",
+                "item_ids": [
+                    Command.create(
+                        {
+                            "compute_price": "fixed",
+                            "product_id": cls.usb_adapter.id,
+                            "applied_on": "0_product_variant",
+                            "fixed_price": 110,
+                        }
+                    ),
+                ],
+            }
+        )
+
         cls.pricelist01 = cls.env["product.pricelist"].create(
             {
-                "name": "Sale pricelist",
+                "name": "Sale pricelist01",
                 "item_ids": [
                     Command.create(
                         {
@@ -86,7 +102,7 @@ class CommonProductPricelistAlternative(common.TransactionCase):
 
         cls.pricelist02 = cls.env["product.pricelist"].create(
             {
-                "name": "Sale pricelist",
+                "name": "Sale pricelist02",
                 "item_ids": [
                     Command.create(
                         {
@@ -99,6 +115,25 @@ class CommonProductPricelistAlternative(common.TransactionCase):
                 ],
                 "alternative_pricelist_ids": [
                     (4, cls.alternative_pricelist_01.id),
+                ],
+            }
+        )
+
+        cls.pricelist03 = cls.env["product.pricelist"].create(
+            {
+                "name": "Sale pricelist03",
+                "item_ids": [
+                    Command.create(
+                        {
+                            "compute_price": "formula",
+                            "base": "pricelist",
+                            "base_pricelist_id": cls.pricelist01.id,
+                            "applied_on": "3_global",
+                        }
+                    ),
+                ],
+                "alternative_pricelist_ids": [
+                    (4, cls.alternative_pricelist_03.id),
                 ],
             }
         )

--- a/product_pricelist_alternative/tests/test_pricelist_alternative.py
+++ b/product_pricelist_alternative/tests/test_pricelist_alternative.py
@@ -56,6 +56,11 @@ class TestPricelistAlternative(
             result[self.usb_adapter.id][1], self.pricelist02.item_ids[0].id
         )
 
+    def test_product_price_formula_based_on_other_price(self):
+        """Test that pricelists with formula based on other pricelist
+        does not take alternative pricelists into account"""
+        self.assertEqual(self.pricelist03._get_product_price(self.usb_adapter, 1.0), 95)
+
     def test_product_price_ignore_alternative_pricelist(self):
         """Test that the product price ignore alternative pricelist"""
 


### PR DESCRIPTION
Initial design of this module expected that:
When one pricelist inherits the prices of another pricelist in standard waterfall (compute_price == "formula" and base == "pricelist"), do not inherit the alternative prices on parent pricelist.                    