### PR TITLE
[16.0][FIX] add addClassCleanup in testcase

### DIFF
--- a/base_product_mass_addition/tests/test_product_mass_addition.py
+++ b/base_product_mass_addition/tests/test_product_mass_addition.py
@@ -20,6 +20,7 @@ class TestProductMassAddition(TransactionCase):
         # Setup Fake Models
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
+        cls.addClassCleanup(cls.loader.restore_registry)
         from .models.order import ModelOrder, ModelOrderLine
 
         cls.loader.update_registry(

--- a/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
+++ b/product_packaging_container_deposit/tests/test_container_deposit_order_mixin.py
@@ -15,6 +15,7 @@ class TestProductPackagingContainerDepositMixin(Common):
         super().setUpClass()
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
+        cls.addClassCleanup(cls.loader.restore_registry)
         from .fake_models import (
             ContainerDepositOrderLineTest,
             ContainerDepositOrderTest,

--- a/product_secondary_unit/tests/test_secondary_unit_mixin.py
+++ b/product_secondary_unit/tests/test_secondary_unit_mixin.py
@@ -11,6 +11,7 @@ class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
         super().setUpClass()
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
+        cls.addClassCleanup(cls.loader.restore_registry)
         from .models import SecondaryUnitFake
 
         cls.loader.update_registry((SecondaryUnitFake,))
@@ -56,11 +57,6 @@ class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
                 "product_uom_id": cls.product_uom_unit.id,
             }
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super(TestProductSecondaryUnitMixin, cls).tearDownClass()
 
     def test_product_secondary_unit_mixin(self):
         fake_model = self.secondary_unit_fake

--- a/product_set/tests/test_product_set_wizard.py
+++ b/product_set/tests/test_product_set_wizard.py
@@ -12,6 +12,7 @@ class TestProductSetWizard(TransactionCase, FakeModelLoader):
         super().setUpClass()
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
+        cls.addClassCleanup(cls.loader.restore_registry)
         from .models import FakeProductSetWizard
 
         cls.loader.update_registry((FakeProductSetWizard,))
@@ -25,11 +26,6 @@ class TestProductSetWizard(TransactionCase, FakeModelLoader):
                 "quantity": 1,
             }
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
 
     def test_product_set_wizard_compute_lines(self):
         # Check if the wizard lines are updated when the product set changes


### PR DESCRIPTION
The test class in the `product_abc_classification_sale_stock` module has the same name as a test class in `product_abc_classification`, which is causing an error in GitHub CI in https://github.com/OCA/product-attribute/pull/1561, https://github.com/OCA/product-attribute/pull/1683