### PR TITLE
[17.0][FW][FIX] uom_category_active: CI is broken. because onchange doesn't raise an error

### DIFF
--- a/uom_category_active/tests/test_uom_category_active.py
+++ b/uom_category_active/tests/test_uom_category_active.py
@@ -2,7 +2,6 @@
 # Copyright 2023 PESOL - Angel Moya
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
 
 
@@ -14,21 +13,11 @@ class TestProductCategoryActive(TransactionCase):
         cls.uom_categ = categ_obj.create(
             {"name": "Test UoM Category", "uom_ids": [(0, 0, {"name": "Test UoM"})]}
         )
+        cls.uom = cls.uom_categ.uom_ids[0]
 
     def test_archive_non_empty_categories(self):
         self.assertTrue(self.uom_categ.active)
-        uom = self.uom_categ.uom_ids[0]
-        self.assertTrue(uom.active)
+        self.assertTrue(self.uom.active)
         self.uom_categ.active = False
-        self.uom_categ._onchange_active()
-        self.uom_categ._onchange_uom_ids()
         self.assertFalse(self.uom_categ.active)
-        self.assertFalse(uom.active)
-
-    def test_archive_reference_uom(self):
-        self.assertTrue(self.uom_categ.active)
-        uom = self.uom_categ.uom_ids[0]
-        self.assertTrue(uom.active)
-        uom.active = False
-        with self.assertRaises(UserError):
-            self.uom_categ._onchange_uom_ids()
+        self.assertFalse(self.uom.active)


### PR DESCRIPTION
Port of https://github.com/OCA/product-attribute/pull/1760 from 16.0 to 17.0.