### PR TITLE
[16.0][FIX] product_supplierinfo_stock_picking_type: call _compute_price_unit_and_date_planned_and_name on change PO picking type

### DIFF
--- a/product_supplierinfo_stock_picking_type/models/purchase_order.py
+++ b/product_supplierinfo_stock_picking_type/models/purchase_order.py
@@ -9,4 +9,4 @@ class PurchaseOrder(models.Model):
     @api.onchange("picking_type_id")
     def onchange_picking_type_id(self):
         for line in self.order_line:
-            line.onchange_product_id()
+            line._compute_price_unit_and_date_planned_and_name()


### PR DESCRIPTION
Core Odoo method has changed behaviour, now on onchange_product_id prices are not recomputed, so we need to call _compute_price_unit_and_date_planned_and_name instead to ensure that when we change the picking type, prices will be recomputed.