### PR TITLE
[16.0][FIX] product_supplierinfo_stock_picking_type: rename on change picking type method

### DIFF
--- a/product_supplierinfo_stock_picking_type/models/purchase_order.py
+++ b/product_supplierinfo_stock_picking_type/models/purchase_order.py
@@ -7,6 +7,8 @@ class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
     @api.onchange("picking_type_id")
-    def onchange_picking_type_id(self):
+    def onchange_picking_type_id_onchange_product(self):
+        # Method name is to avoid conflicts with mrp_subcontracting_dropshipping
+        # that have an onchange method named onchange_picking_type_id
         for line in self.order_line:
             line.onchange_product_id()

--- a/product_supplierinfo_stock_picking_type/tests/test_product_supplierinfo_stock_picking_type.py
+++ b/product_supplierinfo_stock_picking_type/tests/test_product_supplierinfo_stock_picking_type.py
@@ -102,5 +102,5 @@ class TestProductSupplierinfoStockPickingType(BaseCommon):
         po = self._create_purchase_order(self.picking_in_c)
         self.assertEqual(po.order_line.price_unit, 20)
         po.picking_type_id = self.picking_in_a
-        po.onchange_picking_type_id()
+        po.onchange_picking_type_id_onchange_product()
         self.assertEqual(po.order_line.price_unit, 5)


### PR DESCRIPTION
If module mrp_subcontracting_dropshipping, form Odoo, is installed in our system, there are conflicts between onchange methods, mrp_subcontracting_dropshipping method https://github.com/odoo/odoo/blob/16.0/addons/mrp_subcontracting_dropshipping/models/purchase.py#L23 is overriding the onchange method previously defined in this module. So I suggest renaming the onchange method.