### PR TITLE
[FIX] product_uom_measure_type: Fixed the issue, that the module cannot be installed #1778

### DIFF
--- a/product_uom_measure_type/hooks.py
+++ b/product_uom_measure_type/hooks.py
@@ -17,7 +17,7 @@ def pre_init_hook(cr):
     cr.execute(
         """
         ALTER TABLE uom_category
-        ADD column measure_type character varying;
+        ADD column IF NOT EXISTS measure_type character varying;
         """
     )
 
@@ -50,7 +50,7 @@ def pre_init_hook(cr):
     cr.execute(
         """
         ALTER TABLE uom_uom
-        ADD column measure_type character varying;
+        ADD column IF NOT EXISTS measure_type character varying;
         """
     )
 
@@ -67,7 +67,7 @@ def pre_init_hook(cr):
     cr.execute(
         """
         ALTER TABLE product_template
-        ADD column uom_measure_type character varying;
+        ADD column IF NOT EXISTS uom_measure_type character varying;
         """
     )
 


### PR DESCRIPTION
[FIX] product_uom_measure_type: Fixed the issue, that the module cannot be installed on migrated databases which already have a column 'measure_type'

This pr fixed https://github.com/OCA/product-attribute/issues/1778

@dreispt @legalsylvain @rousseldenis 

Kindly ask to check this pr :) 



