### PR TITLE
[16.0][FIX] product_packaging_level: cannot input name with user_defined policy + update rename hook

### DIFF
--- a/product_packaging_level/hooks.py
+++ b/product_packaging_level/hooks.py
@@ -8,9 +8,22 @@ from odoo import SUPERUSER_ID, api
 def pre_init_hook(cr):
     if openupgrade.table_exists(cr, "product_packaging_type"):
         env = api.Environment(cr, SUPERUSER_ID, {})
+        # Re-mapping the name for the xml record to be the same as the new version
+        openupgrade.logged_query(
+            cr,
+            query="""
+            UPDATE ir_model_data
+            SET name = 'product_packaging_level_default'
+            WHERE name = 'product_packaging_type_default'
+            AND module = 'product_packaging_type';
+            """,
+        )
+
         # Former version of the module is present
         models = [("product.packaging.type", "product.packaging.level")]
         openupgrade.rename_models(env.cr, models)
+        tables = [("product_packaging_type", "product_packaging_level")]
+        openupgrade.rename_tables(env.cr, tables)
         fields = [
             (
                 "product.packaging",

--- a/product_packaging_level/models/product_packaging.py
+++ b/product_packaging_level/models/product_packaging.py
@@ -137,12 +137,11 @@ class ProductPackaging(models.Model):
 
     # Keep this method to respect translations on level name
     @api.depends("product_id", "packaging_level_id", "name_policy")
-    def _compute_display_name(self):
+    def _compute_display_name(self):  # pylint: disable=W8110
+        super()._compute_display_name()
         for record in self:
             if record.product_id and record.packaging_level_id:
                 record.display_name = record._get_name_from_policy(lang=self.env.lang)
-            else:
-                return super()._compute_display_name()
 
     def _get_name_from_policy(self, lang=None):
         new_name = self.name

--- a/product_packaging_level/views/product_packaging_view.xml
+++ b/product_packaging_level/views/product_packaging_view.xml
@@ -31,12 +31,6 @@
         <field name="model">product.packaging</field>
         <field name="inherit_id" ref="stock.product_packaging_form_view" />
         <field name="arch" type="xml">
-            <field name="name" position="before">
-                <field name="display_name" string="Packaging" />
-            </field>
-            <field name="name" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
             <xpath expr="//field[@name='product_id']" position="before">
                 <field name="name_policy" invisible="1" />
             </xpath>


### PR DESCRIPTION
### Note
steps to reproduce
1. Create a level with Name Policy is: User Defined
2. Create a packaging with the level
3. Name of packaging becomes read-only and cannot be created

### This changes
- Backported from https://github.com/OCA/product-attribute/pull/1806
- Take this comment into account: https://github.com/OCA/product-attribute/pull/1215#discussion_r1280298221: impact db table as well
