### PR TITLE
[16.0][FIX] fix dimensional_uom_id initial value

### DIFF
--- a/product_dimension/models/product_template.py
+++ b/product_dimension/models/product_template.py
@@ -71,6 +71,8 @@ class ProductTemplate(models.Model):
         we catch the variant values preparation to update them
         """
         res = super()._prepare_variant_values(combination)
+        if self.dimensional_uom_id:
+            res.update({"dimensional_uom_id": self.dimensional_uom_id.id})
         if self.product_length:
             res.update({"product_length": self.product_length})
         if self.product_height:

--- a/product_dimension/tests/__init__.py
+++ b/product_dimension/tests/__init__.py
@@ -1,2 +1,2 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from . import test_compute_volume, test_template
+from . import test_compute_volume, test_template, test_variants

--- a/product_dimension/tests/test_variants.py
+++ b/product_dimension/tests/test_variants.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+
+class TestVariants(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.uom_cm = cls.env["uom.uom"].search([("name", "=", "cm")])
+        cls.product_attribute_1 = cls.env.ref("product.product_attribute_1")
+        cls.product_attribute_value_1 = cls.env.ref("product.product_attribute_value_1")
+        cls.product_attribute_value_2 = cls.env.ref("product.product_attribute_value_2")
+        cls.test_product_template_1 = cls.env["product.template"].create(
+            {
+                "name": "test product template 1",
+                "dimensional_uom_id": cls.uom_cm.id,
+                "weight": 2.0,
+                "product_length": 100.0,
+                "product_width": 50.0,
+                "product_height": 30.0,
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "type": "consu",
+            }
+        )
+
+    def test_create_variant_keeps_product_dimensions(self):
+        """
+        Test that creating a new variant keeps all product dimensions.
+        """
+        variant_1 = self.test_product_template_1.product_variant_ids
+        self.assertEqual(variant_1.dimensional_uom_id, self.uom_cm)
+        self.assertAlmostEqual(variant_1.volume, 0.15)
+        self.test_product_template_1.write(
+            {
+                "attribute_line_ids": [
+                    fields.Command.create(
+                        {
+                            "attribute_id": self.product_attribute_1.id,
+                            "value_ids": [
+                                fields.Command.set(
+                                    [
+                                        self.product_attribute_value_1.id,
+                                        self.product_attribute_value_2.id,
+                                    ],
+                                ),
+                            ],
+                        },
+                    ),
+                ]
+            }
+        )
+        for variant in self.test_product_template_1.product_variant_ids:
+            self.assertEqual(variant.dimensional_uom_id, self.uom_cm)
+            self.assertEqual(variant.product_length, 100.0)
+            self.assertEqual(variant.product_width, 50.0)
+            self.assertEqual(variant.product_height, 30.0)
+            self.assertAlmostEqual(variant.volume, 0.15)


### PR DESCRIPTION
correctly set `dimensional_uom_id` on newly created `product.template` and `product.product` records instead of always using the default value.