### PR TITLE
[17.0][IMP] product_supplierinfo_for_customer: change _name_search product restrictions

### DIFF
--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -30,7 +30,8 @@ class ProductProduct(models.Model):
             or (limit and res_ids_len >= limit)
         ):
             return res_ids
-        limit -= res_ids_len
+        if limit:
+            limit -= res_ids_len
         customerinfo_ids = self.env["product.customerinfo"]._search(
             [
                 ("partner_id", "=", self._context.get("partner_id")),

--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -26,9 +26,8 @@ class ProductProduct(models.Model):
             limit = (limit - res_ids_len) if limit else False
         if (
             not name
-            and limit
             or not self._context.get("partner_id")
-            or res_ids_len >= limit
+            or (limit and res_ids_len >= limit)
         ):
             return res_ids
         limit -= res_ids_len


### PR DESCRIPTION
Using these features with the [product_supplierinfo_for_customer_sale](https://github.com/OCA/sale-workflow/tree/16.0/product_supplierinfo_for_customer_sale) module when searching for a product by code in an order line, the limit field has no value and does not work correctly.

@ForgeFlow 