### PR TITLE
[18.0][IMP] product_set: add packaging for product.set.line

### DIFF
--- a/product_set/models/product_set_line.py
+++ b/product_set/models/product_set_line.py
@@ -1,7 +1,9 @@
 # Copyright 2015 Anybox S.A.S
 # Copyright 2016-2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import float_is_zero
 
 
 class ProductSetLine(models.Model):
@@ -35,3 +37,46 @@ class ProductSetLine(models.Model):
         "res.company", related="product_set_id.company_id", store=True, readonly=True
     )
     name = fields.Char()
+    product_packaging_id = fields.Many2one(
+        "product.packaging", domain="[('product_id', '=', product_id)]"
+    )
+    product_packaging_qty = fields.Float(
+        compute="_compute_product_packaging_qty",
+        inverse="_inverse_product_packaging_qty",
+        digits="Product Unit of Measure",
+    )
+
+    @api.depends(
+        "quantity",
+        "product_packaging_id",
+        "product_packaging_id.qty",
+        "product_id.packaging_ids",
+    )
+    def _compute_product_packaging_qty(self):
+        for line in self:
+            uom_rounding = line.product_id.uom_id.rounding
+            if not line.product_packaging_id or float_is_zero(
+                line.quantity, precision_rounding=uom_rounding
+            ):
+                line.product_packaging_qty = 0
+                continue
+            line.product_packaging_qty = line.quantity / line.product_packaging_id.qty
+            line.update(line._prepare_product_packaging_qty_values())
+
+    def _inverse_product_packaging_qty(self):
+        for line in self:
+            if line.product_packaging_qty and not line.product_packaging_id:
+                raise UserError(
+                    self.env._(
+                        "You must define a package before setting a quantity "
+                        "of said package."
+                    )
+                )
+            if line.product_packaging_id and line.product_packaging_qty:
+                line.write(line._prepare_product_packaging_qty_values())
+
+    def _prepare_product_packaging_qty_values(self):
+        self.ensure_one()
+        return {
+            "quantity": self.product_packaging_id.qty * self.product_packaging_qty,
+        }

--- a/product_set/readme/CONTRIBUTORS.md
+++ b/product_set/readme/CONTRIBUTORS.md
@@ -9,3 +9,6 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Pilar Vargas
 - Nils Coenen \<<nils.coenen@nico-solutions.de>\>
+- Akim Juillerat \<<akim.juillerat@camptocamp.com>\>
+- Son (Ho Dac) \<<hodacson.6491@gmail.com>\>
+- Tris Doan \<<tridm@trobz.com>\>

--- a/product_set/tests/__init__.py
+++ b/product_set/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_product_set_wizard
 from . import test_product_set
+from . import test_product_set_line

--- a/product_set/tests/test_product_set_line.py
+++ b/product_set/tests/test_product_set_line.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import exceptions
+from odoo.tests.common import TransactionCase
+
+
+class TestProductSetLine(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.line = cls.env.ref("product_set.product_set_line_computer_3")
+        cls.packaging = cls.env["product.packaging"].create(
+            {"name": "Box", "product_id": cls.line.product_id.id, "qty": 10}
+        )
+
+    def test_with_packaging(self):
+        line = self.line
+        line.quantity = 50
+        line.product_packaging_id = self.packaging
+        # 50 units of packages with 10 units each means 5 packages
+        self.assertEqual(line.product_packaging_qty, 5)
+
+    def test_write_packaging_qty(self):
+        line = self.line
+        line.product_packaging_id = self.packaging
+        line.product_packaging_qty = 8
+        # 8 packages with 10 units each means 80 units
+        self.assertEqual(line.quantity, 80)
+
+    def test_error_write_qty_but_no_packaging(self):
+        line = self.line
+        with self.assertRaises(exceptions.UserError):
+            line.product_packaging_qty = 10
+
+    def test_packaging_qty_update(self):
+        line = self.line
+        line.product_packaging_id = self.packaging
+
+        # set packaging qty and check product.set.line quantity is correctly updated
+        line.product_packaging_qty = 2
+        self.assertEqual(self.packaging.qty, 10)
+        # qty on line is 20: 2 packages of 10 units each
+        self.assertEqual(line.quantity, 20)
+
+        # change qty on packaging
+        # and check product.set.line quantity is correctly updated
+        self.packaging.qty = 5
+        self.line.product_packaging_qty = 2
+
+        self.assertEqual(self.packaging.qty, 5)
+        self.assertEqual(line.product_id.packaging_ids.qty, 5)
+        self.assertEqual(line.product_id.product_tmpl_id.packaging_ids.qty, 5)
+
+        # qty on line is 10: 2 packages of 5 units each
+        self.assertEqual(line.quantity, 10)

--- a/product_set/views/product_set.xml
+++ b/product_set/views/product_set.xml
@@ -49,6 +49,15 @@
                             <list editable="top">
                                 <field name="sequence" widget="handle" />
                                 <field name="product_id" required="not display_type" />
+                                <field
+                                    name="product_packaging_id"
+                                    context="{'default_product_id': product_id}"
+                                    groups="product.group_stock_packaging"
+                                />
+                                <field
+                                    name="product_packaging_qty"
+                                    groups="product.group_stock_packaging"
+                                />
                                 <field name="quantity" />
                                 <field name="display_type" invisible="1" />
                                 <field name="name" widget="section_and_note_text" />

--- a/product_set/views/product_set_line.xml
+++ b/product_set/views/product_set_line.xml
@@ -8,6 +8,11 @@
             <list editable="top">
                 <field name="product_set_id" />
                 <field name="product_id" />
+                <field
+                    name="product_packaging_id"
+                    context="{'default_product_id': product_id}"
+                />
+                <field name="product_packaging_qty" />
                 <field name="quantity" />
             </list>
         </field>


### PR DESCRIPTION
### This changes
- Add 'Product Packaging' on product.set.line, which allows to propagate packages to other modules, like `Sale`, one example is: https://github.com/OCA/sale-workflow/pull/3474