### PR TITLE
[16.0][FIX] product_category_active: harmonization of category display.

### DIFF
--- a/product_category_active/README.rst
+++ b/product_category_active/README.rst
@@ -78,6 +78,7 @@ Authors
 ~~~~~~~
 
 * Tecnativa
+* GRAP
 
 Contributors
 ~~~~~~~~~~~~

--- a/product_category_active/__manifest__.py
+++ b/product_category_active/__manifest__.py
@@ -3,10 +3,10 @@
 
 {
     "name": "Product Category Active",
-    "version": "16.0.1.0.2",
+    "version": "16.0.2.0.0",
     "category": "Product",
     "summary": "Add option to archive product categories",
-    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "author": "Tecnativa, GRAP, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "license": "AGPL-3",
     "depends": ["product"],

--- a/product_category_active/migrations/16.0.2.0.0/post-migration.py
+++ b/product_category_active/migrations/16.0.2.0.0/post-migration.py
@@ -1,0 +1,21 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+from odoo.tools.safe_eval import safe_eval
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    action = env.ref("product.product_category_action_form")
+    current_context = safe_eval(action.context)
+    if "active_test" in current_context:
+        _logger.info("Removing active_test on product_category_action_form")
+        del current_context["active_test"]
+        action.context = current_context

--- a/product_category_active/static/description/index.html
+++ b/product_category_active/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -424,6 +424,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
+<li>GRAP</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -441,7 +442,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_category_active/views/product_views.xml
+++ b/product_category_active/views/product_views.xml
@@ -2,6 +2,26 @@
 <!-- Copyright 2018 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
+
+    <record id="product_category_search_view" model="ir.ui.view">
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_search_view" />
+        <field name="arch" type="xml">
+            <field name="parent_id" position="after">
+                <filter
+                    name="inactive"
+                    string="Archived"
+                    domain="[('active','=',False)]"
+                />
+                <filter
+                    name="active_and_inactive"
+                    string="Archived or Active"
+                    context="{'active_test': False}"
+                />
+            </field>
+        </field>
+    </record>
+
     <record id="product_category_form_view" model="ir.ui.view">
         <field name="name">product.category.form.inherit</field>
         <field name="model">product.category</field>
@@ -31,7 +51,5 @@
             </tree>
         </field>
     </record>
-    <record id="product.product_category_action_form" model="ir.actions.act_window">
-        <field name="context">{"active_test": False}</field>
-    </record>
+
 </odoo>


### PR DESCRIPTION
In odoo, archived items are not displayed by default. (see users view, products, etc...) The product_category_active module doesn't follow this convention because it is changing the context of the action of product.category. As a result, all categories are displayed, polluting visibility with obsolete items.

- Remove the active_test in the context of the action.
- create a migration script to remove the active_test on existing instances.
- add filters to display archived and 'archived or active' categories, in case you want to see all categories