### PR TITLE
[IMP] product_pricelist_supplierinfo: improve sale margin string in view and exclude supplier info discount in price

### DIFF
--- a/product_pricelist_supplierinfo/i18n/ca.po
+++ b/product_pricelist_supplierinfo/i18n/ca.po
@@ -67,13 +67,8 @@ msgstr ""
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr "Marge de vendes"
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
-msgstr "Marge de venda"
+msgid "Sale Margin (%)"
+msgstr "Marge de venda (%)"
 
 #. module: product_pricelist_supplierinfo
 #: model:res.groups,name:product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin

--- a/product_pricelist_supplierinfo/i18n/es.po
+++ b/product_pricelist_supplierinfo/i18n/es.po
@@ -68,13 +68,8 @@ msgstr "Variante del producto"
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr "Margen de venta"
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
-msgstr "Margen de venta"
+msgid "Sale Margin (%)"
+msgstr "Margen de venta (%)"
 
 #. module: product_pricelist_supplierinfo
 #: model:res.groups,name:product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin

--- a/product_pricelist_supplierinfo/i18n/fr.po
+++ b/product_pricelist_supplierinfo/i18n/fr.po
@@ -67,13 +67,8 @@ msgstr ""
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr "Marge à la revente"
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
-msgstr "Marge à la revente"
+msgid "Sale Margin (%)"
+msgstr "Marge à la revente (%)"
 
 #. module: product_pricelist_supplierinfo
 #: model:res.groups,name:product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin

--- a/product_pricelist_supplierinfo/i18n/it.po
+++ b/product_pricelist_supplierinfo/i18n/it.po
@@ -72,13 +72,8 @@ msgstr "Variante prodotto"
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr "Margine di vendita"
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
-msgstr "Margine di vendita"
+msgid "Sale Margin (%)"
+msgstr "Margine di vendita (%)"
 
 #. module: product_pricelist_supplierinfo
 #: model:res.groups,name:product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin

--- a/product_pricelist_supplierinfo/i18n/nl.po
+++ b/product_pricelist_supplierinfo/i18n/nl.po
@@ -69,13 +69,8 @@ msgstr ""
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr "Verkoopsmarge"
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
-msgstr "Verkoopsmarge"
+msgid "Sale Margin (%)"
+msgstr "Verkoopsmarge (%)"
 
 #. module: product_pricelist_supplierinfo
 #: model:res.groups,name:product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin

--- a/product_pricelist_supplierinfo/i18n/product_pricelist_supplierinfo.pot
+++ b/product_pricelist_supplierinfo/i18n/product_pricelist_supplierinfo.pot
@@ -64,12 +64,7 @@ msgstr ""
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr ""
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
+msgid "Sale Margin (%)"
 msgstr ""
 
 #. module: product_pricelist_supplierinfo

--- a/product_pricelist_supplierinfo/i18n/pt_BR.po
+++ b/product_pricelist_supplierinfo/i18n/pt_BR.po
@@ -67,13 +67,8 @@ msgstr "Variante do produto"
 
 #. module: product_pricelist_supplierinfo
 #: model:ir.model.fields,field_description:product_pricelist_supplierinfo.field_product_supplierinfo__sale_margin
-msgid "Sale Margin"
-msgstr "Margem de Venda"
-
-#. module: product_pricelist_supplierinfo
-#: model_terms:ir.ui.view,arch_db:product_pricelist_supplierinfo.product_supplierinfo_tree_view
-msgid "Sale margin"
-msgstr "Margem de venda"
+msgid "Sale Margin (%)"
+msgstr "Margem de venda (%)"
 
 #. module: product_pricelist_supplierinfo
 #: model:res.groups,name:product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin

--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -20,6 +20,13 @@ class ProductPricelistItem(models.Model):
         string="Supplier filter",
         help="Only match prices from the selected supplier",
     )
+    no_supplierinfo_discount = fields.Boolean(
+        string="Ignore Supplier Info Discount",
+        help=(
+            "If checked, the discount set on the supplier info "
+            "will be ignored in price calculation."
+        ),
+    )
 
     def _compute_price(self, product, quantity, uom, date, currency=None):
         result = super()._compute_price(product, quantity, uom, date, currency)

--- a/product_pricelist_supplierinfo/models/product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/models/product_supplierinfo.py
@@ -14,9 +14,9 @@ class ProductSupplierinfo(models.Model):
         help="Margin to apply on price to obtain sale price",
     )
 
-    def _get_supplierinfo_pricelist_price(self):
+    def _get_supplierinfo_pricelist_price(self, no_supplierinfo_discount=False):
         self.ensure_one()
-        sale_price = self.price
+        sale_price = self.price if no_supplierinfo_discount else self.price_discounted
         if self.sale_margin:
-            sale_price = (self.price + (self.price * (self.sale_margin / 100))) or 0.0
+            sale_price = (sale_price + (sale_price * (self.sale_margin / 100))) or 0.0
         return sale_price

--- a/product_pricelist_supplierinfo/models/product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/models/product_supplierinfo.py
@@ -10,6 +10,7 @@ class ProductSupplierinfo(models.Model):
     sale_margin = fields.Float(
         default=0,
         digits=(16, 2),
+        string="Sale Margin (%)",
         help="Margin to apply on price to obtain sale price",
     )
 

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -41,7 +41,9 @@ class ProductTemplate(models.Model):
                 date=date,
             )
             if seller:
-                price = seller._get_supplierinfo_pricelist_price()
+                price = seller._get_supplierinfo_pricelist_price(
+                    rule.no_supplierinfo_discount
+                )
         if price:
             # We need to convert the price if the pricelist and seller have
             # different currencies so the price have the pricelist currency

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -311,3 +311,19 @@ class TestProductSupplierinfo(TransactionCase):
         # And the price with the pricelist and the uom of Units (Instead of Dozen)
         # will be 100, plus the 20% the total will be 120 per Unit
         self.assertEqual(product_pricelist_price_unit, 120)
+
+    def test_pricelist_exclude_supplier_info_discount(self):
+        """Test the scenario where the product supplier info includes a discount, to
+        verify the functionality of the option to exclude this discount from the price
+        calculation.
+        """
+        self.product.seller_ids[1].discount = 10
+        self.assertAlmostEqual(
+            self.pricelist._get_product_price(self.product, 1),
+            9,
+        )
+        self.pricelist.item_ids[0].no_supplierinfo_discount = True
+        self.assertAlmostEqual(
+            self.pricelist._get_product_price(self.product, 1),
+            10,
+        )

--- a/product_pricelist_supplierinfo/views/product_pricelist_item_views.xml
+++ b/product_pricelist_supplierinfo/views/product_pricelist_item_views.xml
@@ -11,6 +11,10 @@
                     name="no_supplierinfo_min_quantity"
                     invisible="base != 'supplierinfo'"
                 />
+                <field
+                    name="no_supplierinfo_discount"
+                    invisible="base != 'supplierinfo'"
+                />
                 <field name="filter_supplier_id" invisible="base != 'supplierinfo'" />
             </xpath>
         </field>

--- a/product_pricelist_supplierinfo/views/product_supplierinfo_view.xml
+++ b/product_pricelist_supplierinfo/views/product_supplierinfo_view.xml
@@ -9,7 +9,6 @@
             <field name="price" position="after">
                 <field
                     name="sale_margin"
-                    string="Sale margin"
                     groups="product_pricelist_supplierinfo.group_supplierinfo_pricelist_sale_margin"
                 />
             </field>


### PR DESCRIPTION
Update the sale margin string on the field to match the format of the discount field [1], which is located beside it in the list view.

Also, introduce a new field to optionally exclude the discount set in the product supplier info when calculating the product's price. A test has been added to validate this new functionality.

[1]: https://github.com/odoo/odoo/blob/e947c589/addons/product/models/product_supplierinfo.py#L65