### PR TITLE
[16.0][FIX] product_category_active: in odoo, disabled items are muted by default.

### DIFF
--- a/product_category_active/views/product_views.xml
+++ b/product_category_active/views/product_views.xml
@@ -44,7 +44,7 @@
         <field name="inherit_id" ref="product.product_category_list_view" />
         <field name="arch" type="xml">
             <tree position="attributes">
-                <attribute name="decoration-info">not active</attribute>
+                <attribute name="decoration-muted">not active</attribute>
             </tree>
             <tree position="inside">
                 <field name="active" widget="boolean_toggle" />


### PR DESCRIPTION


this patch makes also the current module compatible with product_category_type. (same repo)