### PR TITLE
[FIX] product_print_category: Do no set current company by default on category model

### DIFF
--- a/product_print_category/models/product_print_category.py
+++ b/product_print_category/models/product_print_category.py
@@ -21,7 +21,6 @@ class ProductPrintCategory(models.Model):
         string="Company",
         comodel_name="res.company",
         index=True,
-        default=lambda x: x._default_company_id(),
     )
 
     product_ids = fields.One2many(
@@ -55,9 +54,6 @@ class ProductPrintCategory(models.Model):
         domain="[('type', '=', 'qweb')]",
         required=True,
     )
-
-    def _default_company_id(self):
-        return self.env.company
 
     def get_xml_id_view(self):
         return self.qweb_view_id.sudo().key


### PR DESCRIPTION
Rational: The categories are mainly created by xml code, because it requires to define qweb report. In that case, setting by default the company of the admin user doesn't makes sense. Also if categories are created by UI, in a multi-company context, you may or may not want the category to be global.