### PR TITLE
[16.0][FIX] product_assortment ir_filters create vals_list

### DIFF
--- a/product_assortment/models/ir_filters.py
+++ b/product_assortment/models/ir_filters.py
@@ -74,7 +74,7 @@ class IrFilters(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         self._update_assortment_default_values(vals_list=vals_list)
-        return super().create(vals_list=vals_list)
+        return super().create(vals_list)
 
     @api.model
     @ormcache()


### PR DESCRIPTION
In `16.0` `vals_list` list is not a key arg on create method. 
https://github.com/odoo/odoo/blob/b010799d7716357e98303a896e15bb067c33ec97/odoo/models.py#L3908

```
Traceback (most recent call last):
  File "/odoo/src/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/odoo/src/odoo/tools/convert.py", line 599, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/odoo/src/odoo/models.py", line 4416, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/odoo/src/odoo/models.py", line 4327, in _load_records_create
    return self.create(values)
  File "<decorator-gen-127>", line 2, in create
  File "/odoo/src/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/odoo/external-src/product-attribute/product_assortment/models/ir_filters.py", line 77, in create
    return super().create(vals_list=vals_list)
TypeError: create() got an unexpected keyword argument 'vals_list'
```