### PR TITLE
[FIX] [16.0] product_sticker: Allow to select which models can use Stickers

### DIFF
--- a/product_sticker/README.rst
+++ b/product_sticker/README.rst
@@ -61,6 +61,7 @@ Usage
 Go to Settings > Technical > Database Structure > Product Stickers.
 You can add Stickers to Attributes resulting in different behaviours:
 - If an Image has no Company, it will be available to all Companies
+- If an Image has Available Models, it will be restricted to selected Models.
 - If an Image has no Attribute, it will be available to all Attributes
 - If an Image has no Attribute Value, it will be available to all Attribute
 Values of the Attribute

--- a/product_sticker/i18n/es.po
+++ b/product_sticker/i18n/es.po
@@ -4,17 +4,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2023-10-28 20:20+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2025-02-19 12:19+0000\n"
+"PO-Revision-Date: 2025-02-19 13:19+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. module: product_sticker
 #: model_terms:ir.ui.view,arch_db:product_sticker.product_sticker_kanban_view
@@ -40,6 +41,12 @@ msgstr "Valor del Atributo"
 #: model:ir.model.fields,field_description:product_sticker.field_product_sticker__product_attribute_value_id
 msgid "Attribute value"
 msgstr "Valor del atributo"
+
+#. module: product_sticker
+#: model:ir.model.fields,field_description:product_sticker.field_product_sticker__available_model_ids
+#: model_terms:ir.ui.view,arch_db:product_sticker.product_sticker_search_view
+msgid "Available Models"
+msgstr "Modelos disponibles"
 
 #. module: product_sticker
 #: model:ir.model.fields,field_description:product_sticker.field_product_sticker__product_category_id
@@ -151,6 +158,11 @@ msgid "Last Updated on"
 msgstr "Última Actualización el"
 
 #. module: product_sticker
+#: model:ir.model.fields,help:product_sticker.field_product_sticker__available_model_ids
+msgid "Models where this sticker is available. Empty means all models."
+msgstr "Modelos en los que esta pegatina está disponible. Vacío significa todos los modelos."
+
+#. module: product_sticker
 #: model:ir.model.fields,field_description:product_sticker.field_product_sticker__name
 #: model_terms:ir.ui.view,arch_db:product_sticker.product_sticker_form_view
 msgid "Name"
@@ -162,7 +174,7 @@ msgid "Note"
 msgstr "Nota"
 
 #. module: product_sticker
-#: model:ir.model,name:product_sticker.model_product_product
+#: model:ir.model,name:product_sticker.model_product_template
 msgid "Product"
 msgstr "Producto"
 
@@ -205,9 +217,9 @@ msgid "Product Stickers"
 msgstr "Pegatinas de Producto"
 
 #. module: product_sticker
-#: model:ir.model,name:product_sticker.model_product_template
-msgid "Product Template"
-msgstr "Plantilla del Producto"
+#: model:ir.model,name:product_sticker.model_product_product
+msgid "Product Variant"
+msgstr "Variante de producto"
 
 #. module: product_sticker
 #: model:ir.model.fields,field_description:product_sticker.field_product_sticker__sequence

--- a/product_sticker/i18n/product_sticker.pot
+++ b/product_sticker/i18n/product_sticker.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-02-19 12:18+0000\n"
+"PO-Revision-Date: 2025-02-19 12:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -36,6 +38,12 @@ msgstr ""
 #. module: product_sticker
 #: model:ir.model.fields,field_description:product_sticker.field_product_sticker__product_attribute_value_id
 msgid "Attribute value"
+msgstr ""
+
+#. module: product_sticker
+#: model:ir.model.fields,field_description:product_sticker.field_product_sticker__available_model_ids
+#: model_terms:ir.ui.view,arch_db:product_sticker.product_sticker_search_view
+msgid "Available Models"
 msgstr ""
 
 #. module: product_sticker
@@ -145,6 +153,11 @@ msgstr ""
 #. module: product_sticker
 #: model:ir.model.fields,field_description:product_sticker.field_product_sticker__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: product_sticker
+#: model:ir.model.fields,help:product_sticker.field_product_sticker__available_model_ids
+msgid "Models where this sticker is available. Empty means all models."
 msgstr ""
 
 #. module: product_sticker

--- a/product_sticker/models/product_product.py
+++ b/product_sticker/models/product_product.py
@@ -11,21 +11,11 @@ class ProductProduct(models.Model):
         action["domain"] = [("id", "in", stickers.ids)]
         return action
 
-    def _get_sticker_arguments(self):
-        pavs = self.product_template_variant_value_ids.product_attribute_value_id
-        return {
-            "categories": self.categ_id,
-            "attributes": pavs.attribute_id,
-            "attribute_values": pavs,
-        }
-
     @api.returns("product.sticker")
-    def get_product_stickers(self):
-        """Product Stickers related to this Product Variant and its Template"""
-        # Product Template: Common stickers
-        pt_stickers = self.product_tmpl_id.get_product_stickers()
-        # Product Product: Specific stickers
-        pp_stickers = self.env["product.sticker"]._get_stickers(
-            **self._get_sticker_arguments()
+    def get_product_stickers(self, extra_domain=None):
+        """Product Stickers related to this Product Variant and
+        its Template for certain models"""
+        return self.env["product.sticker"]._get_stickers(
+            self,
+            extra_domain=extra_domain,
         )
-        return pt_stickers | pp_stickers

--- a/product_sticker/models/product_template.py
+++ b/product_sticker/models/product_template.py
@@ -1,4 +1,4 @@
-from odoo import api, models
+from odoo import models
 
 
 class ProductTemplate(models.Model):
@@ -6,24 +6,7 @@ class ProductTemplate(models.Model):
 
     def action_view_stickers(self):
         """Action to open the Stickers related to this Product Template"""
-        stickers = self.get_product_stickers()
+        stickers = self.product_variant_ids.get_product_stickers()
         action = self.env.ref("product_sticker.action_product_sticker").read()[0]
         action["domain"] = [("id", "in", stickers.ids)]
         return action
-
-    def _get_sticker_arguments(self):
-        no_variant_attribute_lines = self.attribute_line_ids.filtered(
-            lambda al: al.attribute_id.create_variant == "no_variant"
-        )
-        return {
-            "categories": self.categ_id,
-            "attributes": no_variant_attribute_lines.attribute_id,
-            "attribute_values": no_variant_attribute_lines.value_ids,
-        }
-
-    @api.returns("product.sticker")
-    def get_product_stickers(self):
-        """Attribute Stickers related to this Product Template and its variants"""
-        return self.env["product.sticker"]._get_stickers(
-            **self._get_sticker_arguments()
-        )

--- a/product_sticker/readme/USAGE.rst
+++ b/product_sticker/readme/USAGE.rst
@@ -1,6 +1,7 @@
 Go to Settings > Technical > Database Structure > Product Stickers.
 You can add Stickers to Attributes resulting in different behaviours:
 - If an Image has no Company, it will be available to all Companies
+- If an Image has Available Models, it will be restricted to selected Models.
 - If an Image has no Attribute, it will be available to all Attributes
 - If an Image has no Attribute Value, it will be available to all Attribute
 Values of the Attribute

--- a/product_sticker/static/description/index.html
+++ b/product_sticker/static/description/index.html
@@ -405,6 +405,7 @@ be printed or not.</p>
 <p>Go to Settings &gt; Technical &gt; Database Structure &gt; Product Stickers.
 You can add Stickers to Attributes resulting in different behaviours:
 - If an Image has no Company, it will be available to all Companies
+- If an Image has Available Models, it will be restricted to selected Models.
 - If an Image has no Attribute, it will be available to all Attributes
 - If an Image has no Attribute Value, it will be available to all Attribute
 Values of the Attribute

--- a/product_sticker/tests/test_product.py
+++ b/product_sticker/tests/test_product.py
@@ -2,27 +2,43 @@ from .common import ProductStickerCommon
 
 
 class TestStickersOnProducts(ProductStickerCommon):
-    def test_global_stickers(self):
-        stickers = self.product_as500.get_product_stickers()
-        self.assertEqual(len(stickers), 1, "Global sticker must be present")
+    def _test_model_availability(self, product):
+        stickers = product.get_product_stickers()
+        same_model = self.env.ref("base.model_ir_model")
+        stickers.write({"available_model_ids": [(6, 0, same_model.ids)]})
+        # Test same model
+        self.assertEqual(
+            len(
+                product.get_product_stickers(
+                    extra_domain=[
+                        "|",
+                        ("available_model_ids", "in", same_model.ids),
+                        ("available_model_ids", "=", False),
+                    ]
+                )
+            ),
+            len(stickers),
+            "Stickers must be present because has the same model",
+        )
+        # Test different model
+        other_model = self.env.ref("base.model_ir_ui_view")
+        self.assertEqual(
+            len(
+                product.get_product_stickers(
+                    extra_domain=[
+                        "|",
+                        ("available_model_ids", "in", other_model.ids),
+                        ("available_model_ids", "=", False),
+                    ]
+                )
+            ),
+            0,
+            "Stickers must not be present because has different model",
+        )
 
-    def test_product_template_stickers(self):
-        stickers = self.product_as400.get_product_stickers()
-        self.assertEqual(
-            len(stickers), 1, "Attribute that create variants has been generated"
-        )
-        # Add a new attribute value to the template
-        self.product_as400.attribute_line_ids.filtered(
-            lambda al: al.attribute_id == self.att_license
-        ).write(
-            {
-                "value_ids": [(4, self.att_license_freemium.id)],
-            }
-        )
-        new_stickers = self.product_as400.get_product_stickers()
-        self.assertEqual(
-            len(new_stickers), 2, "Attribute Value sticker must be present"
-        )
+    def test_global_stickers(self):
+        stickers = self.product_as500.product_variant_ids.get_product_stickers()
+        self.assertEqual(len(stickers), 1, "Global sticker must be present")
 
     def test_product_product_stickers(self):
         stickers = self.product_as400.product_variant_ids[0].get_product_stickers()
@@ -43,3 +59,5 @@ class TestStickersOnProducts(ProductStickerCommon):
             3,
             "Sticker for Attribute with no create variants not present",
         )
+        # Test models
+        self._test_model_availability(self.product_as400.product_variant_ids[0])

--- a/product_sticker/views/product_sticker_views.xml
+++ b/product_sticker/views/product_sticker_views.xml
@@ -24,6 +24,11 @@
                                 class="h2 mb-5"
                             />
                             <field
+                                name="available_model_ids"
+                                options="{'no_create': True}"
+                                widget="many2many_tags"
+                            />
+                            <field
                                 name="company_id"
                                 options="{'no_create': True}"
                                 groups="base.group_multi_company"
@@ -73,6 +78,7 @@
             <tree multi_edit="1">
                 <field name="sequence" widget="handle" />
                 <field name="name" />
+                <field name="available_model_ids" widget="many2many_tags" />
                 <field name="product_category_id" />
                 <field
                     name="product_attribute_id"
@@ -107,6 +113,7 @@
                 <field name="image_1920" />
                 <field name="product_attribute_id" />
                 <field name="product_attribute_value_id" />
+                <field name="available_model_ids" />
                 <field name="sequence" widget="handle" />
                 <field name="company_id" />
                 <field name="show_sticker_note" />
@@ -169,6 +176,7 @@
                                         <field name="name" class="o_text_overflow" />
                                     </div>
                                     <div class="o_kanban_record_body">
+                                        <field name="available_model_ids" />
                                         <div
                                             t-if="record.product_category_id.value"
                                             class="d-block"
@@ -188,7 +196,6 @@
                                             > / </span>
                                             <field name="product_attribute_value_id" />
                                         </div>
-
                                     </div>
                                     <div class="o_kanban_record_bottom">
                                         <div class="oe_kanban_bottom_left">
@@ -215,6 +222,7 @@
         <field name="arch" type="xml">
             <search string="Product Stickers">
                 <field name="name" />
+                <field name="available_model_ids" />
                 <field name="product_category_id" />
                 <field
                     name="product_attribute_id"
@@ -250,6 +258,11 @@
                     domain="[('show_sticker_note', '=', True)]"
                 />
                 <group>
+                    <filter
+                        name="grp_available_models"
+                        string="Available Models"
+                        context="{'group_by': 'available_model_ids'}"
+                    />
                     <filter
                         name="grp_company"
                         string="Company"


### PR DESCRIPTION
This change is introduced because when creating submodules that uses Stickers, all Stickers (that matches category, attributes, etc) are chosen to be displayed in all models.

Real Example: 
The [Risk Insurance Product Sticker](https://github.com/OCA/credit-control/tree/16.0/partner_risk_insurance_product_sticker_invoice_report) module introduces a new field which pretends to show only in invoices what Invoice has been risk secured.
If you create a Sticker with the proper configuration, the Sticker shows in the [Picking reports](https://github.com/OCA/stock-logistics-reporting/tree/16.0/stock_picking_report_product_sticker), and should not appear in this reports.

With this change, you can select on which models you want to apply the sticker.
If no model is selected, will be available for all models (what is happening right now).

MT-9075 @moduon @rafaelbn @yajo @fcvalgar @EmilioPascual please review if you want 😄 