### PR TITLE
[14.0][FIX] product_lot_sequence: use same sequence as duplicate prod

### DIFF
--- a/product_lot_sequence/models/product.py
+++ b/product_lot_sequence/models/product.py
@@ -95,6 +95,15 @@ class ProductTemplate(models.Model):
                     vals["lot_sequence_padding"] = lot_sequence_id.padding
         return super().write(vals)
 
+    def copy(self, default=None):
+        self.ensure_one()
+        default = dict(default or {})
+
+        if self.lot_sequence_id:
+            default["lot_sequence_id"] = self.lot_sequence_id.id
+
+        return super().copy(default)
+
     @api.model
     def create(self, vals):
         if vals.get("tracking", False) in ["lot", "serial"]:

--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -64,3 +64,38 @@ class TestProductLotSequence(SavepointCase):
                 sequence=self.sequence.id
             ),
         )
+
+    def test_copy_lot_sequence(self):
+        """Check if copying a product copies the lot sequence of the copied product"""
+
+        # Create a sequence for testing
+        test_sequence = self.env["ir.sequence"].create(
+            {
+                "name": "Test Lot Sequence",
+                "implementation": "no_gap",
+                "prefix": "test/",
+                "padding": 6,
+                "number_increment": 1,
+                "use_date_range": False,
+            }
+        )
+
+        # Create a product with lot tracking and assign the test sequence
+        original_product = self.product_product.create(
+            {
+                "name": "Original Product",
+                "tracking": "lot",
+                "lot_sequence_id": test_sequence.id,
+            }
+        )
+
+        # Duplicate the product
+        copied_product = original_product.product_tmpl_id.copy()
+
+        # Check if the copied product retains the same sequence
+        self.assertEqual(
+            copied_product.lot_sequence_id.id,
+            original_product.lot_sequence_id.id,
+            msg="The copied product should retain the same"
+            " lot sequence as the original product.",
+        )


### PR DESCRIPTION
**Description**
When duplicating a product with a custom lot sequence (e.g., Y), the new product incorrectly receives the company's default sequence (e.g., X) instead of maintaining the original one.

**Current Behavior**

When duplicating a product with lot sequence Y, the new product is assigned the default sequence X instead.

**Expected Behavior**

The duplicated product should retain the original lot sequence Y instead of being reset to the default.

**Proposed implementation**

Override the copy method to ensure the lot sequence (lot_sequence_id) is correctly copied from the original product if existant.