### PR TITLE
[FIX] product_supplierinfo_group: fix incompatibility with other module

### DIFF
--- a/product_supplierinfo_group/views/product.xml
+++ b/product_supplierinfo_group/views/product.xml
@@ -6,9 +6,17 @@
         <field name="arch" type="xml">
             <field name="seller_ids" position="attributes">
                 <attribute name="invisible">1</attribute>
+                <!-- seller_ids should be readonly so when saving
+                    the value set by the onchange are ignored
+                -->
+                <attribute name="readonly">1</attribute>
             </field>
             <field name="variant_seller_ids" position="attributes">
                 <attribute name="invisible">1</attribute>
+                <!-- variant_seller_ids should be readonly so when saving
+                    the value set by the onchange are ignored
+                -->
+                <attribute name="readonly">1</attribute>
             </field>
             <field name="variant_seller_ids" position="after">
                 <field


### PR DESCRIPTION
Some other module can trigger some compute and onchange and this will set value in variant_seller_ids.
And so saving raise an error as in variant_seller_ids we do not have all the value, and we do not care of this field anymore so make it readonly to ignore this field and save time

@Kev-Roche 