### PR TITLE
[16.0][IMP] product_pricelist_direct_print: Rounding by Product Price

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
+from odoo.tools import float_round
 
 
 @api.model
@@ -96,12 +97,17 @@ class ProductPricelistPrint(models.TransientModel):
         price = self.get_pricelist_to_print()._get_product_price(
             product, 1, date=self.date
         )
+        precision = self.env["decimal.precision"].precision_get("Product Price")
         if self.vat_mode == "vat_excl":
-            self.product_price = product.taxes_id.compute_all(price)["total_excluded"]
+            self.product_price = float_round(
+                product.taxes_id.compute_all(price)["total_excluded"], precision
+            )
         elif self.vat_mode == "vat_incl":
-            self.product_price = product.taxes_id.compute_all(price)["total_included"]
+            self.product_price = float_round(
+                product.taxes_id.compute_all(price)["total_included"], precision
+            )
         else:
-            self.product_price = price
+            self.product_price = float_round(price, precision)
 
     @api.depends("partner_ids")
     def _compute_partner_count(self):


### PR DESCRIPTION
### Module

product_pricelist_direct_print

product_pricelist_direct_print_xlsx

### Describe the bug

Inside the cell of xlsx file, digits are not rounding according to the decimal precision establish in the view.

PR related: https://github.com/OCA/product-attribute/pull/1887

### To Reproduce

1. Configure advanced pricelist rules (in order to be more easy to reproduce the bug).
2. Create or edit a sale pricelist.

(image from runboat OCA)

![imagen](https://github.com/user-attachments/assets/9d061ba4-a348-434a-b5b6-e17a81278811)

![imagen](https://github.com/user-attachments/assets/3fa30475-7356-48cd-b33d-8db263a79ffc)

![imagen](https://github.com/user-attachments/assets/705afb4e-8592-49b5-8719-fc28db9da554)

![Selección_087](https://github.com/user-attachments/assets/26f9b1d0-c672-4b43-9314-232cde1671ec)

**Affected versions:**

16.0