### PR TITLE
[16.0][IMP] product_print_category - report wizard launch with print button

### DIFF
--- a/product_print_category/wizard/view_product_print_wizard.xml
+++ b/product_print_category/wizard/view_product_print_wizard.xml
@@ -45,6 +45,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="target">new</field>
         <field name="binding_model_id" ref="product.model_product_product" />
         <field name="binding_view_types">list,form</field>
+        <field name="binding_type">report</field>
     </record>
 
     <record
@@ -57,6 +58,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="target">new</field>
         <field name="binding_model_id" ref="product.model_product_template" />
         <field name="binding_view_types">list,form</field>
+        <field name="binding_type">report</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
In Form and List view, `Print Products` is in Print button instead of Action

![image](https://github.com/user-attachments/assets/e2f3f99c-d4f3-4f42-b4f5-104164b1739b)
