### PR TITLE
[FIX] [18.0] product_state: inefficient post_install_hook

### DIFF
--- a/product_state/__init__.py
+++ b/product_state/__init__.py
@@ -1,16 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
-
-
-def post_init_hook(env):
-    """This hook is used to add a state on existing products
-    when module product_state is installed.
-    """
-
-    product_without_state = env["product.template"].search([("state", "=", False)])
-    product_without_state.write({"state": "sellable"})
-    product_without_state = env["product.template"].search(
-        [("product_state_id", "=", False)]
-    )
-    product_without_state._inverse_product_state()
+from .hooks import post_init_hook

--- a/product_state/hooks.py
+++ b/product_state/hooks.py
@@ -1,0 +1,16 @@
+from openupgradelib.openupgrade import logged_query
+
+
+def post_init_hook(env):
+    """This hook is used to add a state on existing products
+    when module product_state is installed.
+    Using direct SQL query to avoid computational overhead.
+    """
+    logged_query(env.cr, """
+        UPDATE product_template
+        SET state = 'sellable',
+        product_state_id = (
+            SELECT id FROM product_state WHERE code = 'sellable' LIMIT 1
+        )
+        WHERE state IS NULL;
+    """)


### PR DESCRIPTION
With databases containing a large set of products, the post install hook which populates the values in the database for existing products was inefficient. The ORM could not handle this dataset. Instead, we should use direct SQL to set the appropriate values directly.