### PR TITLE
[FIX] product_dimension: product volume conversion support freedom units

### DIFF
--- a/product_dimension/models/product_product.py
+++ b/product_dimension/models/product_product.py
@@ -16,7 +16,9 @@ class ProductProduct(models.Model):
         "Dimensional UoM",
         domain=lambda self: self._get_dimension_uom_domain(),
         help="UoM for length, height, width",
-        default=lambda self: self.env.ref("uom.product_uom_meter"),
+        default=lambda self: self.env[
+            "product.template"
+        ]._get_length_uom_id_from_ir_config_parameter(),
     )
     volume = fields.Float(
         compute="_compute_volume",

--- a/product_dimension/models/product_template.py
+++ b/product_dimension/models/product_template.py
@@ -41,6 +41,15 @@ class ProductTemplate(models.Model):
             width_m = self.convert_to_meters(product_width, uom_id)
             volume = length_m * height_m * width_m
 
+        uom_cubic_meters = self.env.ref("uom.product_uom_cubic_meter")
+        to_unit = self._get_volume_uom_id_from_ir_config_parameter()
+
+        volume = uom_cubic_meters._compute_quantity(
+            qty=volume,
+            to_unit=to_unit,
+            round=False,
+        )
+
         return volume
 
     @api.depends(

--- a/product_logistics_uom/models/product_product.py
+++ b/product_logistics_uom/models/product_product.py
@@ -46,7 +46,7 @@ class ProductProduct(models.Model):
         compute="_compute_show_weight_uom_warning",
     )
 
-    @api.depends("product_volume", "product_tmpl_id.volume_uom_id")
+    @api.depends("volume", "product_tmpl_id.volume_uom_id")
     def _compute_product_volume(self):
         odoo_volume_uom = (
             self.product_tmpl_id._get_volume_uom_id_from_ir_config_parameter()


### PR DESCRIPTION
I encountered an issue with the following flow when both the product_dimension and product_logistics_uom modules are installed:
1. Set system-wide dimensions to imperial UOMs (ft, ft^3, lbs)
2. Go to a product and set dimensions
3. The volume is locked as a meters^3 value regardless of the volume set

To solve this I am multiplying the value from the product lengths, converting to meters, then convert to m^3 and then back to the UOM set on the product volume. This should support all configurations, especially those with American leanings.