### PR TITLE
[FIX] 18.0 product_status: re-align template and variant form view

### DIFF
--- a/product_status/views/product_views.xml
+++ b/product_status/views/product_views.xml
@@ -4,27 +4,34 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <group name="sale" position="inside">
-                <group name="product_status_wrapper">
+            <notebook position="inside">
+                <page name="product_status" string="Product Status">
                     <group name="product_status" string="Product Status">
-                        <field name="new_until" />
-                        <field name="discontinued_until" />
-                        <field name="end_of_life_date" />
-                        <field name="state" />
+                        <group>
+                            <field name="new_until" />
+                            <field name="discontinued_until" />
+                            <field name="end_of_life_date" />
+                            <field name="state" />
+                        </group>
+                        <group>
+                            <div class="alert alert-info" role="alert" colspan="2">
+                                By order of importance, the status is computed by:<br />
+                                <ul>
+                                <li>End-of-life</li>
+                                <li>Discontinued until</li>
+                                <li>New until</li>
+                            </ul>
+                                <strong
+                            >End-of-life</strong> has priority over the other dates.<br
+                            />
+                                <strong
+                            >Discontinued-until</strong> has priority over <strong
+                            >New until</strong>.
+                            </div>
+                        </group>
                     </group>
-                    <div class="alert alert-info" role="alert" colspan="2">
-            By order of importance, the status is computed by:<br />
-            <ul>
-                        <li>End-of-life</li>
-                        <li>Discontinued until</li>
-                        <li>New until</li>
-                    </ul>
-            <strong>End-of-life</strong> has priority over the other dates.<br />
-            <strong>Discontinued-until</strong> has priority over <strong
-                    >New until</strong>.
-          </div>
-                </group>
-            </group>
+                </page>
+            </notebook>
         </field>
     </record>
 
@@ -32,37 +39,44 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
-            <group name="sale" position="inside">
-                <group name="product_status_wrapper">
+            <notebook position="inside">
+                <page name="product_status" string="Product Status">
                     <group name="product_status" string="Product Status">
-                        <field name="has_status_date" invisible="1" />
-                        <field name="new_until" />
-                        <field name="discontinued_until" />
-                        <field name="end_of_life_date" />
-                        <field name="tmpl_new_until" invisible="has_status_date" />
-                        <field
-                            name="tmpl_discontinued_until"
-                            invisible="has_status_date"
-                        />
-                        <field
-                            name="tmpl_end_of_life_date"
-                            invisible="has_status_date"
-                        />
-                        <field name="state" />
+                        <group>
+                            <field name="has_status_date" invisible="1" />
+                            <field name="new_until" />
+                            <field name="discontinued_until" />
+                            <field name="end_of_life_date" />
+                            <field name="tmpl_new_until" invisible="has_status_date" />
+                            <field
+                                name="tmpl_discontinued_until"
+                                invisible="has_status_date"
+                            />
+                            <field
+                                name="tmpl_end_of_life_date"
+                                invisible="has_status_date"
+                            />
+                            <field name="state" />
+                        </group>
+                        <group>
+                            <div class="alert alert-info" role="alert" colspan="2">
+                                By order of importance, the status is computed by:<br />
+                                <ul>
+                                <li>End-of-life</li>
+                                <li>Discontinued until</li>
+                                <li>New until</li>
+                            </ul>
+                                <strong
+                            >End-of-life</strong> has priority over the other dates.<br
+                            />
+                                <strong
+                            >Discontinued-until</strong> has priority over <strong
+                            >New until</strong>.
+                            </div>
+                        </group>
                     </group>
-                    <div class="alert alert-info" role="alert" colspan="2">
-            By order of importance, the status is computed by:<br />
-            <ul>
-                        <li>End-of-life</li>
-                        <li>Discontinued until</li>
-                        <li>New until</li>
-                    </ul>
-            <strong>End-of-life</strong> has priority over the other dates.<br />
-            <strong>Discontinued-until</strong> has priority over <strong
-                    >New until</strong>.
-          </div>
-                </group>
-            </group>
+                </page>
+            </notebook>
         </field>
     </record>
 


### PR DESCRIPTION
This is the template view prior to the changes:
![image](https://github.com/user-attachments/assets/69f828f1-db3a-4508-a02d-b6a7e61f0458)
You can clearly see that the information groups for e-commerce are split and that the product status group has been glued to the left side of the form.

This is a screenshot of the result:
![image](https://github.com/user-attachments/assets/559b9dfd-a598-4085-aa0c-023318ec1ab0)
The product status group has been moved to its own page and now presents itself consistently without breaking the other information groups.