### PR TITLE
[16.0][REF] uom_alias: dev status -> Production/Stable

### DIFF
--- a/uom_alias/__manifest__.py
+++ b/uom_alias/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": """Adds alias for UOM""",
     "version": "16.0.1.0.0",
     "license": "LGPL-3",
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "maintainers": ["renatonlima"],


### PR DESCRIPTION
The small well tested code from the recently added `uom_alias` module that has been designed to match the features we used in `l10n_br_fiscal` (OCA/l10n-brazil repo) for a few years. At the moment `l10n_br_fiscal` is declared as Production/Stable and depend on this uom_alias module. It would suck to downgrade development status of the very central module `l10n_br_fiscal` to Beta just because of this little uom feature. So I propose to promote uom_alias to Production/Stable.

This change will  avoid the error we have now in OCA/l10n_brazil:

```
Run manifestoo -d . check-dev-status --default-dev-status=Beta
l10n_br_fiscal (Production/Stable) depends on uom_alias (Beta)
Error: Process completed with exit code 1.
```

https://github.com/OCA/l10n-brazil/actions/runs/14756809896/job/41427074549?pr=3762



cc @renatonlima @marcelsavegnago @antoniospneto