### PR TITLE
[18.0] product_set: fix archive line + improve UI

### DIFF
--- a/product_set/models/product_set.py
+++ b/product_set/models/product_set.py
@@ -9,7 +9,7 @@ class ProductSet(models.Model):
     _description = "Product set"
 
     name = fields.Char(help="Product set name", required=True, translate=True)
-    active = fields.Boolean(default=True)
+    active = fields.Boolean(default=True, inverse="_inverse_active")
     ref = fields.Char(
         string="Internal Reference", help="Product set internal reference", copy=False
     )
@@ -33,6 +33,14 @@ class ProductSet(models.Model):
     )
 
     display_name = fields.Char(compute="_compute_display_name")
+
+    def _inverse_active(self):
+        """Set the active field on the set lines."""
+        for rec in self:
+            if rec.active:
+                rec.set_line_ids.filtered(lambda x: not x.active).active = True
+            else:
+                rec.set_line_ids.filtered(lambda x: x.active).active = False
 
     @api.depends("name", "ref", "partner_id.name")
     def _compute_display_name(self):

--- a/product_set/models/product_set_line.py
+++ b/product_set/models/product_set_line.py
@@ -30,7 +30,10 @@ class ProductSetLine(models.Model):
     )
     product_set_id = fields.Many2one("product.set", string="Set", ondelete="cascade")
     active = fields.Boolean(
-        string="Active", related="product_set_id.active", store=True, readonly=True
+        compute="_compute_active",
+        readonly=False,
+        store=True,
+        default=True,
     )
     sequence = fields.Integer(required=True, default=0)
     company_id = fields.Many2one(
@@ -45,6 +48,14 @@ class ProductSetLine(models.Model):
         inverse="_inverse_product_packaging_qty",
         digits="Product Unit of Measure",
     )
+
+    def _compute_active(self):
+        """Compute the active field based on the product_set_id by default."""
+        for line in self:
+            if line.product_set_id:
+                line.active = line.product_set_id.active
+            else:
+                line.active = True
 
     @api.depends(
         "quantity",

--- a/product_set/tests/test_product_set.py
+++ b/product_set/tests/test_product_set.py
@@ -35,3 +35,30 @@ class TestProductSet(common.TransactionCase):
             product_set.read(["display_name"]),
             [{"id": product_set.id, "display_name": f"[123] Foo @ {partner.name}"}],
         )
+
+    def test_active(self):
+        """Test the archive/unarchive of the set and its lines."""
+        prod_set = self.env["product.set"].create(
+            {
+                "name": "Test",
+                "set_line_ids": [
+                    (
+                        0,
+                        0,
+                        {"product_id": self.env.ref("product.product_product_1").id},
+                    ),
+                    (
+                        0,
+                        0,
+                        {"product_id": self.env.ref("product.product_product_2").id},
+                    ),
+                ],
+            }
+        )
+        self.assertTrue(prod_set.active)
+        all_lines = prod_set.set_line_ids.with_context(active_test=False)
+        self.assertTrue(all(all_lines.mapped("active")))
+        all_lines[0].active = False
+        self.assertTrue(all_lines[1].active)
+        prod_set.active = False
+        self.assertTrue(all(not x for x in all_lines.mapped("active")))

--- a/product_set/views/product_set.xml
+++ b/product_set/views/product_set.xml
@@ -48,6 +48,7 @@
                         >
                             <list editable="top">
                                 <field name="sequence" widget="handle" />
+                                <field name="active" widget="boolean_toggle" />
                                 <field name="product_id" required="not display_type" />
                                 <field
                                     name="product_packaging_id"
@@ -91,13 +92,24 @@
         <field name="arch" type="xml">
             <search string="Product set">
                 <field name="name" select="True" />
-                <filter
-                    name="active"
-                    string="Archived"
-                    domain="[('active', '=', False)]"
-                />
                 <field name="ref" select="True" />
                 <field name="partner_id" />
+                <separator />
+                <filter
+                    string="All"
+                    name="all"
+                    domain="['|', ('active', '=', False), ('active', '=', True)]"
+                />
+                <filter
+                    string="Active"
+                    name="active"
+                    domain="[('active', '=', True)]"
+                />
+                <filter
+                    string="Archived"
+                    name="archived"
+                    domain="[('active', '=', False)]"
+                />
                 <filter
                     name="group_by_partner_id"
                     string="Partner"
@@ -114,7 +126,7 @@
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_product_set_search" />
         <field name="domain">[]</field>
-        <field name="context">{}</field>
+        <field name="context">{'active_test': False, 'search_default_all': 1}</field>
     </record>
     <record model="ir.actions.act_window.view" id="act_open_product_set_view_form">
         <field name="act_window_id" ref="act_open_product_set_view" />

--- a/product_set/views/product_set_line.xml
+++ b/product_set/views/product_set_line.xml
@@ -26,6 +26,24 @@
             <search string="Product set line">
                 <field name="product_set_id" />
                 <field name="product_id" />
+                <field name="active" />
+                <separator />
+                <filter
+                    string="All"
+                    name="all"
+                    domain="['|', ('active', '=', False), ('active', '=', True)]"
+                />
+                <filter
+                    string="Active"
+                    name="active"
+                    domain="[('active', '=', True)]"
+                />
+                <filter
+                    string="Archived"
+                    name="archived"
+                    domain="[('active', '=', False)]"
+                />
+                <separator />
                 <filter
                     name="group_by_product_set_id"
                     string="Product set"
@@ -48,6 +66,6 @@
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_product_set_line_search" />
         <field name="domain">[]</field>
-        <field name="context">{}</field>
+        <field name="context">{'search_default_all': 1}</field>
     </record>
 </odoo>


### PR DESCRIPTION
In v18 the archive/unarchive action is visible only if the field is not readonly
hence we cannot use a related field anymore.