### PR TITLE
[17.0][FIX] product_supplierinfo_for_customer: couldn't add customer price in the product variant form view

### DIFF
--- a/product_supplierinfo_for_customer/views/product_views.xml
+++ b/product_supplierinfo_for_customer/views/product_views.xml
@@ -126,6 +126,23 @@
             </xpath>
         </field>
     </record>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <field name="customer_ids" position="attributes">
+                <attribute
+                    name="context"
+                >{'default_product_tmpl_id': product_tmpl_id}</attribute>
+            </field>
+            <field name="variant_customer_ids" position="attributes">
+                <attribute
+                    name="context"
+                >{'default_product_tmpl_id': product_tmpl_id}</attribute>
+            </field>
+        </field>
+    </record>
     <record id="product_customerinfo_search_view" model="ir.ui.view">
         <field name="name">product.customerinfo.search.view</field>
         <field name="model">product.customerinfo</field>


### PR DESCRIPTION
fix the issue [1982](https://github.com/OCA/product-attribute/issues/1982)
module: product_supplierinfo_for_customer [17.0]
bug: couldn't add customer price in the product variant form view.