### PR TITLE
[16.0][IMP] product_pricelist_margin computation - allow pricelist item margin simulation

### DIFF
--- a/product_pricelist_margin/README.rst
+++ b/product_pricelist_margin/README.rst
@@ -29,6 +29,8 @@ Product Pricelist Margin
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module shows the product's cost and margin from the pricelists.
+The margin is calculated as the difference between the price and the cost, expressed as a percentage of the price.
+The price is based on the computation applied from the current pricelist item. This allows the user to make price simulations while editing the pricelist item. 
 
 **Table of contents**
 
@@ -67,6 +69,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Nguyen Minh Chien <chien@trobz.com>
+* Telmo Santos <telmo.santos@camptocamp.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_pricelist_margin/models/product_pricelist_item.py
+++ b/product_pricelist_margin/models/product_pricelist_item.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_is_zero
+from odoo.tools.float_utils import float_is_zero, float_round
 
 
 class ProductPricelistItem(models.Model):
@@ -37,16 +37,20 @@ class ProductPricelistItem(models.Model):
     )
     def _compute_margin(self):
         for item in self:
-            if item.applied_on not in ("1_product", "0_product_variant"):
+            if (
+                item.applied_on not in ("1_product", "0_product_variant")
+                or not item.product_tmpl_id
+            ):
                 item.margin = 0
                 item.margin_percent = 0
                 continue
 
-            price_rule = item.pricelist_id._compute_price_rule(
-                item.product_tmpl_id, item.min_quantity
+            price = item._compute_price(
+                item.product_tmpl_id,
+                item.min_quantity,
+                item.product_tmpl_id.uom_id,
+                fields.Datetime.now(),
             )
-
-            price = price_rule.get(item.product_tmpl_id.id, [0])[0]
 
             if float_is_zero(price, precision_digits=item.currency_id.rounding):
                 item.margin = 0
@@ -70,6 +74,7 @@ class ProductPricelistItem(models.Model):
             )
 
             item.margin = price_vat_excl - cost
-            item.margin_percent = (
-                price_vat_excl and (item.margin / price_vat_excl) * 100
+            item.margin_percent = float_round(
+                price_vat_excl and (item.margin / price_vat_excl) * 100,
+                self.env["decimal.precision"].precision_get("Product Unit of Measure"),
             )

--- a/product_pricelist_margin/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_margin/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Nguyen Minh Chien <chien@trobz.com>
+* Telmo Santos <telmo.santos@camptocamp.com>

--- a/product_pricelist_margin/readme/DESCRIPTION.rst
+++ b/product_pricelist_margin/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
 This module shows the product's cost and margin from the pricelists.
+The margin is calculated as the difference between the price and the cost, expressed as a percentage of the price.
+The price is based on the computation applied from the current pricelist item. This allows the user to make price simulations while editing the pricelist item. 

--- a/product_pricelist_margin/static/description/index.html
+++ b/product_pricelist_margin/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -276,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -302,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -371,7 +369,9 @@ ul.auto-toc {
 !! source digest: sha256:f7a304e2acd01b42ff2f6e9de3dfa6a6ee4519e2beeddba42b49fad5e8d7d0b6
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/product-attribute/tree/16.0/product_pricelist_margin"><img alt="OCA/product-attribute" src="https://img.shields.io/badge/github-OCA%2Fproduct--attribute-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/product-attribute-16-0/product-attribute-16-0-product_pricelist_margin"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/product-attribute&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module shows the product’s cost and margin from the pricelists.</p>
+<p>This module shows the product’s cost and margin from the pricelists.
+The margin is calculated as the difference between the price and the cost, expressed as a percentage of the price.
+The price is based on the computation applied from the current pricelist item. This allows the user to make price simulations while editing the pricelist item.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -414,14 +414,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li>Nguyen Minh Chien &lt;<a class="reference external" href="mailto:chien&#64;trobz.com">chien&#64;trobz.com</a>&gt;</li>
+<li>Telmo Santos &lt;<a class="reference external" href="mailto:telmo.santos&#64;camptocamp.com">telmo.santos&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_pricelist_margin/tests/test_margin.py
+++ b/product_pricelist_margin/tests/test_margin.py
@@ -37,7 +37,18 @@ class TestMargin(BaseCommon):
         )
         cls.env.ref("product.group_sale_pricelist").users |= cls.env.user
 
-    def test_margin_computation_compute_price(self):
+    def test_margin_with_fixed_price_computation(self):
         self.assertEqual(self.line.cost, 20.0)
         self.assertEqual(self.line.margin, (35 - 20))
-        self.assertEqual(self.line.margin_percent, ((35 - 20) / 35) * 100)
+        self.assertEqual(self.line.margin_percent, 42.86)
+
+        # Copy production and test that margin is computed based on current item
+        # => self.line should not impact margin of new_line
+        new_line = self.line.copy()
+        new_line.fixed_price = 40
+        self.assertEqual(new_line.margin, (40 - 20))
+        self.assertEqual(new_line.margin_percent, 50.00)
+
+    def test_margin_with_discount_computation(self):
+        self.line.write({"compute_price": "percentage", "percent_price": 0.5})
+        self.assertAlmostEqual(self.line.margin_percent, 49.75)


### PR DESCRIPTION
The following refactoring is proposed:
- The price is based on the computation applied from the current pricelist item. This allows the user to make price simulations while editing the pricelist item. 
