### PR TITLE
[18.0] product_packaging_level_salable: drop useless code

### DIFF
--- a/product_packaging_level_salable/models/sale_order_line.py
+++ b/product_packaging_level_salable/models/sale_order_line.py
@@ -25,20 +25,6 @@ class SaleOrderLine(models.Model):
                     )
                 )
 
-    @api.onchange("product_packaging_id")
-    def _onchange_product_packaging_id(self):
-        if self._can_be_sold_error_condition():
-            return {
-                "warning": {
-                    "title": self.env._("Warning"),
-                    "message": self.env._(
-                        "This product packaging must be set as 'Sales' in"
-                        " order to be used on a sale order."
-                    ),
-                },
-            }
-        return super()._onchange_product_packaging_id()
-
     @api.depends("product_id", "product_uom_qty", "product_uom")
     def _compute_product_packaging_id(self):
         res = super()._compute_product_packaging_id()

--- a/product_packaging_level_salable/tests/test_packaging_level_can_be_sold.py
+++ b/product_packaging_level_salable/tests/test_packaging_level_can_be_sold.py
@@ -25,11 +25,6 @@ class TestPackagingLevelCanBeSold(Common):
                 {"product_packaging_id": self.packaging_cannot_be_sold.id}
             )
 
-    def test_onchange_product_packaging_id(self):
-        self.order_line.write({"product_packaging_id": self.packaging_tu.id})
-        result = self.order_line._onchange_product_packaging_id()
-        self.assertIn("warning", result)
-
     def test_product_packaging_can_be_sold(self):
         """Check that a product.packaging can be independently set as can be sold."""
         exception_msg = (


### PR DESCRIPTION
The packaging field has already a proper domain to select only pkg that are sale-able and belong to the product. There's no need for the onchange.