### PR TITLE
[17.0][FIX] product_secondary_unit: ensure qty persists.

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -119,6 +119,10 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
                 rec.secondary_uom_qty * factor,
                 precision_rounding=rec._get_uom_line().rounding,
             )
+            # To avoid resetting the primary quantity to 0.0
+            if not rec.secondary_uom_qty:
+                # Don't modify the primary quantity - preserve it
+                continue
             rec[rec._secondary_unit_fields["qty_field"]] = qty
 
     def _onchange_helper_product_uom_for_secondary(self):

--- a/product_secondary_unit/tests/test_secondary_unit_mixin.py
+++ b/product_secondary_unit/tests/test_secondary_unit_mixin.py
@@ -129,3 +129,23 @@ class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
         fake_model.write({"secondary_uom_qty": 4})
         self.assertEqual(fake_model.product_uom_qty, 17)
         self.assertEqual(fake_model.secondary_uom_qty, 4)
+
+    def test_independent_type_with_existing_qty(self):
+        """Test assigning secondary_uom_id to a record with existing qty.
+
+        This should not reset product_uom_qty to 0.0,
+        then switching to independent type, the original qty should be preserved.
+        """
+        fake_model = self.secondary_unit_fake
+        fake_model.product_uom_qty = 10.0
+        fake_model.secondary_uom_id = self.secondary_unit_box_5
+        fake_model.secondary_uom_id.write({"dependency_type": "independent"})
+
+        self.assertFalse(fake_model.secondary_uom_qty)
+        previous_product_uom_qty = fake_model.product_uom_qty
+
+        self.assertEqual(previous_product_uom_qty, 10.0)
+        fake_model.write({"secondary_uom_qty": 2})
+
+        self.assertEqual(fake_model.product_uom_qty, previous_product_uom_qty)
+        self.assertEqual(fake_model.secondary_uom_qty, 2)


### PR DESCRIPTION
Problem occurred after `sale_stock` module [update](https://github.com/versada/odoo/commit/6f39273bc58337a6cf7015d79ffa46597f050b76). 

**Description**
After new `write` method update in `sale.order.line`,  line change triggers sec uom qty calculation and test fails in `sale_order_secondary_unit` module.

**Current Behaviour**
Test fails:
```python
2025-06-11 03:44:49,795 1 INFO odoodb odoo.addons.sale_order_secondary_unit.tests.test_sale_order: ======================================================================
Error: 2025-06-11 03:44:49,795 1 ERROR odoodb odoo.addons.sale_order_secondary_unit.tests.test_sale_order: FAIL: TestSaleOrder.test_independent_type

"/opt/odoo/projects/sale-workflow/sale_order_secondary_unit/tests/test_sale_order.py", line 95, in test_independent_type
   self.assertEqual(self.order.order_line.product_uom_qty, previous_uom_qty)
pr=2890#step:8:3432)AssertionError: 1.0 != 0.0
``` 


**Expected Behavior**
Test does not fail. Setting secondary_uom_id on line (at the moment when secondary qty is not set), won't reset existing product_uom_qty .

**Proposed implementation**
Check if secondary_uom_qty exists, if not - do not continue calculation and do not reset qty. 

