### PR TITLE
[18.0][FIX] product_secondary_unit: restore search by code and name

### DIFF
--- a/product_secondary_unit/models/product_second_unit.py
+++ b/product_secondary_unit/models/product_second_unit.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 class ProductSecondaryUnit(models.Model):
     _name = "product.secondary.unit"
     _description = "Product Secondary Unit"
+    _rec_names_search = ["name", "code"]
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char()
@@ -46,14 +47,3 @@ class ProductSecondaryUnit(models.Model):
     def _compute_display_name(self):
         for unit in self:
             unit.display_name = f"{unit.name}-{unit.factor}"
-
-    @api.model
-    def name_search(self, name="", args=None, operator="ilike", limit=100):
-        if args is None:
-            args = []
-        units = self.search([("code", "=", name)] + args, limit=1)
-        if not units:
-            return super().name_search(
-                name=name, args=args, operator=operator, limit=limit
-            )
-        return [(unit.id, unit.sudo().display_name) for unit in units]


### PR DESCRIPTION
Before this fix:
![image](https://github.com/user-attachments/assets/342b0c68-8052-4952-9a84-049bb77da398)

After this fix:
![image](https://github.com/user-attachments/assets/be98e1c9-5a1d-4a87-9820-fba9b046f447)

In v15:
![image](https://github.com/user-attachments/assets/382f6f7b-eaba-4701-897a-3393ea66334b)

@pedrobaeza @carlos-lopez-tecnativa please review