### PR TITLE
[18.0][FIX] product_state: Field 'id' is not defined in domain of action_open_state_products

### DIFF
--- a/product_state/views/product_template_views.xml
+++ b/product_state/views/product_template_views.xml
@@ -5,7 +5,7 @@
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,form,list</field>
         <field name="context">{}</field>
-        <field name="domain">[('product_state_id', '=', id)]</field>
+        <field name="domain">[('product_state_id', '=', active_id)]</field>
     </record>
     <record id="view_product_template_search_state" model="ir.ui.view">
         <field name="name">product.template.search.state</field>


### PR DESCRIPTION
- Go to Sales \> Configuration \> Products \> Product States. 
- This will fix the application error when the user click button Products in header of Product State 
  <img width="1520" height="820" alt="image" src="https://github.com/user-attachments/assets/241d4cae-0c67-4769-9f84-4a58c455e77d" />