### PR TITLE
[18.0][FIX] product_packaging_unit_price_calculator: pop-up default product_tmpl_id

### DIFF
--- a/product_packaging_unit_price_calculator/__manifest__.py
+++ b/product_packaging_unit_price_calculator/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Product Packaging Unit Price Calculator",
     "summary": "Wizard to calculate a unit price from a packaging price",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Product",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/product_packaging_unit_price_calculator/wizards/product_package_price.xml
+++ b/product_packaging_unit_price_calculator/wizards/product_package_price.xml
@@ -5,6 +5,8 @@
         <field name="model">product.package.price.wizard</field>
         <field name="arch" type="xml">
             <form string="Product Packaging Price">
+                <!-- Used for default product_tmpl_id when pop-up wizard -->
+                <field name="product_tmpl_id" invisible="1" />
                 <group name="main">
                     <group name="package_price_group">
                         <field name="packaging_price" />


### PR DESCRIPTION
## Issue
When setting packaging on a product variant and clicking the **"Packaging Prices"** button, Odoo does not automatically populate the default packaging.

## Steps to Reproduce

1. Install the following modules:
   - `stock`
   - `product_packaging_unit_price_calculator`
2. Assign the **"Manage Product Packaging"** access rights to your user.
3. Go to **Inventory > Products > Product Variants**.
4. Add two packaging options to a product variant.
5. Click the **"Packaging Prices"** button.

Before:
<img width="1466" height="864" alt="image" src="https://github.com/user-attachments/assets/5a96ccb4-ddc8-4e14-a2a9-0d4816ef39cb" />
After:
<img width="1466" height="864" alt="image" src="https://github.com/user-attachments/assets/1fd84818-130f-4f35-9803-202c016b6b3c" />

