### PR TITLE
[16.0][IMP] product_pricelist_margin original vs final price

### DIFF
--- a/product_pricelist_margin/i18n/fr.pot
+++ b/product_pricelist_margin/i18n/fr.pot
@@ -35,6 +35,16 @@ msgid "Margin"
 msgstr "Marge"
 
 #. module: product_pricelist_margin
+#: model:ir.model.fields,field_description:product_pricelist_margin.field_product_pricelist_item__original_price
+msgid "Original Price"
+msgstr ""
+
+#. module: product_pricelist_margin
+#: model:ir.model.fields,help:product_pricelist_margin.field_product_pricelist_item__original_price
+msgid "Original price before applying this pricelist item."
+msgstr ""
+
+#. module: product_pricelist_margin
 #: model:ir.model.fields,field_description:product_pricelist_margin.field_product_pricelist_item__margin_percent
 msgid "Margin (%)"
 msgstr "Marge (%)"

--- a/product_pricelist_margin/i18n/product_pricelist_margins.pot
+++ b/product_pricelist_margin/i18n/product_pricelist_margins.pot
@@ -21,6 +21,16 @@ msgid "Cost"
 msgstr ""
 
 #. module: product_pricelist_margin
+#: model:ir.model.fields,field_description:product_pricelist_margin.field_product_pricelist_item__final_price
+msgid "Final Price"
+msgstr "Prix Final"
+
+#. module: product_pricelist_margin
+#: model:ir.model.fields,help:product_pricelist_margin.field_product_pricelist_item__final_price
+msgid "Final price after applying this pricelist item."
+msgstr "Prix final après application de cet item de la liste de prix."
+
+#. module: product_pricelist_margin
 #: model:ir.model.fields,help:product_pricelist_margin.field_product_pricelist_item__cost
 msgid ""
 "In Standard Price & AVCO: value of the product (automatically computed in AVCO).\n"
@@ -33,6 +43,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:product_pricelist_margin.field_product_pricelist_item__margin
 msgid "Margin"
 msgstr ""
+
+#. module: product_pricelist_margin
+#: model:ir.model.fields,field_description:product_pricelist_margin.field_product_pricelist_item__original_price
+msgid "Original Price"
+msgstr "Prix d'origine"
+
+#. module: product_pricelist_margin
+#: model:ir.model.fields,help:product_pricelist_margin.field_product_pricelist_item__original_price
+msgid "Original price before applying this pricelist item."
+msgstr "Prix original avant l'application de cet item de la liste de prix."
 
 #. module: product_pricelist_margin
 #: model:ir.model.fields,field_description:product_pricelist_margin.field_product_pricelist_item__margin_percent

--- a/product_pricelist_margin/models/product_pricelist_item.py
+++ b/product_pricelist_margin/models/product_pricelist_item.py
@@ -20,6 +20,14 @@ class ProductPricelistItem(models.Model):
         string="Margin (%)",
         compute="_compute_margin",
     )
+    original_price = fields.Float(
+        compute="_compute_margin",
+        help="Original price before applying this pricelist item.",
+    )
+    final_price = fields.Float(
+        compute="_compute_margin",
+        help="Final price after applying this pricelist item.",
+    )
 
     @api.depends(
         "compute_price",
@@ -43,6 +51,8 @@ class ProductPricelistItem(models.Model):
             ):
                 item.margin = 0
                 item.margin_percent = 0
+                item.original_price = 0
+                item.final_price = 0
                 continue
 
             price = item._compute_price(
@@ -55,6 +65,8 @@ class ProductPricelistItem(models.Model):
             if float_is_zero(price, precision_digits=item.currency_id.rounding):
                 item.margin = 0
                 item.margin_percent = 0
+                item.original_price = 0
+                item.final_price = 0
                 continue
 
             current_company = self.env.company
@@ -66,13 +78,19 @@ class ProductPricelistItem(models.Model):
                 item.currency_id,
                 product=item.product_tmpl_id,
             )
-
             price_vat_excl = res["total_excluded"]
 
             cost = self.env.user.company_id.currency_id.compute(
                 item.cost, item.currency_id
             )
-
+            pricelist = item.pricelist_id._origin or item.pricelist_id
+            item.original_price = pricelist._get_product_price(
+                item.product_tmpl_id,
+                item.min_quantity,
+                item.product_tmpl_id.uom_id,
+                fields.Datetime.now(),
+            )
+            item.final_price = price_vat_excl
             item.margin = price_vat_excl - cost
             item.margin_percent = float_round(
                 price_vat_excl and (item.margin / price_vat_excl) * 100,

--- a/product_pricelist_margin/tests/test_margin.py
+++ b/product_pricelist_margin/tests/test_margin.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.tests import Form
 from odoo.tests.common import tagged
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -52,3 +53,23 @@ class TestMargin(BaseCommon):
     def test_margin_with_discount_computation(self):
         self.line.write({"compute_price": "percentage", "percent_price": 0.5})
         self.assertAlmostEqual(self.line.margin_percent, 49.75)
+
+    def test_original_vs_final_price(self):
+        pricelist_form = Form(self.pricelist)
+        with pricelist_form.item_ids.new() as item_form:
+            item_form.compute_price = "fixed"
+            item_form.applied_on = "1_product"
+            item_form.product_tmpl_id = self.product.product_tmpl_id
+            item_form.fixed_price = 50.0
+            item_form.min_quantity = 1
+            self.assertEqual(item_form.original_price, 35.0)
+            self.assertEqual(item_form.final_price, 50.0)
+        self.pricelist = pricelist_form.save()
+        with pricelist_form.item_ids.new() as item_form:
+            item_form.compute_price = "percentage"
+            item_form.applied_on = "1_product"
+            item_form.product_tmpl_id = self.product.product_tmpl_id
+            item_form.percent_price = 50.0
+            item_form.min_quantity = 1
+            self.assertEqual(item_form.original_price, 50.0)
+            self.assertEqual(item_form.final_price, 40.0 * 0.5)

--- a/product_pricelist_margin/views/product_pricelist_item_views.xml
+++ b/product_pricelist_margin/views/product_pricelist_item_views.xml
@@ -9,6 +9,8 @@
                 <field name="cost" invisible="1" />
                 <field name="margin" optional="show" />
                 <field name="margin_percent" optional="show" />
+                <field name="original_price" optional="hide" />
+                <field name="final_price" optional="hide" />
             </field>
         </field>
     </record>
@@ -41,6 +43,8 @@
                     <field name="cost" invisible="1" />
                     <field name="margin" />
                     <field name="margin_percent" />
+                    <field name="original_price" />
+                    <field name="final_price" />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
With this development, when the user adds an item to the price list, the original price can be compared with the final price after the item has been applied.

Original price: The price of the product before applying this item.
Final price: The price of the product after applying this item.