### PR TITLE
[18.0][IMP] product_packaging_level_salable: warning if not pack multiple

### DIFF
--- a/product_packaging_level_salable/__manifest__.py
+++ b/product_packaging_level_salable/__manifest__.py
@@ -14,5 +14,6 @@
     "depends": ["product_packaging_level", "sale_stock"],
     "data": [
         "views/product_packaging_level.xml",
+        "views/res_config_settings.xml",
     ],
 }

--- a/product_packaging_level_salable/models/__init__.py
+++ b/product_packaging_level_salable/models/__init__.py
@@ -1,3 +1,5 @@
 from . import product_packaging
 from . import product_packaging_level
 from . import sale_order_line
+from . import res_company
+from . import res_config_settings

--- a/product_packaging_level_salable/models/res_company.py
+++ b/product_packaging_level_salable/models/res_company.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    sale_check_packaging_multiple = fields.Boolean()

--- a/product_packaging_level_salable/models/res_config_settings.py
+++ b/product_packaging_level_salable/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_check_packaging_multiple = fields.Boolean(
+        related="company_id.sale_check_packaging_multiple",
+        readonly=False,
+    )

--- a/product_packaging_level_salable/models/sale_order_line.py
+++ b/product_packaging_level_salable/models/sale_order_line.py
@@ -12,6 +12,9 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return self.product_packaging_id and not self.product_packaging_id.sales
 
+    def _is_packaging_multiple_check_enabled(self):
+        return self.env.company.sale_check_packaging_multiple
+
     @api.constrains("product_packaging_id")
     def _check_product_packaging_can_be_sold(self):
         for line in self:

--- a/product_packaging_level_salable/models/sale_order_line.py
+++ b/product_packaging_level_salable/models/sale_order_line.py
@@ -1,8 +1,11 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+# Copyright 2020 Odoo SA (`_check_pkg_qty_multiple` method)
+# License LGPL-3.0 (https://https://www.gnu.org/licenses/lgpl-3.0)
 
 from odoo import api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_compare, float_round
 
 
 class SaleOrderLine(models.Model):
@@ -28,6 +31,16 @@ class SaleOrderLine(models.Model):
                     )
                 )
 
+    @api.constrains("product_id", "product_packaging_qty", "product_uom_qty")
+    def _check_product_packaging_qty_multiple(self):
+        if not self._is_packaging_multiple_check_enabled():
+            return
+        for line in self:
+            if not line.product_uom_qty:
+                continue
+            if error_message_qty_multiple := line._check_pkg_qty_multiple():
+                raise ValidationError(error_message_qty_multiple)
+
     @api.depends("product_id", "product_uom_qty", "product_uom")
     def _compute_product_packaging_id(self):
         res = super()._compute_product_packaging_id()
@@ -35,3 +48,33 @@ class SaleOrderLine(models.Model):
             if line.product_packaging_id and not line.product_packaging_id.sales:
                 line.product_packaging_id = False
         return res
+
+    def _check_pkg_qty_multiple(self):
+        # Ported from sale_stock.models.sale_order_line,_check_package on v14
+        default_uom = self.product_id.uom_id
+        pack = self.product_packaging_id
+        qty = self.product_uom_qty
+        q = default_uom._compute_quantity(pack.qty, self.product_uom)
+        # We do not use the modulo operator to check if qty is a multiple of q.
+        # Indeed the qty per package might be a float, leading to incorrect results.
+        # For example: 8 % 1.6 = 1.5999999999999996
+        #              5.4 % 1.8 = 2.220446049250313e-16
+        if (
+            qty
+            and q
+            and float_compare(
+                qty / q,
+                float_round(qty / q, precision_rounding=1.0),
+                precision_rounding=0.001,
+            )
+            != 0
+        ):
+            next_valid_qty = qty - (qty % q) + q
+            return self.env._(
+                "This product is packaged by %(pack_size).2f %(pack_name)s. "
+                + "You should sell %(quantity).2f %(unit)s.",
+                pack_size=pack.qty,
+                pack_name=default_uom.name,
+                quantity=next_valid_qty,
+                unit=self.product_uom.name,
+            )

--- a/product_packaging_level_salable/tests/test_packaging_level_can_be_sold.py
+++ b/product_packaging_level_salable/tests/test_packaging_level_can_be_sold.py
@@ -50,3 +50,21 @@ class TestPackagingLevelCanBeSold(Common):
         # Changing the can_be_sold on the packaging_level does not update the packaging
         self.packaging_level_cannot_be_sold.can_be_sold = True
         self.assertEqual(self.packaging_cannot_be_sold.sales, False)
+
+    def test_check_pkg_qty_multiple(self):
+        """Test the _check_pkg_qty_multiple method in different scenarios."""
+        self.order_line.write(
+            {
+                "product_packaging_id": self.packaging_tu.id,
+                "product_uom_qty": 20.0,  # Is multiple of packaging quantity
+            }
+        )
+        # sale_check_packaging_multiple False by default - no error
+        self.order_line.product_uom_qty = 25.0
+
+        # Set a quantity that is not a multiple of the packaging quantity
+        self.env.company.sale_check_packaging_multiple = True
+        with self.assertRaisesRegex(
+            ValidationError, r"This product is packaged by.*You should sell"
+        ):
+            self.order_line.product_uom_qty = 25.0

--- a/product_packaging_level_salable/views/res_config_settings.xml
+++ b/product_packaging_level_salable/views/res_config_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record
+        id="res_config_settings_view_form_product_packaging_level_salable"
+        model="ir.ui.view"
+    >
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <setting id="order_warnings" position="after">
+                <setting
+                    id="sale_check_packaging_multiple"
+                    help="Allow selling products if quantity is multiple of packaging units."
+                    company_dependent="1"
+                >
+                    <field name="sale_check_packaging_multiple" />
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The validation that checks whether the quantity on a sales order line is a multiple of the package quantity was present in v14. This PR restores this functionality to raise a warning on sale order.

To achieve this, the PR also adds a company related configuration parameter (packaging_multiple) to be defined at the company level, which can be used in constraints or in any context where this feature needs to be disabled.