### PR TITLE
[18.0][FIX] product_set: fix product set search behavior

### DIFF
--- a/product_set/models/product_set.py
+++ b/product_set/models/product_set.py
@@ -32,7 +32,9 @@ class ProductSet(models.Model):
         "it's going to be available for all of them.",
     )
 
-    display_name = fields.Char(compute="_compute_display_name")
+    display_name = fields.Char(
+        compute="_compute_display_name", search="_search_display_name"
+    )
 
     def _inverse_active(self):
         """Set the active field on the set lines."""
@@ -52,3 +54,13 @@ class ProductSet(models.Model):
             if rec.partner_id and rec.partner_id.name:
                 parts.append(f"@ {rec.partner_id.name}")
             rec.display_name = " ".join(map(str, parts))
+
+    @api.model
+    def _search_display_name(self, operator, value):
+        return [
+            "|",
+            "|",
+            ("name", operator, value),
+            ("ref", operator, value),
+            ("partner_id.name", operator, value),
+        ]


### PR DESCRIPTION
This PR fixes the user experience when selecting product sets in forms by enhancing the _search_display_name behavior. Product sets are now easier to find through the standard search field.

Before:
Searching for a product set by keywords did not always return relevant results unless "Search more..." was used.
<img width="560" height="293" alt="image" src="https://github.com/user-attachments/assets/b25b3185-6df5-41b8-ae65-5aae9a4163ef" />

After:
The _search_display_name method is now extended to fix matching, making relevant product sets appear directly in the autocomplete suggestions.
<img width="564" height="289" alt="image" src="https://github.com/user-attachments/assets/83647038-99ee-4214-a6df-b6d453dea84e" />