### PR TITLE
[18.0][FIX] product_assortment: TypeError:  An incorrect keyword argument (vals_list) was passed 

### DIFF
--- a/product_assortment/models/ir_filters.py
+++ b/product_assortment/models/ir_filters.py
@@ -73,7 +73,7 @@ class IrFilters(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self._update_assortment_default_values(vals_list=vals_list)
+        self._update_assortment_default_values(vals_list)
         return super().create(vals_list)
 
     @api.model


### PR DESCRIPTION
Fixes:
TypeError

An incorrect keyword argument (vals_list) was passed to a superclass's create method.

Fix:
Modify the create method in product_assortment to pass vals_list as a positional argument.