### PR TITLE
[FIX] product_packaging_level: Allow to input packaging name depending on name policy

### DIFF
--- a/product_packaging_level/views/product_packaging_view.xml
+++ b/product_packaging_level/views/product_packaging_view.xml
@@ -16,7 +16,7 @@
                 <attribute name="required">barcode_required_for_gtin</attribute>
             </xpath>
             <field name="name" position="attributes">
-                <attribute name="column_invisible">1</attribute>
+                <attribute name="readonly">name_policy != 'user_defined'</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
On product form, the user was not allowed to fill in the packaging name even if the name policy is set on 'user_defined'.