### PR TITLE
[16.0][IMP] product_supplierinfo_for_customer: extend partner to look for parent also

### DIFF
--- a/product_supplierinfo_for_customer/models/product_product.py
+++ b/product_supplierinfo_for_customer/models/product_product.py
@@ -5,6 +5,7 @@
 import datetime
 
 from odoo import api, models
+from odoo.osv import expression
 
 
 class ProductProduct(models.Model):
@@ -110,14 +111,32 @@ class ProductProduct(models.Model):
     def _prepare_domain_customerinfo(self, params):
         self.ensure_one()
         partner_id = params.get("partner_id")
-        return [
-            ("partner_id", "=", partner_id),
+        domain = [
             "|",
             ("product_id", "=", self.id),
             "&",
             ("product_tmpl_id", "=", self.product_tmpl_id.id),
             ("product_id", "=", False),
         ]
+        if partner_id:
+            partner = self.env["res.partner"].browse(partner_id)
+            domain = expression.AND(
+                [
+                    domain,
+                    [
+                        (
+                            "partner_id",
+                            "in",
+                            (
+                                partner
+                                + partner.parent_id
+                                + partner.commercial_partner_id
+                            ).ids,
+                        )
+                    ],
+                ]
+            )
+        return domain
 
     def _select_customerinfo(
         self, partner=False, _quantity=0.0, _date=None, _uom_id=False, params=False

--- a/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
+++ b/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
@@ -185,3 +185,33 @@ class TestProductSupplierinfoForCustomer(TransactionCase):
             "partner", product_1.uom_id, self.company.currency_id, self.company
         )
         self.assertEqual(res[product_1.id], 10.0)
+
+    def test_child_customer_pricing(self):
+        """Test pricing for child contact of a parent customer"""
+        # Create child contact
+        child_customer = self._create_customer("child_customer")
+        child_customer.parent_id = self.customer.id
+        child_customer.is_company = False
+
+        # Create customerinfo for parent
+        self._create_partnerinfo("customer", self.customer, self.product)
+
+        # Test that child inherits pricing from parent
+        price = self.product._get_price_from_customerinfo(partner_id=child_customer.id)
+        self.assertEqual(
+            price, 100.0, "Error: Child customer should inherit price from parent"
+        )
+
+        # Test price computation with child customer context
+        res = self.product.with_context(partner_id=child_customer.id).price_compute(
+            "partner", self.product.uom_id, self.company.currency_id, self.company
+        )
+        self.assertEqual(
+            res[self.product.id], 100.0, "Error: Wrong price for child customer"
+        )
+
+        # Test pricelist with child customer
+        price, rule_id = self.pricelist._get_product_price_rule(
+            self.product, 1, partner=child_customer
+        )
+        self.assertEqual(price, 100.0, "Error: Price not found for child customer")


### PR DESCRIPTION
Code taken from v14, in order to search customerinfo of addresses using its parent partner.