### PR TITLE
[18.0][FIX] product_pricelist_supplierinfo: compute pricelist item description

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
+from odoo.tools import format_amount
 
 
 class ProductPricelistItem(models.Model):
@@ -42,3 +43,41 @@ class ProductPricelistItem(models.Model):
                 quantity=quantity,
             )
         return result
+
+    def _compute_price_label(self):
+        pricelist_items_to_update = self.filtered(
+            lambda r: r.compute_price != "fixed" and r.base == "supplierinfo"
+        )
+        for item in pricelist_items_to_update:
+            base_str = self.env._("supplier's price")
+            # Replicate standard label computation with new base string
+            extra_fee_str = ""
+            if item.price_surcharge > 0:
+                extra_fee_str = self.env._(
+                    "+ %(amount)s extra fee",
+                    amount=format_amount(
+                        item.env,
+                        abs(item.price_surcharge),
+                        currency=item.currency_id,
+                    ),
+                )
+            elif item.price_surcharge < 0:
+                extra_fee_str = self.env._(
+                    "- %(amount)s rebate",
+                    amount=format_amount(
+                        item.env,
+                        abs(item.price_surcharge),
+                        currency=item.currency_id,
+                    ),
+                )
+            discount_type, percentage = self._get_displayed_discount(item)
+            item.price = self.env._(
+                "%(percentage)s %% %(discount_type)s on %(base)s %(extra)s",
+                percentage=percentage,
+                discount_type=discount_type,
+                base=base_str,
+                extra=extra_fee_str,
+            )
+        return super(
+            ProductPricelistItem, self - pricelist_items_to_update
+        )._compute_price_label()

--- a/product_pricelist_supplierinfo/readme/CONTRIBUTORS.md
+++ b/product_pricelist_supplierinfo/readme/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - [TAKOBI](https://takobi.online/):
   - Lorenzo Battistini
 - Andrea Gidalti \<<andreag@vauxoo.com>\>
+- Maciej Wichowski \<<maciej@versada.eu>\>

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -352,3 +352,9 @@ class TestProductSupplierinfo(BaseCommon):
             self.pricelist.item_ids[0]
         )
         self.assertAlmostEqual(price, 0)
+
+    def test_pricelist_item_label(self):
+        """Test if the pricelist label shows correct information on base price"""
+        self.assertEqual(
+            self.pricelist.item_ids.price, "0 % discount on supplier's price "
+        )


### PR DESCRIPTION
`price` field in `product.pricelist.item` is computed and provides 
description of applied price rules. The description computation is
based on applied formula and options chosen in `compute_price` field.

`product_pricelist_supplierinfo` adds new selection to `compute_price`
field. This option was not included in `price` computation resulting
in incorrect price description - for example "10% discount on sales 
price". 

This fix corrects the price description computation by including 
"supplier's price" label - for example "10% discount on supplier's 
price".

Before:
<img width="1261" height="631" alt="image" src="https://github.com/user-attachments/assets/d9dc3900-0b3a-45b1-8ff1-3623410612f0" />

After:
<img width="1261" height="631" alt="image" src="https://github.com/user-attachments/assets/17d6c73d-bc21-48c2-9fb3-7138f4f5e239" />
