### PR TITLE
[18.0][FW] product_supplierinfo_for_customer: multiple ports from 16.0 + commercial partner and parent in _name_search

### DIFF
--- a/product_customerinfo/models/product_customerinfo.py
+++ b/product_customerinfo/models/product_customerinfo.py
@@ -25,8 +25,13 @@ class ProductCustomerInfo(models.Model):
 
     @api.model
     def _get_name_search_domain(self, partner_id, operator, name):
+        # NOTE: Ideally we could use child_of operator here instead
+        # of building top level commercial partner + parent + current contact
+        partner = self.env["res.partner"].browse(partner_id)
+        partner_ids = (partner + partner.parent_id + partner.commercial_partner_id).ids
+
         return [
-            ("partner_id", "=", partner_id),
+            ("partner_id", "in", partner_ids),
             "|",
             ("product_code", operator, name),
             ("product_name", operator, name),

--- a/product_customerinfo/models/product_product.py
+++ b/product_customerinfo/models/product_product.py
@@ -85,14 +85,32 @@ class ProductProduct(models.Model):
     def _prepare_domain_customerinfo(self, params):
         self.ensure_one()
         partner_id = params.get("partner_id")
-        return [
-            ("partner_id", "=", partner_id),
+        domain = [
             "|",
             ("product_id", "=", self.id),
             "&",
             ("product_tmpl_id", "=", self.product_tmpl_id.id),
             ("product_id", "=", False),
         ]
+        if partner_id:
+            partner = self.env["res.partner"].browse(partner_id)
+            domain = expression.AND(
+                [
+                    domain,
+                    [
+                        (
+                            "partner_id",
+                            "in",
+                            (
+                                partner
+                                + partner.parent_id
+                                + partner.commercial_partner_id
+                            ).ids,
+                        )
+                    ],
+                ]
+            )
+        return domain
 
     def _select_customerinfo(
         self, partner=False, _quantity=0.0, _date=None, _uom_id=False, params=False

--- a/product_customerinfo/models/product_product.py
+++ b/product_customerinfo/models/product_product.py
@@ -109,7 +109,7 @@ class ProductProduct(models.Model):
         any_match = self.env["product.customerinfo"].search(
             domain, order="sequence,min_qty,price,id"
         )
-        first_template_match = None
+        first_template_match = self.env["product.customerinfo"].browse()
         # return the first customer_info matching the variant
         # otherwise the first one matching the template
         for customer_info in any_match:

--- a/product_customerinfo/models/product_product.py
+++ b/product_customerinfo/models/product_product.py
@@ -105,10 +105,20 @@ class ProductProduct(models.Model):
             params = dict()
         params.update({"partner_id": partner.id})
         domain = self._prepare_domain_customerinfo(params)
-        res = (
-            self.env["product.customerinfo"]
-            .search(domain)
-            .sorted(lambda s: (s.sequence, s.min_qty, s.price, s.id))
+        # Search for customerinfo records based on the domain
+        any_match = self.env["product.customerinfo"].search(
+            domain, order="sequence,min_qty,price,id"
         )
-        res_1 = res.sorted("product_tmpl_id")[:1]
-        return res_1
+        first_template_match = None
+        # return the first customer_info matching the variant
+        # otherwise the first one matching the template
+        for customer_info in any_match:
+            if customer_info.product_id == self:
+                return customer_info
+            if (
+                not customer_info.product_id
+                and not first_template_match
+                and customer_info.product_tmpl_id == self.product_tmpl_id
+            ):
+                first_template_match = customer_info
+        return first_template_match

--- a/product_customerinfo/tests/test_product_customerinfo.py
+++ b/product_customerinfo/tests/test_product_customerinfo.py
@@ -183,3 +183,33 @@ class TestProductSupplierinfoForCustomer(BaseCommon):
             "partner", product_1.uom_id, self.company.currency_id, self.company
         )
         self.assertEqual(res[product_1.id], 10.0)
+
+    def test_child_customer_pricing(self):
+        """Test pricing for child contact of a parent customer"""
+        # Create child contact
+        child_customer = self._create_customer("child_customer")
+        child_customer.parent_id = self.customer.id
+        child_customer.is_company = False
+
+        # Create customerinfo for parent
+        self._create_partnerinfo("customer", self.customer, self.product)
+
+        # Test that child inherits pricing from parent
+        price = self.product._get_price_from_customerinfo(partner_id=child_customer.id)
+        self.assertEqual(
+            price, 100.0, "Error: Child customer should inherit price from parent"
+        )
+
+        # Test price computation with child customer context
+        res = self.product.with_context(partner_id=child_customer.id)._price_compute(
+            "partner", self.product.uom_id, self.company.currency_id, self.company
+        )
+        self.assertEqual(
+            res[self.product.id], 100.0, "Error: Wrong price for child customer"
+        )
+
+        # Test pricelist with child customer
+        price, rule_id = self.pricelist._get_product_price_rule(
+            self.product, 1, partner=child_customer
+        )
+        self.assertEqual(price, 100.0, "Error: Price not found for child customer")


### PR DESCRIPTION
Same commits as:

https://github.com/OCA/product-attribute/pull/2057