### PR TITLE
[18.0][FIX] product_secondary_unit: don't show inactive UoMs

### DIFF
--- a/product_secondary_unit/views/product_views.xml
+++ b/product_secondary_unit/views/product_views.xml
@@ -28,7 +28,7 @@
                             />
                             <field name="code" />
                             <field name="name" />
-                            <field name="uom_id" />
+                            <field name="uom_id" context="{'active_test': True}" />
                             <field name="factor" />
                             <field name="dependency_type" />
                         </list>


### PR DESCRIPTION
Because of the active test context in the one2many on product, inactive UoM's would show when this is not the intention