### PR TITLE
[16.0] [IMP] product_packaging_dimension: Add packaging dimensions as optional columns

### DIFF
--- a/product_packaging_dimension/views/product_packaging.xml
+++ b/product_packaging_dimension/views/product_packaging.xml
@@ -53,4 +53,16 @@
             </group>
         </field>
     </record>
+    <record id="product_packaging_tree_view2_dimensions" model="ir.ui.view">
+        <field name="name">product.packaging.tree.view2.dimensions</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_tree_view2" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree[@name='packaging']" position="inside">
+                <field name="packaging_length" optional="hide" />
+                <field name="width" optional="hide" />
+                <field name="height" optional="hide" />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION

Add packaging_length, width and height fields as optional columns in the product packaging one2many tree view within the product form.


In the product form, the packaging one2many tree view doesn't show the dimension fields (length, width, height), making it difficult to quickly compare packaging dimensions without opening each packaging record individually.

Users can optionally display the packaging dimensions columns in the one2many tree view within the product form, allowing quick comparison of packaging sizes directly from the product view.