### PR TITLE
[18.0][IMP] product_customerinfo: Change terms to customer + Usability for variant creation

### DIFF
--- a/product_customerinfo/README.rst
+++ b/product_customerinfo/README.rst
@@ -32,9 +32,19 @@ Product Supplierinfo for Customers
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module allows to use supplier info structure, available in
-*Purchase* tab of the product form, also for defining customer
-information, allowing to define prices per customer and product.
+This module allows you to define a customer-specific product data
+structure (patterned after the standard supplier/vendor info) on the
+product form.
+
+This structure enables defining customized information for each customer
+and product, including:
+
+::
+
+   - Custom Price (Price-list price)
+   - Customer Product Name
+   - Customer Product Code
+   - Minimum Order Quantity (MOQ)
 
 **Table of contents**
 
@@ -62,9 +72,10 @@ from the supplierinfo at the product form.
 Known issues / Roadmap
 ======================
 
-- Product prices through this method are only guaranteed on the standard
-  sale order workflow. Other custom flows maybe don't reflect the price.
-- The minimum quantity will neither apply on sale orders.
+-  Product prices through this method are only guaranteed on the
+   standard sale order workflow. Other custom flows maybe don't reflect
+   the price.
+-  The minimum quantity will neither apply on sale orders.
 
 Bug Tracker
 ===========
@@ -88,18 +99,18 @@ Authors
 Contributors
 ------------
 
-- Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
-- Aaron Henriquez <ahenriquez@forgeflow.com>
-- Miquel Raïch <miquel.raich@forgeflow.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+-  Aaron Henriquez <ahenriquez@forgeflow.com>
+-  Miquel Raïch <miquel.raich@forgeflow.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Sergio Teruel
-  - Carlos Lopez
+   -  Pedro M. Baeza
+   -  Sergio Teruel
+   -  Carlos Lopez
 
-- `Komit <https://komit-consulting.com>`__:
+-  `Komit <https://komit-consulting.com>`__:
 
-  - Vang Nguyen Phu
+   -  Vang Nguyen Phu
 
 Maintainers
 -----------

--- a/product_customerinfo/models/product_customerinfo.py
+++ b/product_customerinfo/models/product_customerinfo.py
@@ -12,6 +12,16 @@ class ProductCustomerInfo(models.Model):
     partner_id = fields.Many2one(string="Customer", help="Customer of this product")
     product_name = fields.Char(string="Customer Product Name")
     product_code = fields.Char(string="Customer Product Code")
+    # Override fields with corrected help texts
+    min_qty = fields.Float(
+        help="The minimum quantity to purchase for this customer to benefit from the "
+        "price. Expressed in the customer's Product Unit of Measure if set, "
+        "otherwise in the default Product Unit of Measure."
+    )
+    price = fields.Float(help="Price at which the product is sold to this customer.")
+    date_start = fields.Date(help="Start date for this customer price")
+    date_end = fields.Date(help="End date for this customer price")
+    product_uom = fields.Many2one(help="Customer specific unit of measure.")
 
     @api.model
     def get_import_templates(self):

--- a/product_customerinfo/readme/DESCRIPTION.md
+++ b/product_customerinfo/readme/DESCRIPTION.md
@@ -1,3 +1,8 @@
-This module allows to use supplier info structure, available in
-*Purchase* tab of the product form, also for defining customer
-information, allowing to define prices per customer and product.
+This module allows you to define a customer-specific product data structure (patterned after the standard supplier/vendor info) on the product form.
+
+This structure enables defining customized information for each customer and product, including:
+
+    - Custom Price (Price-list price)
+    - Customer Product Name
+    - Customer Product Code
+    - Minimum Order Quantity (MOQ)

--- a/product_customerinfo/static/description/index.html
+++ b/product_customerinfo/static/description/index.html
@@ -374,10 +374,18 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:7a01a3bac8aef2bd72c38ed73074413a5c54966d5dc2396b209408aac97cffa9
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/product-attribute/tree/18.0/product_customerinfo"><img alt="OCA/product-attribute" src="https://img.shields.io/badge/github-OCA%2Fproduct--attribute-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/product-attribute-18-0/product-attribute-18-0-product_customerinfo"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/product-attribute&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module allows to use supplier info structure, available in
-<em>Purchase</em> tab of the product form, also for defining customer
-information, allowing to define prices per customer and product.</p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/product-attribute/tree/18.0/product_customerinfo"><img alt="OCA/product-attribute" src="https://img.shields.io/badge/github-OCA%2Fproduct--attribute-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/product-attribute-18-0/product-attribute-18-0-product_customerinfo"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/product-attribute&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p>This module allows you to define a customer-specific product data
+structure (patterned after the standard supplier/vendor info) on the
+product form.</p>
+<p>This structure enables defining customized information for each customer
+and product, including:</p>
+<pre class="literal-block">
+- Custom Price (Price-list price)
+- Customer Product Name
+- Customer Product Code
+- Minimum Order Quantity (MOQ)
+</pre>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -411,8 +419,9 @@ from the supplierinfo at the product form.</p>
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h2>
 <ul class="simple">
-<li>Product prices through this method are only guaranteed on the standard
-sale order workflow. Other custom flows maybe don’t reflect the price.</li>
+<li>Product prices through this method are only guaranteed on the
+standard sale order workflow. Other custom flows maybe don’t reflect
+the price.</li>
 <li>The minimum quantity will neither apply on sale orders.</li>
 </ul>
 </div>

--- a/product_customerinfo/views/product_views.xml
+++ b/product_customerinfo/views/product_views.xml
@@ -115,6 +115,7 @@
                     context="{
                            'default_product_tmpl_id': context.get('product_tmpl_id',id),
                            'product_template_invisible_variant': True,
+                           'form_view_ref': 'product_customerinfo.product_customerinfo_form_view'
                        }"
                     invisible="product_variant_count &gt; 1"
                     readonly="product_variant_count &gt; 1"
@@ -124,6 +125,7 @@
                     nolabel="1"
                     context="{
                             'default_product_tmpl_id': context.get('product_tmpl_id',id),
+                            'form_view_ref': 'product_customerinfo.product_customerinfo_form_view'
                         }"
                     invisible="product_variant_count &lt;= 1"
                     readonly="product_variant_count &lt;= 1"
@@ -139,12 +141,12 @@
             <field name="customer_ids" position="attributes">
                 <attribute
                     name="context"
-                >{'default_product_tmpl_id': product_tmpl_id, 'product_template_invisible_variant': True}</attribute>
+                >{'default_product_tmpl_id': product_tmpl_id, 'product_template_invisible_variant': True, 'form_view_ref': 'product_customerinfo.product_customerinfo_form_view'}</attribute>
             </field>
             <field name="variant_customer_ids" position="attributes">
                 <attribute
                     name="context"
-                >{'default_product_tmpl_id': product_tmpl_id}</attribute>
+                >{'default_product_tmpl_id': product_tmpl_id, 'default_product_id': id, 'form_view_ref': 'product_customerinfo.product_customerinfo_form_view'}</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Help texts incorrectly mentioned "vendor" instead of "customer" for fields:
   - customer_product_name
   - customer_product_code
   - quantity (min_qty)
   - price
   - validity (date_start/date_end)

Popup windows when adding customer info lines showed generic titles like "Create Customer" instead of clearer titles like "Create Customer Info". 

When creating customer info from a specific product variant, the product variant field was not pre-populated.