### PR TITLE
[18.0][REF] product_pricelist_direct_print_xlsx

### DIFF
--- a/product_pricelist_direct_print_xlsx/readme/CONTRIBUTORS.md
+++ b/product_pricelist_direct_print_xlsx/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
   - Alexey Pelykh \<alexey.pelykh@corphub.eu\>
 - [GRAP](http://www.grap.coop/):
   - Sylvain LE GAL \<https://twitter.com/legalsylvain\>
+- [Versada](https://versada.eu)
+  - Maciej Wichowski \<maciej@versada.eu\>

--- a/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py
+++ b/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py
@@ -8,84 +8,52 @@ class ProductPricelistXlsx(models.AbstractModel):
     _inherit = "report.report_xlsx.abstract"
     _description = "Abstract model to export as xlsx the product pricelist"
 
+    def generate_xlsx_report(self, workbook, data, objects):
+        book = objects[0].with_context(
+            lang=objects[0].lang
+            or self.env["res.users"].browse(objects[0].create_uid.id).lang
+        )
+        formats = self._prepare_formats(workbook, book)
+        self = self.with_context(
+            lang=book.lang or self.env["res.users"].browse(book.create_uid.id).lang
+        )
+        pricelist = book.get_pricelist_to_print()
+        sheet = self._create_product_pricelist_sheet(workbook, book, pricelist, formats)
+        sheet = self._fill_data(workbook, sheet, book, pricelist, formats)
+
     def _get_lang(self, user_id, lang_code=False):
         if not lang_code:
             lang_code = self.env["res.users"].browse(user_id).lang
         return self.env["res.lang"]._lang_get(lang_code)
 
-    def _create_product_pricelist_sheet(self, workbook, book, pricelist):
-        title_format = workbook.add_format(
-            {"bold": 1, "border": 1, "align": "left", "valign": "vjustify"}
-        )
-        header_format = workbook.add_format(
-            {
-                "bold": 1,
-                "border": 1,
-                "align": "center",
-                "valign": "vjustify",
-                "fg_color": "#F2F2F2",
-            }
-        )
-        lang = self._get_lang(book.create_uid.id, lang_code=book.lang)
-        date_format = lang.date_format.replace("%d", "dd")
-        date_format = date_format.replace("%m", "mm")
-        date_format = date_format.replace("%Y", "YYYY")
-        date_format = date_format.replace("/", "-")
-        date_format = workbook.add_format({"num_format": date_format})
+    def _create_product_pricelist_sheet(self, workbook, book, pricelist, formats):
         sheet = workbook.add_worksheet(self.env._("PRODUCTS"))
-        sheet.set_column("A:A", 45)
-        sheet.set_column("B:H", 15)
         # Title construction
-        sheet.write("A1", self.env._("Price List Name:"), title_format)
+        sheet.write("A1", self.env._("Price List Name:"), formats["title"])
         if book.show_pricelist_name:
             sheet.write("A2", pricelist.name)
         else:
             sheet.write("A2", self.env._("Special Pricelist"))
-        sheet.write("B1", self.env._("Currency:"), title_format)
+        sheet.write("B1", self.env._("Currency:"), formats["title"])
         sheet.write("B2", pricelist.currency_id.name)
-        sheet.write("D1", self.env._("Date:"), title_format)
-        sheet.write("D2", book.date, date_format)
+        sheet.write("D1", self.env._("Date:"), formats["title"])
+        sheet.write("D2", book.date, formats["date"])
         # Header construction
         if book.partner_id:
-            sheet.write(4, 0, book.partner_id.name, header_format)
+            sheet.write(4, 0, book.partner_id.name, formats["header"])
         elif book.partner_ids:
-            sheet.write(4, 0, book.partner_ids[0].name, header_format)
-        next_col = 0
-        sheet.write(5, next_col, self.env._("Description"), header_format)
-        next_col = self._add_extra_header(sheet, book, next_col, header_format)
-        if book.show_internal_category:
-            next_col += 1
-            sheet.write(5, next_col, self.env._("Internal Category"), header_format)
-        if book.show_standard_price:
-            next_col += 1
-            sheet.write(5, next_col, self.env._("Cost Price"), header_format)
-        if book.show_sale_price:
-            next_col += 1
-            sheet.write(5, next_col, self.env._("Sale Price"), header_format)
-        next_col += 1
-        sheet.write(5, next_col, self.env._("List Price"), header_format)
-        if book.show_product_uom:
-            next_col += 1
-            sheet.write(5, next_col, self.env._("UoM"), header_format)
+            sheet.write(4, 0, book.partner_ids[0].name, formats["header"])
+        header_row = self._prepare_header_row(book)
+        self._set_column_widths(sheet, header_row)
+        sheet.write_row(5, 0, header_row, formats["header"])
         return sheet
 
-    def _add_extra_header(self, sheet, book, next_col, header_format):
-        return next_col
-
-    def _fill_data(self, workbook, sheet, book, pricelist):
-        bold_format = workbook.add_format({"bold": 1})
-        decimal_format = workbook.add_format({"num_format": "0.00"})
-        decimal_bold_format = workbook.add_format({"num_format": "0.00", "bold": 1})
+    def _fill_data(self, workbook, sheet, book, pricelist, formats):
         row = 6
-        formats = {
-            "bold_format": bold_format,
-            "decimal_format": decimal_format,
-            "decimal_bold_format": decimal_bold_format,
-        }
         for group in book.get_groups_to_print():
             if book.breakage_per_category:
                 sheet.write(
-                    row, 0, book.get_group_name(group["group_name"]), bold_format
+                    row, 0, book.get_group_name(group["group_name"]), formats["bold"]
                 )
                 row += 1
             for product_data in group["products"]:
@@ -95,47 +63,80 @@ class ProductPricelistXlsx(models.AbstractModel):
                     if isinstance(product_data, dict)
                     else product_data
                 )
-                next_col = 0
-                sheet.write(row, next_col, product.display_name)
-                next_col = self._add_extra_info(
-                    sheet, book, product, row, next_col, **formats
+                row_with_formats = self._prepare_data_row_with_formats(
+                    book, product, formats
                 )
-                if book.show_internal_category:
-                    next_col += 1
-                    sheet.write(row, next_col, product.categ_id.display_name)
-                if book.show_standard_price:
-                    next_col += 1
-                    sheet.write(row, next_col, product.standard_price, decimal_format)
-                if book.show_sale_price:
-                    next_col += 1
-                    sheet.write(row, next_col, product.list_price, decimal_format)
-                next_col += 1
-                sheet.write(
-                    row,
-                    next_col,
-                    book.with_context(product=product).product_price,
-                    decimal_bold_format,
-                )
-                if book.show_product_uom:
-                    next_col += 1
-                    sheet.write(row, next_col, product.uom_id.name, bold_format)
+                for i, cell_with_format in enumerate(row_with_formats):
+                    cell_value, format = cell_with_format
+                    sheet.write(row, i, cell_value, format)
                 row += 1
         if book.summary:
-            sheet.write(row, 0, self.env._("Summary:"), bold_format)
+            sheet.write(row, 0, self.env._("Summary:"), formats["bold"])
             sheet.write(row + 1, 0, book.summary)
         return sheet
 
-    def _add_extra_info(self, sheet, book, product, row, next_col, **kw):
-        return next_col
+    def _prepare_formats(self, workbook, book):
+        lang = self._get_lang(book.create_uid.id, lang_code=book.lang)
+        date_format = (
+            lang.date_format.replace("%d", "dd")
+            .replace("%m", "mm")
+            .replace("%Y", "YYYY")
+            .replace("/", "-")
+        )
+        return {
+            "title": workbook.add_format(
+                {"bold": 1, "border": 1, "align": "left", "valign": "vjustify"}
+            ),
+            "header": workbook.add_format(
+                {
+                    "bold": 1,
+                    "border": 1,
+                    "align": "center",
+                    "valign": "vjustify",
+                    "fg_color": "#F2F2F2",
+                }
+            ),
+            "date": workbook.add_format({"num_format": date_format}),
+            "bold": workbook.add_format({"bold": 1}),
+            "decimal": workbook.add_format({"num_format": "0.00"}),
+            "decimal_bold": workbook.add_format({"num_format": "0.00", "bold": 1}),
+        }
 
-    def generate_xlsx_report(self, workbook, data, objects):
-        book = objects[0].with_context(
-            lang=objects[0].lang
-            or self.env["res.users"].browse(objects[0].create_uid.id).lang
+    def _prepare_header_row(self, book):
+        _ = self.env._
+        row = [_("Description")]
+        if book.show_internal_category:
+            row.append(_("Internal Category"))
+        if book.show_standard_price:
+            row.append(_("Cost Price"))
+        if book.show_sale_price:
+            row.append(_("Sale Price"))
+        row.append(_("List Price"))
+        if book.show_product_uom:
+            row.append(_("UoM"))
+        return row
+
+    def _prepare_data_row_with_formats(self, book, product, formats):
+        row = [(product.display_name, None)]
+        if book.show_internal_category:
+            row.append((product.categ_id.display_name, None))
+        if book.show_standard_price:
+            row.append((product.standard_price, formats["decimal"]))
+        if book.show_sale_price:
+            row.append((product.list_price, formats["decimal"]))
+        row.append(
+            (
+                book.with_context(product=product).product_price,
+                formats["decimal_bold"],
+            )
         )
-        self = self.with_context(
-            lang=book.lang or self.env["res.users"].browse(book.create_uid.id).lang
-        )
-        pricelist = book.get_pricelist_to_print()
-        sheet = self._create_product_pricelist_sheet(workbook, book, pricelist)
-        sheet = self._fill_data(workbook, sheet, book, pricelist)
+        if book.show_product_uom:
+            row.append((product.uom_id.name, formats["bold"]))
+        return row
+
+    def _set_column_widths(self, sheet, header_row):
+        # Special label with wider column
+        description_label = self.env._("Description")
+        for i, label in enumerate(header_row):
+            width = 45 if label == description_label else 15
+            sheet.set_column(i, i, width)


### PR DESCRIPTION
Code refactoring made with purpose of making the module easier to extend. Since `xlsxwriter` is "write only" library, there was no way to easily change the properties of printed table. The changes are focused on separating preparation of data / labels / formats.

That way any extension module can change the order of the columns, data formats or add new columns anywhere in the table. For example, prior to this change, to add a new column before the "Description" column, only way was to override `_create_product_pricelist_sheet` and `_fill_data` methods or rewrite  whole workbook from scratch after the original methods are done.