### PR TITLE
[16.0][IMP] product_lot_sequence: product sequence exceptions

### DIFF
--- a/product_lot_sequence/README.rst
+++ b/product_lot_sequence/README.rst
@@ -48,6 +48,9 @@ There are two ways you can configure this module through the use of System Param
   same than in previous Odoo versions with this module installed, i.e. it allows
   to define a dedicated sequence on each product.
 
+  You can configure products to avoid this behavior though. Just unset the *Use specific
+  sequence* flag in the product template form and it will have Odoo's default behavior.
+
 - "global": This was the default behaviour from previous Odoo versions when this
   module was not installed, i.e it will always use the same global sequence for every product.
 

--- a/product_lot_sequence/models/product.py
+++ b/product_lot_sequence/models/product.py
@@ -8,6 +8,10 @@ from odoo import api, fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    use_specific_lot_sequence = fields.Boolean(
+        help="Use an specific lot sequence for this product",
+        default=True,
+    )
     lot_sequence_id = fields.Many2one(
         "ir.sequence",
         string="Entry Sequence",
@@ -33,11 +37,15 @@ class ProductTemplate(models.Model):
         compute="_compute_display_lot_sequence_fields"
     )
 
-    @api.depends("tracking")  # For products being created (before saved).
+    @api.depends("tracking", "use_specific_lot_sequence")
     def _compute_display_lot_sequence_fields(self):
-        self.display_lot_sequence_fields = (
+        product_sequence_policy = (
             self.env["stock.lot"]._get_sequence_policy() == "product"
         )
+        for product in self:
+            product.display_lot_sequence_fields = (
+                product_sequence_policy and product.use_specific_lot_sequence
+            )
 
     @api.model
     def _create_lot_sequence(self, vals):
@@ -59,6 +67,18 @@ class ProductTemplate(models.Model):
             "lot_sequence_number_next", 1
         )
         return seq
+
+    def create_lot_sequence(self):
+        self.ensure_one()
+        if self.lot_sequence_id:
+            return
+        self.lot_sequence_id = self._create_lot_sequence({})
+
+    def remove_lot_sequence(self):
+        self.ensure_one()
+        if not self.lot_sequence_id:
+            return
+        self.lot_sequence_id.unlink()
 
     # do not depend on 'lot_sequence_id.date_range_ids', because
     # lot_sequence_id._get_current_sequence() may invalidate it!
@@ -86,8 +106,13 @@ class ProductTemplate(models.Model):
 
     def write(self, vals):
         seq_policy = self.env["stock.lot"]._get_sequence_policy()
+        # We want to remove the sequence when the user decides that the product won't
+        # use it.
+        add_lot_sequence = vals.get("use_specific_lot_sequence")
         if seq_policy == "product":
             for template in self:
+                if not template.use_specific_lot_sequence and not add_lot_sequence:
+                    continue
                 tracking = vals.get("tracking", False) or template.tracking
                 if tracking in ["lot", "serial"]:
                     if (
@@ -103,7 +128,8 @@ class ProductTemplate(models.Model):
                         )
                         vals["lot_sequence_prefix"] = lot_sequence_id.prefix
                         vals["lot_sequence_padding"] = lot_sequence_id.padding
-        return super().write(vals)
+        res = super().write(vals)
+        return res
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -113,6 +139,11 @@ class ProductTemplate(models.Model):
                 "lot",
                 "serial",
             ]:
+                if (
+                    "use_specific_lot_sequence" in vals
+                    and not vals["use_specific_lot_sequence"]
+                ):
+                    continue
                 if not vals.get("lot_sequence_id", False):
                     vals["lot_sequence_id"] = self.sudo()._create_lot_sequence(vals).id
                 else:

--- a/product_lot_sequence/models/stock_lot.py
+++ b/product_lot_sequence/models/stock_lot.py
@@ -31,6 +31,7 @@ class StockLot(models.Model):
             seq_policy == "product"
             and self.product_id
             and self.product_id.product_tmpl_id.lot_sequence_id
+            and self.product_id.product_tmpl_id.use_specific_lot_sequence
         ):
             self.name = self.product_id.product_tmpl_id.lot_sequence_id._next()
 
@@ -44,7 +45,11 @@ class StockLot(models.Model):
                         product = self.env["product.product"].browse(
                             lot_vals["product_id"]
                         )
-                        if product and product.product_tmpl_id.lot_sequence_id:
+                        if (
+                            product
+                            and product.product_tmpl_id.lot_sequence_id
+                            and product.product_tmpl_id.use_specific_lot_sequence
+                        ):
                             lot_vals[
                                 "name"
                             ] = product.product_tmpl_id.lot_sequence_id._next()
@@ -61,7 +66,7 @@ class StockLot(models.Model):
         seq_policy = self._get_sequence_policy()
         if seq_policy == "product":
             seq = product.product_tmpl_id.lot_sequence_id
-            if seq:
+            if seq and product.product_tmpl_id.use_specific_lot_sequence:
                 return seq._next()
         elif seq_policy == "global":
             return self.env["ir.sequence"].next_by_code("stock.lot.serial")

--- a/product_lot_sequence/readme/CONFIGURE.rst
+++ b/product_lot_sequence/readme/CONFIGURE.rst
@@ -8,6 +8,9 @@ There are two ways you can configure this module through the use of System Param
   same than in previous Odoo versions with this module installed, i.e. it allows
   to define a dedicated sequence on each product.
 
+  You can configure products to avoid this behavior though. Just unset the *Use specific
+  sequence* flag in the product template form and it will have Odoo's default behavior.
+
 - "global": This was the default behaviour from previous Odoo versions when this
   module was not installed, i.e it will always use the same global sequence for every product.
 

--- a/product_lot_sequence/static/description/index.html
+++ b/product_lot_sequence/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -395,12 +396,16 @@ ul.auto-toc {
 <h2><a class="toc-backref" href="#toc-entry-2">Lot Sequence policy</a></h2>
 <p>There are two ways you can configure this module through the use of System Parameter
 <cite>product_lot_sequence.policy</cite>:</p>
-<ul class="simple">
-<li>“product”: This is the default behaviour once you install this module. It’s the
+<ul>
+<li><p class="first">“product”: This is the default behaviour once you install this module. It’s the
 same than in previous Odoo versions with this module installed, i.e. it allows
-to define a dedicated sequence on each product.</li>
-<li>“global”: This was the default behaviour from previous Odoo versions when this
-module was not installed, i.e it will always use the same global sequence for every product.</li>
+to define a dedicated sequence on each product.</p>
+<p>You can configure products to avoid this behavior though. Just unset the <em>Use specific
+sequence</em> flag in the product template form and it will have Odoo’s default behavior.</p>
+</li>
+<li><p class="first">“global”: This was the default behaviour from previous Odoo versions when this
+module was not installed, i.e it will always use the same global sequence for every product.</p>
+</li>
 </ul>
 <p>If any other value is used for this System Parameter, then you will get the default
 behaviour from odoo 15.0 which will look for the last lot number for each product and
@@ -473,7 +478,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_lot_sequence/views/product_views.xml
+++ b/product_lot_sequence/views/product_views.xml
@@ -9,6 +9,10 @@
             <field name="tracking" position="after">
                 <field name="display_lot_sequence_fields" invisible="1" />
                 <field
+                    name="use_specific_lot_sequence"
+                    attrs="{'invisible': [('tracking', 'not in', ['lot', 'serial'])]}"
+                />
+                <field
                     name="lot_sequence_prefix"
                     attrs="{'invisible': ['|', '|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False), ('lot_sequence_id', '!=', False)]}"
                 />
@@ -20,10 +24,32 @@
                     name="lot_sequence_number_next"
                     attrs="{'readonly': [('lot_sequence_id', '!=', False)], 'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False)]}"
                 />
-                <field
-                    name="lot_sequence_id"
-                    attrs="{'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), ('display_lot_sequence_fields', '=', False)]}"
-                />
+                <label for="lot_sequence_id" />
+                <div>
+                    <field
+                        name="lot_sequence_id"
+                        attrs="{'invisible': ['|', ('tracking', 'not in', ['lot', 'serial']), '&amp;', ('display_lot_sequence_fields', '=', False), ('lot_sequence_id', '=', False)]}"
+                    />
+                    <button
+                        name="remove_lot_sequence"
+                        type="object"
+                        role="button"
+                        class="oe_link oe_inline"
+                        confirm="This will remove the lot sequence for this product"
+                        attrs="{'invisible': ['|', ('use_specific_lot_sequence', '=', True), ('lot_sequence_id', '=', False)]}"
+                    ><i
+                            class="fa fa-fw o_button_icon fa-arrow-right"
+                        /> Remove sequence</button>
+                    <button
+                        name="create_lot_sequence"
+                        type="object"
+                        role="button"
+                        class="oe_link oe_inline"
+                        attrs="{'invisible': ['|', ('use_specific_lot_sequence', '=', False), ('lot_sequence_id', '!=', False)]}"
+                    ><i
+                            class="fa fa-fw o_button_icon fa-arrow-right"
+                        /> Create sequence</button>
+                </div>
             </field>
         </field>
     </record>


### PR DESCRIPTION
There might be cases where we don't want to assign specific sequences to our
product and keep the core behavior. For that we've created a flag that allows
to do so.

- The flag *Use specific sequence* is on by default.
- Set it off and the product will behave as in Odoo core.
- Once you do so, you can remove the product's lot sequence as well.

(TODO: remove this vídeo, as it's an old version of the change)
https://www.loom.com/share/4edde17a26ef4d2f9d909e59ea538f7b?sid=86bbaefb-926b-46a8-982f-c9b1a800e364

cc @moduon MT-12305

please review @rafaelbn @fcvalgar @Shide 