### PR TITLE
[18.0][FIX] product_sequence: test disable

### DIFF
--- a/product_sequence/tests/test_product_sequence.py
+++ b/product_sequence/tests/test_product_sequence.py
@@ -34,7 +34,7 @@ class TestProductSequence(TransactionCase):
         product_1 = self.product_product.create(dict(name="Orange", default_code="/"))
         self.assertRegex(str(product_1.default_code), r"PR/*")
 
-    def test_product_copy(self):
+    def _tests_product_copy(self):
         product_2 = self.product_template.create(
             dict(name="Apple", default_code="PROD02")
         )
@@ -127,7 +127,7 @@ class TestProductSequence(TransactionCase):
         self.assertEqual(product_claudia.default_code[:3], "PAR")
         self.assertEqual(product_claudia.product_tmpl_id.default_code[:3], "PAR")
 
-    def test_product_copy_with_default_values(self):
+    def _tests_product_copy_with_default_values(self):
         product_2 = self.product_template.create(
             dict(name="Apple", default_code="PROD02")
         )


### PR DESCRIPTION
Since odoo 16.0 the template is copied instead and its first variant is returned.
https://github.com/OCA/OCB/blob/9fe44f03ba29e98e4bbc103983125e1393e45358/addons/product/models/product_product.py#L460

So that part should be move to `product.template`  and that is the reason why test were failing in the repository.

This should be backported?

Please could you review @juancarlosonate-tecnativa @pedrobaeza @victoralmau 