### PR TITLE
[18.0][FIX] product_pricelist_direct_print: show only defined products is not showing the correct products

### DIFF
--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -312,38 +312,38 @@ class ProductPricelistPrint(models.TransientModel):
     def get_products_domain(self):
         domain = [("sale_ok", "=", True)]
         if self.show_only_defined_products:
-            aux_domain = []
+            aux_domain = [(0, "=", 1)]
             items_dic = {"categ_ids": [], "product_ids": [], "variant_ids": []}
             for item in self.pricelist_id.item_ids:
                 if item.applied_on == "0_product_variant":
                     items_dic["variant_ids"].append(item.product_id.id)
                 if item.applied_on == "1_product":
                     items_dic["product_ids"].append(item.product_tmpl_id.id)
-                if item.applied_on == "2_product_category" and item.categ_id.parent_id:
+                if item.applied_on == "2_product_category":
                     items_dic["categ_ids"].append(item.categ_id.id)
             if items_dic["categ_ids"]:
-                aux_domain = expression.AND(
+                aux_domain = expression.OR(
                     [aux_domain, [("categ_id", "in", items_dic["categ_ids"])]]
                 )
             if items_dic["product_ids"]:
                 if self.show_variants:
-                    aux_domain = expression.AND(
+                    aux_domain = expression.OR(
                         [
                             aux_domain,
                             [("product_tmpl_id", "in", items_dic["product_ids"])],
                         ]
                     )
                 else:
-                    aux_domain = expression.AND(
+                    aux_domain = expression.OR(
                         [aux_domain, [("id", "in", items_dic["product_ids"])]]
                     )
             if items_dic["variant_ids"]:
                 if self.show_variants:
-                    aux_domain = expression.AND(
+                    aux_domain = expression.OR(
                         [aux_domain, [("id", "in", items_dic["variant_ids"])]]
                     )
                 else:
-                    aux_domain = expression.AND(
+                    aux_domain = expression.OR(
                         [
                             aux_domain,
                             [("product_variant_ids", "in", items_dic["variant_ids"])],


### PR DESCRIPTION
The ANDs on the domains is excluding products that are defined but aren't on the categories added to the pricelist, so this is not correct. Set ORs to wor as is was working in last versions.

cc @Tecnativa TT58949

ping @pedrobaeza @carlosdauden 