### PR TITLE
[18.0][IMP] product_customerinfo: allow using discount

### DIFF
--- a/product_customerinfo/models/product_pricelist.py
+++ b/product_customerinfo/models/product_pricelist.py
@@ -12,3 +12,24 @@ class ProductPricelistItem(models.Model):
         selection_add=[("partner", "Partner Prices on the product form")],
         ondelete={"partner": "set default"},
     )
+
+    def _compute_price(self, product, quantity, uom, date, currency=None):
+        return super()._compute_price(
+            product.with_context(include_customerinfo_discount=True),
+            quantity,
+            uom,
+            date,
+            currency,
+        )
+
+    def _show_discount(self):
+        # Show discount when pricelist item is based on customerinfo price
+        res = super()._show_discount()
+        if (
+            self
+            and self._is_discount_feature_enabled()
+            and self.compute_price == "formula"
+            and self.base == "partner"
+        ):
+            return True
+        return res

--- a/product_customerinfo/models/product_product.py
+++ b/product_customerinfo/models/product_product.py
@@ -43,9 +43,14 @@ class ProductProduct(models.Model):
             return 0.0
         partner = self.env["res.partner"].browse(partner_id)
         customerinfo = self._select_customerinfo(partner=partner)
-        if customerinfo:
-            return customerinfo.price
-        return 0.0
+        if not customerinfo:
+            return 0.0
+        price = customerinfo.price
+        if self.env.context.get("include_customerinfo_discount") and price:
+            price = customerinfo.currency_id.round(
+                price - (price * (customerinfo.discount / 100))
+            )
+        return price
 
     def _price_compute(
         self, price_type, uom=False, currency=False, company=None, date=False

--- a/product_customerinfo/tests/test_product_customerinfo.py
+++ b/product_customerinfo/tests/test_product_customerinfo.py
@@ -4,6 +4,8 @@
 # Copyright 2018 ForgeFlow
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from odoo import fields
+
 from odoo.addons.base.tests.common import BaseCommon
 
 
@@ -98,6 +100,30 @@ class TestProductSupplierinfoForCustomer(BaseCommon):
         )
         self.assertEqual(
             res[self.product.id], 750.0, "Error: price does not match list price"
+        )
+
+    def test_product_supplierinfo_discount(self):
+        self.customerinfo.write({"discount": 10.0})
+        self.pricelist_item.write({"base": "partner", "compute_price": "formula"})
+        price = self.pricelist_item._compute_price(
+            self.product.with_context(partner_id=self.customer.id),
+            1,
+            self.product.uom_id,
+            fields.Datetime.now(),
+            self.company.currency_id,
+        )
+        base_price = self.pricelist_item._compute_base_price(
+            self.product.with_context(partner_id=self.customer.id),
+            1,
+            self.product.uom_id,
+            fields.Datetime.now(),
+            self.company.currency_id,
+        )
+        self.assertEqual(
+            base_price, 100.0, "Error: Wrong base price for product and customer"
+        )
+        self.assertEqual(
+            price, 90.0, "Error: Discount not applied for product and customer"
         )
 
     def test_variant_supplierinfo_price(self):

--- a/product_customerinfo/views/product_views.xml
+++ b/product_customerinfo/views/product_views.xml
@@ -51,6 +51,7 @@
                                 groups="base.group_multi_currency"
                             />
                         </div>
+                        <field name="discount" />
                         <label for="date_start" string="Validity" />
                         <div><field name="date_start" class="oe_inline" /> to <field
                             name="date_end"
@@ -97,6 +98,7 @@
                 />
                 <field name="min_qty" />
                 <field name="price" string="Price" />
+                <field name="discount" />
                 <field name="date_start" optional="hide" />
                 <field name="date_end" optional="hide" />
             </list>

--- a/product_supplierinfo_import/wizards/product_supplierinfo_import.py
+++ b/product_supplierinfo_import/wizards/product_supplierinfo_import.py
@@ -9,6 +9,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import parse_version
+from odoo.tools.float_utils import float_round
 
 _logger = logging.getLogger(__name__)
 
@@ -140,6 +141,14 @@ class ProductSupplierInfoImport(models.TransientModel):
                 "date_start": self.date_start,
             }
         )
+        # Round price
+        if "price" in values:
+            values["price"] = float_round(
+                values["price"],
+                precision_digits=self.env["decimal.precision"].precision_get(
+                    "Product Price"
+                ),
+            )
         return values
 
     def _update_create_supplierinfo_data(self, parsed_data):


### PR DESCRIPTION
Had to add rounding on product_supplierinfo_import module when importing the price to prevent error in tests:

<img width="1458" height="653" alt="image" src="https://github.com/user-attachments/assets/23a65fc1-e0e6-4384-a1d8-b9eaf9e4d4f5" />
