### PR TITLE
[16.0][IMP] product_lot_sequence: add new group to allow editing lot sequence attributes

### DIFF
--- a/product_lot_sequence/README.rst
+++ b/product_lot_sequence/README.rst
@@ -61,6 +61,9 @@ Default Number of Digits for Product Sequence Generation
 The default is 7 digits.  To change that to something else, go to the inventory
 configuration, find "Sequence Number of Digits" and change the number.
 
+To allow a user without settings access rights to update generated lot sequence attributes,
+add them to the "Product Lot Sequence Manager: Only Product Lot Sequences" group.
+
 Usage
 =====
 

--- a/product_lot_sequence/__manifest__.py
+++ b/product_lot_sequence/__manifest__.py
@@ -5,12 +5,13 @@
     "name": "Product Lot Sequence",
     "summary": """
         Adds ability to define a lot sequence from the product""",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.1.0",
     "license": "AGPL-3",
     "author": "ForgeFlow S.L., Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/product-attribute",
     "depends": ["stock"],
     "data": [
+        "security/lot_sequence_security.xml",
         "data/ir_config_parameter.xml",
         "views/product_views.xml",
         "views/res_config_settings_views.xml",

--- a/product_lot_sequence/migrations/16.0.1.1.0/post-migration.py
+++ b/product_lot_sequence/migrations/16.0.1.1.0/post-migration.py
@@ -1,0 +1,17 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    sequences = (
+        env["product.template"]
+        .search(
+            [
+                ("lot_sequence_id.code", "=", False),
+                ("lot_sequence_id", "!=", False),
+            ]
+        )
+        .mapped("lot_sequence_id")
+    )
+    if sequences:
+        sequences.write({"code": "product_lot_sequence"})

--- a/product_lot_sequence/models/product.py
+++ b/product_lot_sequence/models/product.py
@@ -47,6 +47,7 @@ class ProductTemplate(models.Model):
         padding = vals.get("lot_sequence_padding") or self.lot_sequence_padding
         seq = {
             "name": name,
+            "code": "product_lot_sequence",
             "implementation": "no_gap",
             "prefix": prefix,
             "padding": padding,

--- a/product_lot_sequence/readme/CONFIGURE.rst
+++ b/product_lot_sequence/readme/CONFIGURE.rst
@@ -20,3 +20,6 @@ Default Number of Digits for Product Sequence Generation
 
 The default is 7 digits.  To change that to something else, go to the inventory
 configuration, find "Sequence Number of Digits" and change the number.
+
+To allow a user without settings access rights to update generated lot sequence attributes,
+add them to the "Product Lot Sequence Manager: Only Product Lot Sequences" group.

--- a/product_lot_sequence/security/lot_sequence_security.xml
+++ b/product_lot_sequence/security/lot_sequence_security.xml
@@ -1,0 +1,45 @@
+<odoo>
+    <record model="res.groups" id="group_product_lot_sequence_manager">
+        <field name="name">Manage Product Lot Sequence</field>
+    </record>
+    <record id="rule_ir_sequence_product_lot_sequence_only" model="ir.rule">
+        <field
+            name="name"
+        >Product Lot Sequence Manager: only product lot sequences</field>
+        <field name="model_id" ref="base.model_ir_sequence" />
+        <field
+            name="groups"
+            eval="[Command.link(ref('product_lot_sequence.group_product_lot_sequence_manager'))]"
+        />
+        <field name="domain_force">
+            [
+                ("code", "=", "product_lot_sequence"),
+                ("company_id", "in", company_ids + [False]),
+            ]
+        </field>
+    </record>
+    <record id="rule_ir_sequence_readonly" model="ir.rule">
+        <field name="name">Read-Only Access to All Sequences</field>
+        <field name="model_id" ref="base.model_ir_sequence" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field
+            name="groups"
+            eval="[Command.link(ref('product_lot_sequence.group_product_lot_sequence_manager'))]"
+        />
+        <field name="perm_write" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_unlink" eval="False" />
+    </record>
+    <record id="access_ir_sequence_product_lot_sequence" model="ir.model.access">
+        <field name="name">ir.sequence access for Product Lot Sequence Manager</field>
+        <field name="model_id" ref="base.model_ir_sequence" />
+        <field
+            name="group_id"
+            ref="product_lot_sequence.group_product_lot_sequence_manager"
+        />
+        <field name="perm_read" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+</odoo>

--- a/product_lot_sequence/static/description/index.html
+++ b/product_lot_sequence/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -410,6 +411,8 @@ will increment it.</p>
 <h2><a class="toc-backref" href="#toc-entry-3">Default Number of Digits for Product Sequence Generation</a></h2>
 <p>The default is 7 digits.  To change that to something else, go to the inventory
 configuration, find “Sequence Number of Digits” and change the number.</p>
+<p>To allow a user without settings access rights to update generated lot sequence attributes,
+add them to the “Product Lot Sequence Manager: Only Product Lot Sequences” group.</p>
 </div>
 </div>
 <div class="section" id="usage">
@@ -473,7 +476,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_lot_sequence/tests/test_product_lot_sequence.py
+++ b/product_lot_sequence/tests/test_product_lot_sequence.py
@@ -1,3 +1,5 @@
+from odoo import Command
+from odoo.exceptions import AccessError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -138,3 +140,29 @@ class TestProductLotSequence(TransactionCase):
         self.assertEqual(
             new_next_sequence_number, seq.get_next_char(seq.number_next_actual)
         )
+
+    def test_product_sequence_access_right(self):
+        self.assertEqual(self.stock_production_lot._get_sequence_policy(), "product")
+        product = self.product_product.create(dict(name="Test", tracking="serial"))
+        self.assertTrue(product.lot_sequence_id)
+        product.lot_sequence_id.prefix = "Test/"
+        stock_manager_group = self.env.ref("stock.group_stock_manager")
+        test_user = self.env["res.users"].create(
+            {
+                "name": "Stock Manager User",
+                "login": "stock_manager_user",
+                "groups_id": [Command.set([stock_manager_group.id])],
+                "email": "stockmanager@example.com",
+            }
+        )
+        lot_seq_as_user = product.lot_sequence_id.with_user(test_user)
+        with self.assertRaises(AccessError):
+            lot_seq_as_user.prefix = "T/"
+        lot_seq_manager_group = self.env.ref(
+            "product_lot_sequence.group_product_lot_sequence_manager"
+        )
+        test_user.write({"groups_id": [Command.link(lot_seq_manager_group.id)]})
+        # Retry as same user (now with new group)
+        lot_seq_as_user = product.lot_sequence_id.with_user(test_user)
+        lot_seq_as_user.prefix = "T/"
+        self.assertEqual(lot_seq_as_user.prefix, "T/")


### PR DESCRIPTION
This PR introduces an improvement that allows non-Settings users who belong to the Product Lot Sequence Manager: Only Product Lot Sequences group to update the attributes of generated lot sequences.

@qrtl QT5799