### PR TITLE
[18.0][FIX] product_variant_route_mto: add missing inverse

### DIFF
--- a/product_variant_route_mto/models/product_product.py
+++ b/product_variant_route_mto/models/product_product.py
@@ -30,6 +30,7 @@ class ProductProduct(models.Model):
         domain="[('product_selectable', '=', True)]",
         store=False,
         search="_search_route_ids",
+        inverse="_inverse_route_ids",
     )
 
     def _compute_is_mto(self):
@@ -58,6 +59,19 @@ class ProductProduct(models.Model):
         if route_ids:
             domain += [("product_tmpl_id.route_ids", operator, route_ids)]
         return domain
+
+    def _inverse_route_ids(self):
+        mto_routes = self.env["stock.route"].search([("is_mto", "=", True)])
+        for product in self:
+            non_mto_routes = product.route_ids - mto_routes
+            if product.route_ids & mto_routes:
+                if not product.is_mto:
+                    product.is_mto = True
+            else:
+                if product.is_mto:
+                    product.is_mto = False
+            if product.product_tmpl_id.route_ids != non_mto_routes:
+                product.product_tmpl_id.route_ids = non_mto_routes
 
     @api.constrains("is_mto")
     def _check_template_is_mto(self):

--- a/product_variant_route_mto/tests/test_mto_variant.py
+++ b/product_variant_route_mto/tests/test_mto_variant.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 import logging
 
+from odoo import Command
 from odoo.exceptions import ValidationError
 
 from .common import TestMTOVariantCommon
@@ -40,6 +41,14 @@ class TestMTOVariant(TestMTOVariantCommon):
         with self.assertLogs(onchange_logger, level="WARNING"):
             self.remove_route(pen_template, self.mto_route)
         self.assertVariantsNotMTO(pens)
+
+    def test_variants_routes_updated(self):
+        blue_pen = self.blue_pen
+        self.assertVariantsNotMTO(blue_pen)
+        blue_pen.route_ids = [Command.link(self.mto_route.id)]
+        self.assertVariantsMTO(blue_pen)
+        blue_pen.route_ids = [Command.clear()]
+        self.assertVariantsNotMTO(blue_pen)
 
     def test_template_routes_updated(self):
         # instanciate variables


### PR DESCRIPTION
When write route on product, ensure is_mto is properly set

cc @henrybackman