### PR TITLE
[16.0][FIX] product_assortment: partner action

### DIFF
--- a/product_assortment/models/res_partner.py
+++ b/product_assortment/models/res_partner.py
@@ -20,8 +20,7 @@ class ResPartner(models.Model):
         xmlid = "product_assortment.actions_product_assortment_view"
         action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
         action["domain"] = [
-            ("partner_ids", "in", self.ids),
-            ("is_assortment", "=", True),
+            ("id", "in", self.applied_assortment_ids.ids),
         ]
         ctx = self.env.context.copy()
         ctx.update(

--- a/product_assortment/tests/test_product_assortment.py
+++ b/product_assortment/tests/test_product_assortment.py
@@ -74,17 +74,18 @@ class TestProductAssortment(TransactionCase):
             )
 
     def test_search_assortment_with_partner(self):
-        self.filter_obj.with_context(product_assortment=True).create(
+        assortment = self.filter_obj.with_context(product_assortment=True).create(
             {
                 "name": "Test Assortment Partner",
                 "domain": [],
                 "partner_ids": [(4, self.partner.id)],
             }
         )
+        self.partner._update_partner_assortments()
         search_domain = self.partner.action_define_product_assortment()["domain"]
         self.assertEqual(
             search_domain,
-            [("partner_ids", "in", [self.partner.id]), ("is_assortment", "=", True)],
+            [("id", "in", [assortment.id])],
         )
 
     def test_product_assortment_view(self):


### PR DESCRIPTION
Partner action to show assortments shows only the ones linked by partner_ids, but not via `partner_domain`. Using already existing `applied_assortment_ids` takes all into account.