### PR TITLE
[18.0][FIX] product_catalog_stock: avoid price check error

### DIFF
--- a/product_catalog_stock/models/stock_picking.py
+++ b/product_catalog_stock/models/stock_picking.py
@@ -39,6 +39,13 @@ class StockPicking(models.Model):
             grouped_moves[move.product_id] |= move
         return grouped_moves
 
+    def _get_product_catalog_order_data(self, products, **kwargs):
+        # Extended to add price avoiding the Component.validateProps check error
+        product_catalog = super()._get_product_catalog_order_data(products, **kwargs)
+        for product in products:
+            product_catalog[product.id] |= self._get_product_price_and_data(product)
+        return product_catalog
+
     def _get_product_price_and_data(self, product):
         self.ensure_one()
         return {"price": product.list_price}


### PR DESCRIPTION
It seems like the way mandatory attrs get checked has been changed upstream, now is checking if the `price` attribute exist before displaying in the view.
This PR avoid the error:

> UncaughtPromiseError > OwlError
> 
> Uncaught Promise > Invalid props for component 'ProductCatalogOrderLine': 'price' is missing (should be a number)
> 
> Occured on localhost:18069 on 2025-11-28 19:07:58 GMT
> 
> OwlError: Invalid props for component 'ProductCatalogOrderLine': 'price' is missing (should be a number)
>     Error: Invalid props for component 'ProductCatalogOrderLine': 'price' is missing (should be a number)
>         at Object.validateProps (http://localhost:18069/web/assets/debug/web.assets_web.js:11207:19) (/web/static/lib/owl/owl.js:3214)
>         at ProductCatalogKanbanRecord.template (eval at compile (http://localhost:18069/web/assets/debug/web.assets_web.js:13800:20), <anonymous>:23:13) (/web/static/lib/owl/owl.js:5807)
>         at Fiber._render (http://localhost:18069/web/assets/debug/web.assets_web.js:9776:38) (/web/static/lib/owl/owl.js:1783)
>         at Fiber.render (http://localhost:18069/web/assets/debug/web.assets_web.js:9768:18) (/web/static/lib/owl/owl.js:1775)
>         at ComponentNode.initiateRender (http://localhost:18069/web/assets/debug/web.assets_web.js:10448:23) (/web/static/lib/owl/owl.js:2455)

Commit with the change: https://github.com/OCA/OCB/commit/4ba63fa8d1319e026f5737d17fd7abce6f3a78b0

@Tecnativa TT57302
@pedrobaeza @victoralmau 