### PR TITLE
[FIX] product_plist_direct_print_xlsx: avoid format builtin

### DIFF
--- a/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py
+++ b/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py
@@ -67,8 +67,8 @@ class ProductPricelistXlsx(models.AbstractModel):
                     book, product, formats
                 )
                 for i, cell_with_format in enumerate(row_with_formats):
-                    cell_value, format = cell_with_format
-                    sheet.write(row, i, cell_value, format)
+                    cell_value, format_ = cell_with_format
+                    sheet.write(row, i, cell_value, format_)
                 row += 1
         if book.summary:
             sheet.write(row, 0, self.env._("Summary:"), formats["bold"])


### PR DESCRIPTION
Avoid this message
```bash
************* Module product_pricelist_direct_print_xlsx.report.product_pricelist_xlsx
product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py:70: [W0622(redefined-builtin), ProductPricelistXlsx._fill_data] Redefining built-in 'format'
```

cc @legalsylvain thanks