### PR TITLE
IMP(18.0) product_dimension: Add digits to dimensions

### DIFF
--- a/product_dimension/models/product_product.py
+++ b/product_dimension/models/product_product.py
@@ -8,9 +8,9 @@ from odoo import api, fields, models
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
-    product_length = fields.Float("length")
-    product_height = fields.Float("height")
-    product_width = fields.Float("width")
+    product_length = fields.Float("length", digits="Product Unit of Measure")
+    product_height = fields.Float("height", digits="Product Unit of Measure")
+    product_width = fields.Float("width", digits="Product Unit of Measure")
     dimensional_uom_id = fields.Many2one(
         "uom.uom",
         "Dimensional UoM",

--- a/product_dimension/models/product_template.py
+++ b/product_dimension/models/product_template.py
@@ -18,13 +18,19 @@ class ProductTemplate(models.Model):
         readonly=False,
     )
     product_length = fields.Float(
-        related="product_variant_ids.product_length", readonly=False
+        related="product_variant_ids.product_length",
+        readonly=False,
+        digits="Product Unit of Measure",
     )
     product_height = fields.Float(
-        related="product_variant_ids.product_height", readonly=False
+        related="product_variant_ids.product_height",
+        readonly=False,
+        digits="Product Unit of Measure",
     )
     product_width = fields.Float(
-        related="product_variant_ids.product_width", readonly=False
+        related="product_variant_ids.product_width",
+        readonly=False,
+        digits="Product Unit of Measure",
     )
     volume = fields.Float(
         compute="_compute_volume",


### PR DESCRIPTION
**Problem:**
Currently, product dimension fields (length, width, height) are forced to use the default database precision (2 decimals). This is inflexible for certain units of measure.

**Example:**
When working with **meters**, 2 decimals are insufficient to represent millimeters:
* Current: `0.01 m` (1 cm) -> cannot express millimeters.
* Required: `0.001 m` (1 mm).

**Solution:**
This PR updates the dimension fields to use the **Product Unit of Measure** digits. This allows users to use decimals with more coherence between the units they use