### PR TITLE
[18.0][IMP] product_secondary_unit: add template/variant sync helpers

### DIFF
--- a/product_secondary_unit/models/product_template.py
+++ b/product_secondary_unit/models/product_template.py
@@ -21,3 +21,39 @@ class ProductTemplate(models.Model):
             and self.secondary_uom_ids[0]
             or self.secondary_uom_ids
         )
+
+    def _compute_template_secondary_uom_field(self, fname):
+        """Helper to sync template secondary UoM field from variant.
+
+        Can be used in modules depending on product_secondary_unit to implement
+        compute methods for secondary UoM fields on product.template.
+
+        - Single variant: Sync the variant's value to the template
+        - Multiple variants: Keep the existing template value
+
+        :param str fname: name of the secondary UoM field to compute
+        """
+        for template in self:
+            if len(template.product_variant_ids) == 1:
+                template[fname] = template.product_variant_ids[fname]
+            # Keep existing value when multiple variants (don't clear)
+
+    def _inverse_template_secondary_uom_field(self, fname):
+        """Helper to propagate template secondary UoM field to variants.
+
+        Can be used in modules depending on product_secondary_unit to implement
+        inverse methods for secondary UoM fields on product.template.
+
+        - Single variant: Always sync the template's value to the variant
+        - Multiple variants: Only update variants without their own setting
+
+        :param str fname: name of the secondary UoM field to propagate
+        """
+        for template in self:
+            if len(template.product_variant_ids) == 1:
+                variants_to_update = template.product_variant_ids
+            else:
+                variants_to_update = template.product_variant_ids.filtered(
+                    lambda v, f=fname: not v[f]
+                )
+            variants_to_update[fname] = template[fname]

--- a/product_secondary_unit/models/product_template.py
+++ b/product_secondary_unit/models/product_template.py
@@ -23,37 +23,88 @@ class ProductTemplate(models.Model):
         )
 
     def _compute_template_secondary_uom_field(self, fname):
-        """Helper to sync template secondary UoM field from variant.
+        """Helper to sync a template secondary UoM field from its variants.
 
         Can be used in modules depending on product_secondary_unit to implement
         compute methods for secondary UoM fields on product.template.
 
-        - Single variant: Sync the variant's value to the template
-        - Multiple variants: Keep the existing template value
+        The template field is a mirror of its variants: it shows the variants'
+        value when they all share one, and is empty otherwise. This keeps the
+        template field from displaying a value that no variant actually uses.
 
         :param str fname: name of the secondary UoM field to compute
         """
         for template in self:
-            if len(template.product_variant_ids) == 1:
-                template[fname] = template.product_variant_ids[fname]
-            # Keep existing value when multiple variants (don't clear)
+            variant_values = template.product_variant_ids[fname]
+            template[fname] = variant_values if len(variant_values) == 1 else False
 
     def _inverse_template_secondary_uom_field(self, fname):
-        """Helper to propagate template secondary UoM field to variants.
+        """Helper to propagate a template secondary UoM field to its variants.
 
         Can be used in modules depending on product_secondary_unit to implement
         inverse methods for secondary UoM fields on product.template.
 
-        - Single variant: Always sync the template's value to the variant
-        - Multiple variants: Only update variants without their own setting
+        The template value is written to every variant, so that the template
+        field keeps mirroring them. Use
+        :meth:`_onchange_template_secondary_uom_field` to warn the user before
+        overwriting variants that hold diverging values.
 
         :param str fname: name of the secondary UoM field to propagate
         """
         for template in self:
-            if len(template.product_variant_ids) == 1:
-                variants_to_update = template.product_variant_ids
-            else:
-                variants_to_update = template.product_variant_ids.filtered(
-                    lambda v, f=fname: not v[f]
-                )
-            variants_to_update[fname] = template[fname]
+            template.product_variant_ids[fname] = template[fname]
+
+    def _onchange_template_secondary_uom_field(self, fname):
+        """Helper to warn that variants with distinct values will be overwritten.
+
+        Can be used in modules depending on product_secondary_unit to implement
+        onchange methods for secondary UoM fields on product.template.
+
+        :param str fname: name of the secondary UoM field being set
+        :return: an onchange warning, or None when variants do not diverge
+        """
+        self.ensure_one()
+        variant_values = self.product_variant_ids[fname]
+        if len(variant_values) <= 1:
+            return None
+        return {
+            "warning": {
+                "title": self.env._("Warning"),
+                "message": self.env._(
+                    "Product variants have distinct secondary units:"
+                    "\n{secondary_uom}\n"
+                    "All variants will be written with the new secondary unit."
+                ).format(secondary_uom="\n".join(variant_values.mapped("name"))),
+            }
+        }
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        templates = super().create(vals_list)
+        fnames = self._get_template_secondary_uom_fields()
+        if not fnames:
+            return templates
+        # The inverse cannot reach the variant at create time, as it does not
+        # exist yet, so the given values are written again once it does.
+        for template, vals in zip(templates, vals_list, strict=True):
+            related_vals = {fname: vals[fname] for fname in fnames if vals.get(fname)}
+            if related_vals:
+                template.write(related_vals)
+        return templates
+
+    def _get_template_secondary_uom_fields(self):
+        """Return the names of the template secondary UoM mirror fields.
+
+        These are the stored compute/inverse many2one fields to
+        product.secondary.unit declared by modules depending on
+        product_secondary_unit.
+        """
+        return [
+            name
+            for name, field in self._fields.items()
+            if field.type == "many2one"
+            and field.comodel_name == "product.secondary.unit"
+            and field.store
+            and field.compute
+            and field.inverse
+        ]


### PR DESCRIPTION
Add helper methods for syncing secondary UoM fields between product.template and product.product:
- _compute_template_secondary_uom_field
- _inverse_template_secondary_uom_field

Can be used by dependent modules like stock_secondary_unit.

Example for ProductTemplate in stock_secondary_unit:

```.py
    stock_secondary_uom_id = fields.Many2one(
        comodel_name="product.secondary.unit",
        domain="[('product_tmpl_id', '=', id), ('product_id', '=', False)]",
        string="Second unit for inventory",
        compute="_compute_stock_secondary_uom_id",
        inverse="_inverse_stock_secondary_uom_id",
        store=True,
        readonly=False,
    )

    @api.depends("product_variant_ids.stock_secondary_uom_id")
    def _compute_stock_secondary_uom_id(self):
        self._compute_template_secondary_uom_field("stock_secondary_uom_id")

    def _inverse_stock_secondary_uom_id(self):
        self._inverse_template_secondary_uom_field("stock_secondary_uom_id")
```

Adding no tests here as it's tricky to do so in this module.

@qrtl QT6192
