### PR TITLE
Set product_logistics_uom as rebel

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -17,7 +17,8 @@ odoo_test_flavor: Both
 odoo_version: 18.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- product_logistics_uom,product_packaging_dimension
 repo_description: product-attribute
 repo_name: product-attribute
 repo_slug: product-attribute

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,17 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
+            include: "product_logistics_uom,product_packaging_dimension"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
+            include: "product_logistics_uom,product_packaging_dimension"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
+            exclude: "product_logistics_uom,product_packaging_dimension"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
+            exclude: "product_logistics_uom,product_packaging_dimension"
             name: test with OCB
             makepot: "true"
     services:
@@ -50,6 +59,8 @@ jobs:
         ports:
           - 5432:5432
     env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
       OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
       - uses: actions/checkout@v4

--- a/product_logistics_uom/README.rst
+++ b/product_logistics_uom/README.rst
@@ -112,18 +112,18 @@ Authors
 Contributors
 ------------
 
-- Raphaël Reverdy <raphael.reverdy@akretion.com>
-- Fernando La Chica <fernandolachica@gmail.com>
-- Laurent Mignon <laurent.mignon@acsone.eu>
-- Nhan Tran <nhant@trobz.com>
+-  Raphaël Reverdy <raphael.reverdy@akretion.com>
+-  Fernando La Chica <fernandolachica@gmail.com>
+-  Laurent Mignon <laurent.mignon@acsone.eu>
+-  Nhan Tran <nhant@trobz.com>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- Akretion <https://akretion.com>
-- La Base <https://labase.coop>
+-  Akretion <https://akretion.com>
+-  La Base <https://labase.coop>
 
 Maintainers
 -----------

--- a/product_logistics_uom/tests/test_product_logistics_uom.py
+++ b/product_logistics_uom/tests/test_product_logistics_uom.py
@@ -2,8 +2,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 
-from unittest.mock import patch
-
 from odoo.tests.common import TransactionCase
 
 
@@ -61,19 +59,10 @@ class TestProductLogisticsUom(TransactionCase):
         template = self.product.product_tmpl_id
         template.volume_uom_id = self.volume_uom_l
         # Volume calculation from product_dimension module has compatibility issue.
-        with patch(
-            "odoo.addons.product_dimension.models.product_template.ProductTemplate._calc_volume",
-            return_value=1,
-        ):
-            template.volume = 1
-            self.assertEqual(template.product_volume, 1000)
-
-        with patch(
-            "odoo.addons.product_dimension.models.product_template.ProductTemplate._calc_volume",
-            return_value=0.01,
-        ):
-            template.product_volume = 10
-            self.assertEqual(template.volume, 0.01)
+        template.volume = 1
+        self.assertEqual(template.product_volume, 1000)
+        template.product_volume = 10
+        self.assertEqual(template.volume, 0.01)
         template.volume_uom_id = self.volume_uom_m3
         self.assertEqual(template.product_volume, template.volume)
 
@@ -120,11 +109,7 @@ class TestProductLogisticsUom(TransactionCase):
         self.assertFalse(template.show_weight_uom_warning)  # for coverage
         variant.unlink()
         # Volume calculation from product_dimension module has compatibility issue.
-        with patch(
-            "odoo.addons.product_dimension.models.product_template.ProductTemplate._calc_volume",
-            return_value=10.0,
-        ):
-            self.assertEqual(template.volume, 10.0)
+        self.assertEqual(template.volume, 10.0)
         self.assertEqual(template.weight, 10.0)
         self.assertEqual(template.product_volume, 10.0)
         self.assertEqual(template.product_weight, 10.0)


### PR DESCRIPTION
Because of that
https://github.com/OCA/product-attribute/blob/18.0/product_logistics_uom/tests/test_product_logistics_uom.py#L63 that we have to remove

Please @bizzappdev could you review ?

Here product_packaging_dimension depends on product_logistics_uom

cc @hparfr @sebastienbeau please could you review it ?