### PR TITLE
[19.0][IMP] product_net_weight: adopt native style of 19.0

### DIFF
--- a/product_net_weight/README.rst
+++ b/product_net_weight/README.rst
@@ -43,8 +43,8 @@ weight. (container excluded)
 Usage
 =====
 
-- Go to 'Inventory > Master Data > Product' and edit items.
-- Go to 'Inventory' tab, and fill the "Net Weight" value.
+-  Go to 'Inventory > Master Data > Product' and edit items.
+-  Go to 'Inventory' tab, and fill the "Net Weight" value.
 
 |image1|
 
@@ -83,14 +83,14 @@ Authors
 Contributors
 ------------
 
-- Sylvain LE GAL (https://www.twitter.com/legalsylvain)
-- `Greenice <https://www.greenice.com>`__:
+-  Sylvain LE GAL (https://www.twitter.com/legalsylvain)
+-  `Greenice <https://www.greenice.com>`__:
 
-  - Fernando La Chica <fernandolachica@gmail.com>
+   -  Fernando La Chica <fernandolachica@gmail.com>
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Sergio Teruel
+   -  Sergio Teruel
 
 Maintainers
 -----------

--- a/product_net_weight/views/view_product_product.xml
+++ b/product_net_weight/views/view_product_product.xml
@@ -11,7 +11,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="arch" type="xml">
             <xpath expr="//label[@for='weight']" position="before">
                 <label for="net_weight" />
-                <div class="o_row">
+                <div class="d-flex">
                     <field name="net_weight" class="oe_inline" />
                     <field name="weight_uom_name" />
                 </div>

--- a/product_net_weight/views/view_product_template.xml
+++ b/product_net_weight/views/view_product_template.xml
@@ -22,7 +22,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     name="net_weight"
                     invisible="product_variant_count > 1 and not is_product_variant"
                 >
-                    <field name="net_weight" class="oe_inline" />
+                    <field
+                        name="net_weight"
+                        class="oe_inline"
+                        style="max-width: 7rem;"
+                    />
                     <field name="weight_uom_name" />
                 </div>
             </xpath>


### PR DESCRIPTION
I just aligned the CSS class/style used by product_net_weight to the CSS class/style used by the product module for the "weight" field.

Before:

<img width="702" height="600" alt="net_weight_before" src="https://github.com/user-attachments/assets/9086cae4-d502-42e7-a526-cd9790a6ac78" />

After:

<img width="703" height="602" alt="net_weight_after" src="https://github.com/user-attachments/assets/a105e40e-6727-4993-87e8-a05a07e8c98f" />
