### PR TITLE
[18.0][FIX][IMP] product_pricelist_supplierinfo: Fixes and refactoring

### DIFF
--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -37,14 +37,17 @@ class ProductPricelistItem(models.Model):
         return self.env.context.get("force_filter_supplier_id", self.filter_supplier_id)
 
     def _compute_base_price(self, product, quantity, uom, date, currency):
+        """Compute the base price for Odoo that will be used for the full price
+        computation (surcharge/discount/etc.)
+        """
+        price = super()._compute_base_price(product, quantity, uom, date, currency)
         rule_base = self.base or "list_price"
         if rule_base == "supplierinfo":
             context = self.env.context
             price = product.sudo()._get_supplierinfo_pricelist_price(
                 self,
-                date=date or context.get("date", fields.Date.today()),
                 quantity=quantity,
+                uom=uom,
+                date=date or context.get("date", fields.Date.today()),
             )
-        else:
-            price = super()._compute_base_price(product, quantity, uom, date, currency)
         return price

--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -32,6 +32,10 @@ class ProductPricelistItem(models.Model):
         help="Based on supplierinfo price without sale margin applied"
     )
 
+    def get_supplier_id(self):
+        self.ensure_one()
+        return self.env.context.get("force_filter_supplier_id", self.filter_supplier_id)
+
     def _compute_price(self, product, quantity, uom, date, currency=None):
         result = super()._compute_price(product, quantity, uom, date, currency)
         context = self.env.context

--- a/product_pricelist_supplierinfo/models/product_pricelist_item.py
+++ b/product_pricelist_supplierinfo/models/product_pricelist_item.py
@@ -36,13 +36,15 @@ class ProductPricelistItem(models.Model):
         self.ensure_one()
         return self.env.context.get("force_filter_supplier_id", self.filter_supplier_id)
 
-    def _compute_price(self, product, quantity, uom, date, currency=None):
-        result = super()._compute_price(product, quantity, uom, date, currency)
-        context = self.env.context
-        if self.compute_price == "formula" and self.base == "supplierinfo":
-            result = product.sudo()._get_supplierinfo_pricelist_price(
+    def _compute_base_price(self, product, quantity, uom, date, currency):
+        rule_base = self.base or "list_price"
+        if rule_base == "supplierinfo":
+            context = self.env.context
+            price = product.sudo()._get_supplierinfo_pricelist_price(
                 self,
                 date=date or context.get("date", fields.Date.today()),
                 quantity=quantity,
             )
-        return result
+        else:
+            price = super()._compute_base_price(product, quantity, uom, date, currency)
+        return price

--- a/product_pricelist_supplierinfo/models/product_product.py
+++ b/product_pricelist_supplierinfo/models/product_product.py
@@ -20,9 +20,11 @@ class ProductProduct(models.Model):
             sellers = sellers.sorted("min_qty")
         return sellers
 
-    def _get_supplierinfo_pricelist_price(self, rule, date=None, quantity=None):
+    def _get_supplierinfo_pricelist_price(
+        self, rule, quantity=None, date=None, uom=None
+    ):
         return self.product_tmpl_id._get_supplierinfo_pricelist_price(
-            rule, date=date, quantity=quantity, product_id=self.id
+            rule, quantity=quantity, product_id=self.id, uom=uom, date=date
         )
 
     def _price_compute(

--- a/product_pricelist_supplierinfo/models/product_product.py
+++ b/product_pricelist_supplierinfo/models/product_product.py
@@ -33,7 +33,8 @@ class ProductProduct(models.Model):
         correct values.
         """
         if price_type == "supplierinfo":
-            return dict.fromkeys(self.ids, 1.0)
+            # Do not use self.ids because of possible NewId values
+            return dict.fromkeys(self.mapped("id"), 1.0)
         return super()._price_compute(
             price_type,
             uom=uom,

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -5,14 +5,14 @@
 
 from datetime import datetime
 
-from odoo import fields, models
+from odoo import models
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     def _get_supplierinfo_pricelist_price(
-        self, rule, date=None, quantity=None, product_id=None
+        self, rule, quantity=None, product_id=None, uom=None, date=None
     ):
         """Method for getting the price from supplier info."""
         self.ensure_one()
@@ -47,21 +47,17 @@ class ProductTemplate(models.Model):
             # We need to convert the price if the pricelist and seller have
             # different currencies so the price have the pricelist currency
             if rule.currency_id != seller.currency_id:
-                convert_date = date or self.env.context.get("date", fields.Date.today())
                 price = seller.currency_id._convert(
-                    price, rule.currency_id, seller.company_id, convert_date
+                    price, rule.currency_id, seller.company_id, date
                 )
-
-            # We have to replicate this logic in this method as pricelist
-            # method are atomic and we can't hack inside.
-            # Verbatim copy of part of product.pricelist._compute_price_rule.
-            qty_uom_id = self._context.get("uom") or self.uom_id.id
-            price_uom = self.env["uom.uom"].browse([qty_uom_id])
 
             # We need to convert the price to the uom used on the sale, if the
             # uom on the seller is a different one that the one used there.
-            if seller and seller.product_uom != price_uom:
-                price = seller.product_uom._compute_price(price, price_uom)
+            if seller:
+                # If no uom is specified, fall back on the product uom
+                target_uom = uom or self.uom_id
+                if seller.product_uom != target_uom:
+                    price = seller.product_uom._compute_price(price, target_uom)
         return price
 
     def _price_compute(

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -91,7 +91,8 @@ class ProductTemplate(models.Model):
         correct values.
         """
         if price_type == "supplierinfo":
-            return dict.fromkeys(self.ids, 1.0)
+            # Do not use self.ids because of possible NewId values
+            return dict.fromkeys(self.mapped("id"), 1.0)
         return super()._price_compute(
             price_type, uom=uom, currency=currency, company=company, date=date
         )

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -5,7 +5,7 @@
 
 from datetime import datetime
 
-from odoo import fields, models, tools
+from odoo import fields, models
 
 
 class ProductTemplate(models.Model):
@@ -62,25 +62,6 @@ class ProductTemplate(models.Model):
             # uom on the seller is a different one that the one used there.
             if seller and seller.product_uom != price_uom:
                 price = seller.product_uom._compute_price(price, price_uom)
-            price_limit = price
-            price = (price - (price * (rule.price_discount / 100))) or 0.0
-            if rule.price_round:
-                price = tools.float_round(price, precision_rounding=rule.price_round)
-            if rule.price_surcharge:
-                price_surcharge = self.uom_id._compute_price(
-                    rule.price_surcharge, price_uom
-                )
-                price += price_surcharge
-            if rule.price_min_margin:
-                price_min_margin = self.uom_id._compute_price(
-                    rule.price_min_margin, price_uom
-                )
-                price = max(price, price_limit + price_min_margin)
-            if rule.price_max_margin:
-                price_max_margin = self.uom_id._compute_price(
-                    rule.price_max_margin, price_uom
-                )
-                price = min(price, price_limit + price_max_margin)
         return price
 
     def _price_compute(

--- a/product_pricelist_supplierinfo/models/product_template.py
+++ b/product_pricelist_supplierinfo/models/product_template.py
@@ -34,9 +34,7 @@ class ProductTemplate(models.Model):
             )._select_seller(
                 # For a public user this record could be not accessible, but we
                 # need to get the price anyway
-                partner_id=self.env.context.get(
-                    "force_filter_supplier_id", rule.sudo().filter_supplier_id
-                ),
+                partner_id=rule.sudo().get_supplier_id(),
                 quantity=quantity,
                 date=date,
             )

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -159,9 +159,22 @@ class TestProductSupplierinfo(BaseCommon):
 
     def test_pricelist_dates(self):
         """Test pricelist and supplierinfo dates"""
+
+        # Set a start date for the supplier #1
         self.product.seller_ids.filtered(lambda x: x.min_qty == 5)[
             0
         ].date_start = "2018-12-31"
+        # If today is before this date, supplier #1 is ignored and we fallback on
+        # selecting supplier #2
+        self.assertAlmostEqual(
+            self.pricelist._get_product_price(
+                self.product,
+                5,
+                date=date(2018, 12, 30),
+            ),
+            10,
+        )
+        # If today is after this date, supplier #1 is selected
         self.assertAlmostEqual(
             self.pricelist._get_product_price(
                 self.product,
@@ -169,6 +182,42 @@ class TestProductSupplierinfo(BaseCommon):
                 date=date(2019, 1, 1),
             ),
             50,
+        )
+        # Now create a new and more interesting supplier offer (same min. quantities)
+        # with a starting date already set
+        supplier3 = self.partner_obj.create({"name": "Supplier #3"})
+        self.product.write(
+            {
+                "seller_ids": [
+                    Command.create(
+                        {
+                            "partner_id": supplier3.id,
+                            "min_qty": 5,
+                            "price": 45,
+                            "date_start": "2019-01-02",
+                        }
+                    ),
+                ]
+            }
+        )
+        # If today is before this date, supplier #3 is ignored and we fallback on
+        # selecting supplier #1
+        self.assertAlmostEqual(
+            self.pricelist._get_product_price(
+                self.product,
+                5,
+                date=date(2019, 1, 1),
+            ),
+            50,
+        )
+        # If today is after this date, the new supplier #3 is selected
+        self.assertAlmostEqual(
+            self.pricelist._get_product_price(
+                self.product,
+                5,
+                date=date(2019, 1, 3),
+            ),
+            45,
         )
 
     def test_pricelist_based_price_round(self):

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -130,6 +130,33 @@ class TestProductSupplierinfo(BaseCommon):
             10,
         )
 
+    def test_pricelist_select_supplier(self):
+        supplier3 = self.partner_obj.create({"name": "Supplier #3"})
+        self.product.write(
+            {
+                "seller_ids": [
+                    Command.create(
+                        {"partner_id": supplier3.id, "min_qty": 1, "price": 9},
+                    )
+                ]
+            }
+        )
+        for seller, expected_price in [
+            (self.product.seller_ids[0], 50),
+            (self.product.seller_ids[1], 10),
+            (self.product.seller_ids[2], 9),
+        ]:
+            price = self.pricelist.with_context(
+                force_filter_supplier_id=seller.partner_id
+            )._get_product_price(
+                product=seller.product_id or seller.product_tmpl_id,
+                quantity=seller.min_qty,
+                partner=False,
+                uom_id=seller.product_uom.id,
+            )
+            self.assertEqual(price, expected_price)
+            self.assertEqual(price, seller.price)
+
     def test_pricelist_dates(self):
         """Test pricelist and supplierinfo dates"""
         self.product.seller_ids.filtered(lambda x: x.min_qty == 5)[

--- a/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
+++ b/product_pricelist_supplierinfo/tests/test_product_supplierinfo.py
@@ -320,28 +320,50 @@ class TestProductSupplierinfo(BaseCommon):
                 "applied_on": "0_product_variant",
                 "product_id": self.product_with_diff_uom.id,
                 "price_discount": -20,
+                # Remember that formula's computed price is expressed in the
+                # product's default UoM
+                "price_surcharge": 3.0,
             }
         )
 
         product_seller_price = self.product_with_diff_uom.seller_ids[0].price
-        uom_dozen = self.env.ref("uom.product_uom_dozen")
-        product_pricelist_price_dozen = self.pricelist._get_product_price(
-            self.product_with_diff_uom.with_context(uom=uom_dozen.id), 1
-        )
-        uom_unit = self.env.ref("uom.product_uom_unit")
-        product_pricelist_price_unit = self.pricelist._get_product_price(
-            self.product_with_diff_uom.with_context(uom=uom_unit.id), 1
-        )
-        # The price with the will be 1200 on the seller (1 Dozen)
+        # The price with the pricelist will be 1200 on the seller (1 Dozen)
         self.assertEqual(product_seller_price, 1200)
 
-        # The price with the will be 1200 plus the increment of the 20% which will
-        # give us a total of 1440 (1 Dozen)
-        self.assertEqual(product_pricelist_price_dozen, 1440)
+        uom_dozen = self.env.ref("uom.product_uom_dozen")
+        product_pricelist_price_dozen = self.pricelist._get_product_price(
+            self.product_with_diff_uom, 1, uom=uom_dozen
+        )
 
+        # The price with the pricelist will be 1200 plus the increment of the 20% plus
+        # a surcharge of 36 which will give us a total of 1476 (for 1 Dozen)
+        self.assertEqual(product_pricelist_price_dozen, 1476)
+
+        uom_unit = self.env.ref("uom.product_uom_unit")
+        product_pricelist_price_unit = self.pricelist._get_product_price(
+            self.product_with_diff_uom, 1, uom=uom_unit
+        )
         # And the price with the pricelist and the uom of Units (Instead of Dozen)
-        # will be 100, plus the 20% the total will be 120 per Unit
-        self.assertEqual(product_pricelist_price_unit, 120)
+        # will be 100, plus the 20%, plus 3.0 of sucharge, the total will be 123 per
+        # Unit
+        self.assertEqual(product_pricelist_price_unit, 123)
+
+        # Add an intermediate UoM (half-dozen) to ensure valid results when the wanted
+        # UoM is not one of the product's default (uom_id, uom_po_id)
+        uom_half_dozen = self.env["uom.uom"].create(
+            {
+                "name": "Half-dozens",
+                "category_id": self.env.ref("uom.product_uom_categ_unit").id,
+                "factor_inv": 6.0,
+                "uom_type": "bigger",
+            }
+        )
+        product_pricelist_price_half_dozen = self.pricelist._get_product_price(
+            self.product_with_diff_uom, 1, uom=uom_half_dozen
+        )
+        # Same logic as before, but now for half-dozen, so the base price will be 600,
+        # plus 20% (120), +3.0/unit surcharge (18), totaling 738
+        self.assertEqual(product_pricelist_price_half_dozen, 738)
 
     def test_pricelist_exclude_supplier_info_discount(self):
         """Test the scenario where the product supplier info includes a discount, to


### PR DESCRIPTION
Fix and improvements for Odoo 18.0 (this PR is based on a closed PR I previously made for Odoo 14.0 https://github.com/OCA/product-attribute/pull/1357)

1. Use rule context: Instead of trying to get the product context, we must use the `product.pricelist.item` context to get the filtered partner. The current implementation is broken, a new test is added to ensure that it works correctly now.
2. Let Odoo compute the produce price: Odoo's pricelist computation is now correctly split, so we override the base price computation instead of the full price and we let Odoo compute surcharge/discount/etc. This improvement removes a lot of code that was copy/paste from Odoo price computation.
3. Refactoring to match Odoo's pricelist API: To match the new price computation signature from https://github.com/odoo/odoo/commit/57ced812. (Also drop support to get "UoM" and "date" from context)
4. More and improved tests on UoM and Dates.
