### PR TITLE
[18.0][FIX] product_multi_price: Use the more atomic function to compute prices in the pricelist

### DIFF
--- a/product_multi_price/models/product_pricelist.py
+++ b/product_multi_price/models/product_pricelist.py
@@ -3,44 +3,6 @@
 from odoo import fields, models
 
 
-class ProductPricelist(models.Model):
-    _inherit = "product.pricelist"
-
-    def _compute_price_rule(
-        self,
-        products,
-        quantity,
-        currency=None,
-        uom=None,
-        date=False,
-        compute_price=True,
-        **kwargs,
-    ):
-        """Recompute price after calling the atomic super method for
-        getting proper prices when based on multi price.
-        """
-        rule_obj = self.env["product.pricelist.item"]
-        result = super()._compute_price_rule(
-            products=products,
-            quantity=quantity,
-            currency=currency,
-            uom=uom,
-            date=date,
-            compute_price=compute_price,
-            **kwargs,
-        )
-        # Make sure all rule records are fetched at once and put in cache
-        rule_obj.browse(x[1] for x in result.values()).mapped("price_discount")
-        for product in products:
-            rule = rule_obj.browse(result[product.id][1])
-            if rule.compute_price == "formula" and rule.base == "multi_price":
-                result[product.id] = (
-                    product._get_multiprice_pricelist_price(rule),
-                    rule.id,
-                )
-        return result
-
-
 class ProductPricelistItem(models.Model):
     _inherit = "product.pricelist.item"
 
@@ -52,3 +14,11 @@ class ProductPricelistItem(models.Model):
         comodel_name="product.multi.price.name",
         string="Other Price Name",
     )
+
+    def _compute_price(self, product, quantity, uom, date, currency=None):
+        # Recompute price after calling the atomic super method for
+        # getting proper prices when based on multi price.
+        price = super()._compute_price(product, quantity, uom, date, currency)
+        if self.compute_price == "formula" and self.base == "multi_price":
+            price = product._get_multiprice_pricelist_price(self)
+        return price

--- a/product_multi_price/tests/test_product_multi_price.py
+++ b/product_multi_price/tests/test_product_multi_price.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import Command
+from odoo import Command, fields
 from odoo.tests.common import TransactionCase
 
 
@@ -93,4 +93,30 @@ class TestProductMultiPrice(TransactionCase):
         price = self.prod_prod_2_2.with_context(
             pricelist=self.pricelist.id
         )._get_contextual_price()
+        self.assertAlmostEqual(price, 7.92)
+
+    def test_product_multi_price_pricelist_item(self):
+        """Pricelists based on multi prices using the pricelist items"""
+        pricelist_item = self.pricelist.item_ids[0]
+        today = fields.Date.context_today(self.env.user)
+        price = pricelist_item._compute_price(
+            self.prod_1,
+            1.0,
+            self.prod_1.uom_id,
+            today,
+        )
+        self.assertAlmostEqual(price, 4.95)
+        price = pricelist_item._compute_price(
+            self.prod_prod_2_1,
+            1.0,
+            self.prod_prod_2_1.uom_id,
+            today,
+        )
+        self.assertAlmostEqual(price, 5.94)
+        price = pricelist_item._compute_price(
+            self.prod_prod_2_2,
+            1.0,
+            self.prod_prod_2_2.uom_id,
+            today,
+        )
         self.assertAlmostEqual(price, 7.92)


### PR DESCRIPTION
When the pricelist is used in the sale order, this does not work because in v18 the `_compute_price_rule` function only computes the `pricelist_item_id` field. https://github.com/odoo/odoo/blob/37bf1703c7478a3010b71cd60bbb43b3295a605b/addons/sale/models/sale_order_line.py#L554

The `price_unit` is computed based on `pricelist_item_id`, but using the `_compute_price` function: https://github.com/odoo/odoo/blob/37bf1703c7478a3010b71cd60bbb43b3295a605b/addons/sale/models/sale_order_line.py#L658C40-L658C54

This commit updates the function to work correctly in all places by inheriting the more atomic function.

Complementary to the migration to v18 https://github.com/OCA/product-attribute/pull/2103
TT56365
@Tecnativa @pedrobaeza @christian-ramos-tecnativa @eduezerouali-tecnativa could you please review this?