### PR TITLE
[FIX] product_code_unique - remove duplicate warning for "Internal Reference"

### DIFF
--- a/product_code_unique/README.rst
+++ b/product_code_unique/README.rst
@@ -45,14 +45,6 @@ Usage
   an internal reference(default_code). A default value is generated to
   populate empty field as a temporary value.
 
-Known issues / Roadmap
-======================
-
-- Avoid duplicate warnings. Odoo has a warning for duplicate "Internal
-  Reference" of its own (it doesn't block from saving). Now both
-  warnings are displayed when trying to save a duplicate "Internal
-  Reference".
-
 Bug Tracker
 ===========
 

--- a/product_code_unique/models/__init__.py
+++ b/product_code_unique/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import product
+from . import product_product
+from . import product_template

--- a/product_code_unique/models/product_product.py
+++ b/product_code_unique/models/product_product.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class ProductProduct(models.Model):
@@ -14,3 +14,10 @@ class ProductProduct(models.Model):
             "Internal Reference must be unique across the database!",
         )
     ]
+
+    @api.onchange("default_code")
+    def _onchange_default_code(self):
+        res = super()._onchange_default_code()
+        if isinstance(res, dict):
+            res.pop("warning", None)
+        return res

--- a/product_code_unique/models/product_template.py
+++ b/product_code_unique/models/product_template.py
@@ -1,0 +1,15 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.onchange("default_code")
+    def _onchange_default_code(self):
+        res = super()._onchange_default_code()
+        if isinstance(res, dict):
+            res.pop("warning", None)
+        return res

--- a/product_code_unique/readme/ROADMAP.md
+++ b/product_code_unique/readme/ROADMAP.md
@@ -1,4 +1,0 @@
-- Avoid duplicate warnings. Odoo has a warning for duplicate "Internal
-  Reference" of its own (it doesn't block from saving). Now both
-  warnings are displayed when trying to save a duplicate "Internal
-  Reference".

--- a/product_code_unique/static/description/index.html
+++ b/product_code_unique/static/description/index.html
@@ -376,12 +376,11 @@ to make it unique across the database.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -396,17 +395,8 @@ an internal reference(default_code). A default value is generated to
 populate empty field as a temporary value.</li>
 </ul>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
-<ul class="simple">
-<li>Avoid duplicate warnings. Odoo has a warning for duplicate “Internal
-Reference” of its own (it doesn’t block from saving). Now both
-warnings are displayed when trying to save a duplicate “Internal
-Reference”.</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/product-attribute/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -414,15 +404,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>Open Source Integrators</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li>Antonio Yamuta &lt;<a class="reference external" href="mailto:ayamuta&#64;opensourceintegrators.com">ayamuta&#64;opensourceintegrators.com</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
@@ -431,7 +421,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
Remove the standard warnings from Odoo when trying to save a duplicate "Internal Reference", because this module already introduces a constraint avoiding duplicates.