### PR TITLE
[18.0][IMP] product_supplierinfo_import: Make tests more resilients

### DIFF
--- a/product_supplierinfo_import/tests/test_product_supplierinfo_import.py
+++ b/product_supplierinfo_import/tests/test_product_supplierinfo_import.py
@@ -141,7 +141,7 @@ class TestProductSupplierinfoImportCommon(BaseCommon):
         for supplierinfo, values in supplierinfo_dict.items():
             for field, value in values.items():
                 if isinstance(value, float):
-                    self.assertAlmostEqual(supplierinfo[field], value)
+                    self.assertAlmostEqual(supplierinfo[field], value, 2)
                 else:
                     self.assertEqual(supplierinfo[field], value)
 


### PR DESCRIPTION
cc @Tecnativa 

This PR avoid test fails like this:

`odoo.addons.product_supplierinfo_import.tests.test_product_supplierinfo_import: FAIL: TestProductSupplierinfoImportByBarcode.test_complex_import_product_code
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/freezegun/api.py", line 778, in wrapper
    result = func(*args, **kwargs)
  File "/opt/odoo/auto/addons/product_supplierinfo_import/tests/test_product_supplierinfo_import.py", line 290, in test_complex_import_product_code
    self._check_supplierinfo_values(
  File "/opt/odoo/auto/addons/product_supplierinfo_import/tests/test_product_supplierinfo_import.py", line 144, in _check_supplierinfo_values
    self.assertAlmostEqual(supplierinfo[field], value)
AssertionError: 15.288 != 15.29 within 7 places (0.0019999999999988916 difference)`

ping @juancarlosonate-tecnativa @carlos-lopez-tecnativa 