### PR TITLE
[18.0][IMP] product_set: improve view product set

### DIFF
--- a/product_set/views/product_set.xml
+++ b/product_set/views/product_set.xml
@@ -3,7 +3,6 @@
     <record id="view_product_set_tree" model="ir.ui.view">
         <field name="name">product.set.list</field>
         <field name="model">product.set</field>
-        <field name="type">list</field>
         <field name="arch" type="xml">
             <list>
                 <field name="ref" />
@@ -16,7 +15,6 @@
     <record id="view_product_set_form" model="ir.ui.view">
         <field name="name">product.set.form</field>
         <field name="model">product.set</field>
-        <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Product set">
                 <sheet>
@@ -40,46 +38,58 @@
                                 groups="base.group_multi_company"
                             />
                         </group>
-                        <label for="set_line_ids" />
-                        <field
-                            name="set_line_ids"
-                            nolabel="1"
-                            widget="section_and_note_one2many"
-                        >
-                            <list editable="top">
-                                <field name="sequence" widget="handle" />
-                                <field name="active" widget="boolean_toggle" />
-                                <field name="product_id" required="not display_type" />
+                        <notebook>
+                            <page name="set_line_ids" string="Set">
                                 <field
-                                    name="product_packaging_id"
-                                    context="{'default_product_id': product_id}"
-                                    groups="product.group_stock_packaging"
-                                />
-                                <field
-                                    name="product_packaging_qty"
-                                    groups="product.group_stock_packaging"
-                                />
-                                <field name="quantity" />
-                                <field name="display_type" invisible="1" />
-                                <field name="name" widget="section_and_note_text" />
-                                <control>
-                                    <create
-                                        name="add_line_control"
-                                        string="Add a line"
-                                    />
-                                    <create
-                                        name="add_section_control"
-                                        string="Add a section"
-                                        context="{'default_display_type': 'line_section'}"
-                                    />
-                                    <create
-                                        name="add_note_control"
-                                        string="Add a note"
-                                        context="{'default_display_type': 'line_note'}"
-                                    />
-                                </control>
-                            </list>
-                        </field>
+                                    name="set_line_ids"
+                                    widget="section_and_note_one2many"
+                                >
+                                    <list editable="bottom">
+                                        <control>
+                                            <create
+                                                name="add_line_control"
+                                                string="Add a line"
+                                            />
+                                            <create
+                                                name="add_section_control"
+                                                string="Add a section"
+                                                context="{'default_display_type': 'line_section'}"
+                                            />
+                                            <create
+                                                name="add_note_control"
+                                                string="Add a note"
+                                                context="{'default_display_type': 'line_note'}"
+                                            />
+                                        </control>
+                                        <field name="sequence" widget="handle" />
+                                        <field
+                                            name="product_id"
+                                            widget="product_label_section_and_note_field"
+                                            required="not display_type"
+                                        />
+                                        <field
+                                            name="name"
+                                            widget="section_and_note_text"
+                                        />
+                                        <field
+                                            name="product_packaging_id"
+                                            context="{'default_product_id': product_id}"
+                                            groups="product.group_stock_packaging"
+                                        />
+                                        <field
+                                            name="product_packaging_qty"
+                                            groups="product.group_stock_packaging"
+                                        />
+                                        <field name="quantity" />
+                                        <field
+                                            name="display_type"
+                                            column_invisible="1"
+                                        />
+                                        <field name="active" widget="boolean_toggle" />
+                                    </list>
+                                </field>
+                            </page>
+                        </notebook>
                     </group>
                 </sheet>
             </form>
@@ -88,11 +98,10 @@
     <record id="view_product_set_search" model="ir.ui.view">
         <field name="name">product.set.search</field>
         <field name="model">product.set</field>
-        <field name="type">search</field>
         <field name="arch" type="xml">
             <search string="Product set">
-                <field name="name" select="True" />
-                <field name="ref" select="True" />
+                <field name="name" />
+                <field name="ref" />
                 <field name="partner_id" />
                 <separator />
                 <filter
@@ -110,34 +119,22 @@
                     name="archived"
                     domain="[('active', '=', False)]"
                 />
-                <filter
-                    name="group_by_partner_id"
-                    string="Partner"
-                    domain="[]"
-                    context="{'group_by':'partner_id'}"
-                />
+                <group>
+                    <filter
+                        name="group_by_partner_id"
+                        string="Partner"
+                        context="{'group_by':'partner_id'}"
+                    />
+                </group>
             </search>
         </field>
     </record>
-    <record model="ir.actions.act_window" id="act_open_product_set_view">
+    <record id="act_open_product_set_view" model="ir.actions.act_window">
         <field name="name">Product set</field>
-        <field name="type">ir.actions.act_window</field>
         <field name="res_model">product.set</field>
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_product_set_search" />
         <field name="domain">[]</field>
         <field name="context">{'active_test': False, 'search_default_all': 1}</field>
-    </record>
-    <record model="ir.actions.act_window.view" id="act_open_product_set_view_form">
-        <field name="act_window_id" ref="act_open_product_set_view" />
-        <field name="sequence" eval="20" />
-        <field name="view_mode">form</field>
-        <field name="view_id" ref="view_product_set_form" />
-    </record>
-    <record model="ir.actions.act_window.view" id="act_open_product_set_view_tree">
-        <field name="act_window_id" ref="act_open_product_set_view" />
-        <field name="sequence" eval="10" />
-        <field name="view_mode">list</field>
-        <field name="view_id" ref="view_product_set_tree" />
     </record>
 </odoo>

--- a/product_set/views/product_set_line.xml
+++ b/product_set/views/product_set_line.xml
@@ -3,7 +3,6 @@
     <record id="view_product_set_line_tree" model="ir.ui.view">
         <field name="name">product.set.line.list</field>
         <field name="model">product.set.line</field>
-        <field name="type">list</field>
         <field name="arch" type="xml">
             <list editable="top">
                 <field name="product_set_id" />
@@ -11,8 +10,12 @@
                 <field
                     name="product_packaging_id"
                     context="{'default_product_id': product_id}"
+                    groups="product.group_stock_packaging"
                 />
-                <field name="product_packaging_qty" />
+                <field
+                    name="product_packaging_qty"
+                    groups="product.group_stock_packaging"
+                />
                 <field name="quantity" />
             </list>
         </field>
@@ -20,7 +23,6 @@
     <record id="view_product_set_line_search" model="ir.ui.view">
         <field name="name">product.set.line.search</field>
         <field name="model">product.set.line</field>
-        <field name="type">search</field>
         <field name="priority" eval="8" />
         <field name="arch" type="xml">
             <search string="Product set line">
@@ -44,24 +46,23 @@
                     domain="[('active', '=', False)]"
                 />
                 <separator />
-                <filter
-                    name="group_by_product_set_id"
-                    string="Product set"
-                    domain="[]"
-                    context="{'group_by':'product_set_id'}"
-                />
-                <filter
-                    name="group_by_product_id"
-                    string="Product"
-                    domain="[]"
-                    context="{'group_by':'product_id'}"
-                />
+                <group>
+                    <filter
+                        name="group_by_product_set_id"
+                        string="Product set"
+                        context="{'group_by':'product_set_id'}"
+                    />
+                    <filter
+                        name="group_by_product_id"
+                        string="Product"
+                        context="{'group_by':'product_id'}"
+                    />
+                </group>
             </search>
         </field>
     </record>
-    <record model="ir.actions.act_window" id="act_open_product_set_line_view">
+    <record id="act_open_product_set_line_view" model="ir.actions.act_window">
         <field name="name">Product set line</field>
-        <field name="type">ir.actions.act_window</field>
         <field name="res_model">product.set.line</field>
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_product_set_line_search" />


### PR DESCRIPTION
- Delete code is not used in version18
- Improve view product set

Before
<img width="2306" height="751" alt="selection_040" src="https://github.com/user-attachments/assets/b6065714-4361-45c6-84d2-e67debbe9e82" />

After
<img width="2393" height="783" alt="selection_041" src="https://github.com/user-attachments/assets/2c88648e-1cff-436b-8ce6-d1f979458ad5" />
