### PR TITLE
[16.0][OU-FIX] product_packaging_level: Fixed migration script for Migration 16.0

### DIFF
--- a/product_packaging_level/migrations/16.0.1.0.0/post-migration.py
+++ b/product_packaging_level/migrations/16.0.1.0.0/post-migration.py
@@ -7,7 +7,7 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env, "product_packaging_level", "16.0.1.0.0/noupdate_changes.xml"
+        env.cr, "product_packaging_level", "16.0.1.0.0/noupdate_changes.xml"
     )
     openupgrade.delete_record_translations(
         env.cr,


### PR DESCRIPTION
This fixes the migration script. The script currently fails when migrating to 16.0 

```
Traceback (most recent call last):
  File "/path/to/odoo/odoo/service/server.py", line 1326, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-16>", line 2, in new
  File "/path/to/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/path/to/odoo/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(cr, graph,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/odoo/odoo/modules/loading.py", line 374, in load_marked_modules
    loaded, processed = load_module_graph(
                        ^^^^^^^^^^^^^^^^^^
  File "/path/to/odoo/odoo/modules/loading.py", line 238, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/path/to/openupgrade/openupgrade_framework/odoo_patch/odoo/modules/migration.py", line 21, in migrate_module
    MigrationManager.migrate_module._original_method(self, pkg, stage)
  File "/path/to/odoo/odoo/modules/migration.py", line 170, in migrate_module
    exec_script(self.cr, installed_version, pyfile, pkg.name, stage, stageformat[stage] % version)
  File "/path/to/odoo/odoo/modules/migration.py", line 188, in exec_script
    migrate(cr, installed_version)
  File "/path/to/venv/lib/python3.12/site-packages/openupgradelib/openupgrade.py", line 2406, in wrapped_function
    func(
  File "/path/to/venv/lib/python3.12/site-packages/odoo/addons/product_packaging_level/migrations/16.0.1.0.0/post-migration.py", line 9, in migrate
    openupgrade.load_data(
  File "/path/to/venv/lib/python3.12/site-packages/openupgradelib/openupgrade.py", line 389, in load_data
    tools.convert_xml_import(env_or_cr, module_name, fp, idref, mode=mode)
  File "/path/to/odoo/odoo/tools/convert.py", line 828, in convert_xml_import
    obj = xml_import(cr, module, idref, mode, noupdate=noupdate, xml_filename=xml_filename)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/odoo/odoo/tools/convert.py", line 731, in __init__
    self.envs = [odoo.api.Environment(cr, SUPERUSER_ID, {})]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/odoo/odoo/api.py", line 522, in __new__
    assert isinstance(cr, BaseCursor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```