### PR TITLE
[FIX] base_product_mass_addition: Trigger onchange for all new lines

### DIFF
--- a/base_product_mass_addition/README.rst
+++ b/base_product_mass_addition/README.rst
@@ -82,6 +82,9 @@ Akretion
 * `Camptocamp <https://www.camptocamp.com>`_
 
     * Iván Todorovich <ivan.todorovich@camptocamp.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_product_mass_addition/models/product_mass_addition.py
+++ b/base_product_mass_addition/models/product_mass_addition.py
@@ -67,7 +67,5 @@ class ProductMassAddition(models.AbstractModel):
             line = lines.filtered(lambda x: x.id == vals["id"])
             return line.play_onchanges(update_vals, list(update_vals.keys()))
         else:
-            line = lines
-            if len(lines) > 1:
-                line = lines[0]
+            line = self.env[lines._name]
             return line.play_onchanges(vals, list(vals.keys()))

--- a/base_product_mass_addition/readme/CONTRIBUTORS.rst
+++ b/base_product_mass_addition/readme/CONTRIBUTORS.rst
@@ -8,3 +8,6 @@ Akretion
 * `Camptocamp <https://www.camptocamp.com>`_
 
     * Iván Todorovich <ivan.todorovich@camptocamp.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/base_product_mass_addition/static/description/index.html
+++ b/base_product_mass_addition/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -438,12 +438,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first"><a class="reference external" href="https://www.pytech.it">PyTech</a>:</p>
+<ul class="simple">
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/base_product_mass_addition/tests/models/order.py
+++ b/base_product_mass_addition/tests/models/order.py
@@ -2,7 +2,7 @@
 # @author Iván Todorovich <ivan.todorovich@camptocamp.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ModelOrder(models.Model):
@@ -34,3 +34,8 @@ class ModelOrderLine(models.Model):
     order_id = fields.Many2one("model.order")
     product_id = fields.Many2one("product.product")
     product_qty = fields.Float()
+    changed = fields.Boolean()
+
+    @api.onchange("product_qty")
+    def onchange_product_qty(self):
+        self.changed = True

--- a/base_product_mass_addition/tests/test_product_mass_addition.py
+++ b/base_product_mass_addition/tests/test_product_mass_addition.py
@@ -24,6 +24,15 @@ class TestProductMassAddition(SavepointCase):
         cls.product = cls.env.ref("product.product_product_8").with_context(
             **cls.quick_ctx
         )
+        cls.other_product = (
+            cls.env["product.product"]
+            .with_context(**cls.quick_ctx)
+            .create(
+                {
+                    "name": "Test Product",
+                }
+            )
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -59,3 +68,15 @@ class TestProductMassAddition(SavepointCase):
         self.product.name = "Testing"
         self.env["base"].flush()
         self.assertEqual(self.product.write_uid, self.env.user)
+
+    def test_complete_multiple_lines(self):
+        """When adding multiple lines, all the lines are completed."""
+        # pre-condition
+        self.assertFalse(self.order.line_ids)
+
+        # Act
+        self.product.qty_to_process = 5.0
+        self.other_product.qty_to_process = 5.0
+
+        # Assert
+        self.assertTrue(all(self.order.line_ids.mapped("changed")))


### PR DESCRIPTION
Backporting https://github.com/OCA/product-attribute/pull/1604 from `15.0`.
@HaraldPanten @angelgarciadelachica @luis-ron you worked on the linked PR, maybe you are interested in this one too?

I also added another commit with a unit test for the added fix.