### PR TITLE
[17.0][OU-ADD] product_pricelist_supplierinfo: Migration scripts

### DIFF
--- a/product_pricelist_supplierinfo/migrations/17.0.2.0.0/post-migration.py
+++ b/product_pricelist_supplierinfo/migrations/17.0.2.0.0/post-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        "UPDATE product_pricelist_item SET no_supplierinfo_discount=True",
+    )
+    env["ir.default"].set("product.pricelist.item", "no_supplierinfo_discount", "true")


### PR DESCRIPTION
When coming from previous versions, where the discount at product.supplierinfo were not taken into account to compute the sales price, you would expect the same for this version, so for this smooth transition, let's set the new flag for ignoring the discount in all the existing lines for preserving the previous behavior, as well as setting it as default for new items.

@Tecnativa TT61036