### PR TITLE
[18.0][FIX] product_attribute_value_menu: same label warning

### DIFF
--- a/product_attribute_value_menu/models/product_attribute_value.py
+++ b/product_attribute_value_menu/models/product_attribute_value.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class ProductAttributeValue(models.Model):
     _inherit = "product.attribute.value"
 
-    product_count = fields.Integer(string="Product", compute="_compute_product_count")
+    product_count = fields.Integer(compute="_compute_product_count")
 
     @api.depends("pav_attribute_line_ids")
     def _compute_product_count(self):


### PR DESCRIPTION
This simple fix avoids a same label warning.