### PR TITLE
[18.0][IMP] product_set: Change where the mock has to be loaded

### DIFF
--- a/product_packaging_calculator/tests/test_product_qty_by_packaging_mixin.py
+++ b/product_packaging_calculator/tests/test_product_qty_by_packaging_mixin.py
@@ -5,21 +5,19 @@ from .common import TestCommon
 
 
 class TestPQPackagingMixin(TestCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
         # Load a test model using odoo_test_helper
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .models import TestProductQtyByPackagingMixin
 
-        cls.loader.update_registry((TestProductQtyByPackagingMixin,))
-        cls.model = cls.env[TestProductQtyByPackagingMixin._name]
+        self.loader.update_registry((TestProductQtyByPackagingMixin,))
+        self.model = self.env[TestProductQtyByPackagingMixin._name]
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_1_quantity_packaging(self):
         record = self.model.create({"product_id": self.product_a.id, "quantity": 10})

--- a/product_secondary_unit/tests/test_secondary_unit_mixin.py
+++ b/product_secondary_unit/tests/test_secondary_unit_mixin.py
@@ -7,27 +7,26 @@ from odoo.tests import TransactionCase
 
 
 class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .models import SecondaryUnitFake
 
-        cls.loader.update_registry((SecondaryUnitFake,))
-        cls.product_uom_unit = cls.env.ref("uom.product_uom_unit")
-        cls.product_uom_dozen = cls.env.ref("uom.product_uom_dozen")
-        cls.product_template = cls.env["product.template"].create(
+        self.loader.update_registry((SecondaryUnitFake,))
+        self.product_uom_unit = self.env.ref("uom.product_uom_unit")
+        self.product_uom_dozen = self.env.ref("uom.product_uom_dozen")
+        self.product_template = self.env["product.template"].create(
             {
                 "name": "test",
-                "uom_id": cls.product_uom_unit.id,
-                "uom_po_id": cls.product_uom_unit.id,
+                "uom_id": self.product_uom_unit.id,
+                "uom_po_id": self.product_uom_unit.id,
                 "secondary_uom_ids": [
                     Command.create(
                         {
                             "code": "C5",
                             "name": "box 5",
-                            "uom_id": cls.product_uom_unit.id,
+                            "uom_id": self.product_uom_unit.id,
                             "factor": 5,
                         }
                     ),
@@ -35,7 +34,7 @@ class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
                         {
                             "code": "C10",
                             "name": "box 10",
-                            "uom_id": cls.product_uom_unit.id,
+                            "uom_id": self.product_uom_unit.id,
                             "factor": 10,
                         }
                     ),
@@ -44,29 +43,28 @@ class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
                             "code": "C20",
                             "name": "box 20",
                             "dependency_type": "independent",
-                            "uom_id": cls.product_uom_unit.id,
+                            "uom_id": self.product_uom_unit.id,
                             "factor": 20,
                         }
                     ),
                 ],
             }
         )
-        cls.secondary_unit_box_5 = cls.product_template.secondary_uom_ids[0]
-        cls.secondary_unit_box_10 = cls.product_template.secondary_uom_ids[1]
-        cls.secondary_unit_box_20 = cls.product_template.secondary_uom_ids[2]
+        self.secondary_unit_box_5 = self.product_template.secondary_uom_ids[0]
+        self.secondary_unit_box_10 = self.product_template.secondary_uom_ids[1]
+        self.secondary_unit_box_20 = self.product_template.secondary_uom_ids[2]
         # Fake model which inherit from
-        cls.secondary_unit_fake = cls.env["secondary.unit.fake"].create(
+        self.secondary_unit_fake = self.env["secondary.unit.fake"].create(
             {
                 "name": "Secondary unit fake",
-                "product_id": cls.product_template.product_variant_ids.id,
-                "product_uom_id": cls.product_uom_unit.id,
+                "product_id": self.product_template.product_variant_ids.id,
+                "product_uom_id": self.product_uom_unit.id,
             }
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_product_secondary_unit_mixin(self):
         fake_model = self.secondary_unit_fake

--- a/product_set/tests/test_product_set_wizard.py
+++ b/product_set/tests/test_product_set_wizard.py
@@ -7,29 +7,27 @@ from odoo.tests import TransactionCase
 
 
 class TestProductSetWizard(TransactionCase, FakeModelLoader):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .models import FakeProductSetWizard
 
-        cls.loader.update_registry((FakeProductSetWizard,))
-        cls.partner_1 = cls.env["res.partner"].create({"name": "Test Partner One"})
-        cls.partner_2 = cls.env["res.partner"].create({"name": "Test Partner Two"})
-        cls.product_set_1 = cls.env.ref("product_set.product_set_i5_computer")
-        cls.product_set_2 = cls.env.ref("product_set.product_set_services")
-        cls.wizard = cls.env["fake.product.set.wizard"].create(
+        self.loader.update_registry((FakeProductSetWizard,))
+        self.partner_1 = self.env["res.partner"].create({"name": "Test Partner One"})
+        self.partner_2 = self.env["res.partner"].create({"name": "Test Partner Two"})
+        self.product_set_1 = self.env.ref("product_set.product_set_i5_computer")
+        self.product_set_2 = self.env.ref("product_set.product_set_services")
+        self.wizard = self.env["fake.product.set.wizard"].create(
             {
-                "product_set_id": cls.product_set_1.id,
+                "product_set_id": self.product_set_1.id,
                 "quantity": 1,
             }
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_product_set_wizard_compute_lines(self):
         # Check if the wizard lines are updated when the product set changes


### PR DESCRIPTION
Change where the mock has to be loaded

With the changes introduced in odoo/odoo@de056cc#diff-b37c7fd5520c97a29ddc59495779e7be61a66e15e85603928e27b3affb9dc31f, an error was occurring because the change validation on the model was being performed before tearDownClass was executed. Therefore, it has been modified so that the mock changes are applied in each test and cleaned up after each test. This way, the error will no longer appear and the test will run normally.

@Tecnativa