### PR TITLE
[18.0][FIX] product_pricelist_assortment: ensure test uses different items for manual modification and removal

### DIFF
--- a/product_pricelist_assortment/tests/test_pricelist_assortment.py
+++ b/product_pricelist_assortment/tests/test_pricelist_assortment.py
@@ -211,7 +211,9 @@ class TestPricelistAssortment(BaseCommon):
         )
         self.default_codes.append("NEW")
         # 3. Remove a product from the assortment
-        product_to_remove = self.products_assortment[0]
+        product_to_remove = items.filtered(lambda i: i.id != manual_item.id)[
+            0
+        ].product_id
         self.default_codes.remove(product_to_remove.default_code)
 
         self.assortment.domain = [("default_code", "in", self.default_codes)]


### PR DESCRIPTION
The test was selecting items from different recordsets (`items[0]` vs `products_assortment[0]`), which could randomly reference the same product for both manual modification and removal, creating an ambiguous scenario and causing intermittent failures.

Fixed by ensuring the removed product is explicitly different from the manually modified item, making the test deterministic.

This eliminates the race condition and correctly validates:
- Manually modified items persist when their products remain in assortment
- Items are deleted when their products are removed from assortment
- New items are created when products are added to assortment

@Tecnativa TT57647
@christian-ramos-tecnativa @pedrobaeza