### PR TITLE
[IMP] product_cost_security: hide standard_price column in product tree views

### DIFF
--- a/product_cost_security/views/product_views.xml
+++ b/product_cost_security/views/product_views.xml
@@ -13,4 +13,28 @@
             </xpath>
         </field>
     </record>
+
+    <record id="product_template_tree_view" model="ir.ui.view">
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='standard_price']" position="attributes">
+                <attribute
+                    name="groups"
+                >product_cost_security.group_product_cost</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_product_tree_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='standard_price']" position="attributes">
+                <attribute
+                    name="groups"
+                >product_cost_security.group_product_cost</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Adds the 'product_cost_security.group_product_cost' group restriction to the 'standard_price' field in both product.product and product.template tree views.

This ensures that users without the explicit cost permission cannot visualize the cost column when triggering the "Search More" popup from sale orders or when accessing the default list views, strictly enforcing the visibility criteria.