### PR TITLE
[FIX] product_status: move status fields to dedicated notebook page

### DIFF
--- a/product_status/views/product_views.xml
+++ b/product_status/views/product_views.xml
@@ -4,29 +4,34 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <group name="sale" position="inside">
-                <group name="product_status_wrapper">
+            <notebook position="inside">
+                <page name="product_status" string="Product Status">
                     <group name="product_status" string="Product Status">
-                        <field name="new_until" />
-                        <field name="discontinued_until" />
-                        <field name="end_of_life_date" />
-                        <field name="state" />
+                        <group>
+                            <field name="new_until" />
+                            <field name="discontinued_until" />
+                            <field name="end_of_life_date" />
+                            <field name="state" />
+                        </group>
+                        <group>
+                            <div class="alert alert-info" role="alert" colspan="2">
+                                By order of importance, the status is computed by:<br />
+                                <ul>
+                                <li>End-of-life</li>
+                                <li>Discontinued until</li>
+                                <li>New until</li>
+                            </ul>
+                                <strong
+                            >End-of-life</strong> has priority over the other dates.<br
+                            />
+                                <strong
+                            >Discontinued-until</strong> has priority over <strong
+                            >New until</strong>.
+                            </div>
+                        </group>
                     </group>
-                    <!-- prettier-ignore-start -->
-                    <!-- prettier will mess up the code and make it harder to read -->
-                    <div class="alert alert-info" role="alert" colspan="2">
-                        By order of importance, the status is computed by:<br />
-                        <ul>
-                            <li>End-of-life</li>
-                            <li>Discontinued until</li>
-                            <li>New until</li>
-                        </ul>
-                        <strong>End-of-life</strong> has priority over the other dates.<br />
-                        <strong>Discontinued-until</strong> has priority over <strong>New until</strong>.
-                    </div>
-                    <!-- prettier-ignore-end -->
-                </group>
-            </group>
+                </page>
+            </notebook>
         </field>
     </record>
 
@@ -34,39 +39,44 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
-            <group name="sale" position="inside">
-                <group name="product_status_wrapper">
+            <notebook position="inside">
+                <page name="product_status" string="Product Status">
                     <group name="product_status" string="Product Status">
-                        <field name="has_status_date" invisible="1" />
-                        <field name="new_until" />
-                        <field name="discontinued_until" />
-                        <field name="end_of_life_date" />
-                        <field name="tmpl_new_until" invisible="has_status_date" />
-                        <field
-                            name="tmpl_discontinued_until"
-                            invisible="has_status_date"
-                        />
-                        <field
-                            name="tmpl_end_of_life_date"
-                            invisible="has_status_date"
-                        />
-                        <field name="state" />
+                        <group>
+                            <field name="has_status_date" invisible="1" />
+                            <field name="new_until" />
+                            <field name="discontinued_until" />
+                            <field name="end_of_life_date" />
+                            <field name="tmpl_new_until" invisible="has_status_date" />
+                            <field
+                                name="tmpl_discontinued_until"
+                                invisible="has_status_date"
+                            />
+                            <field
+                                name="tmpl_end_of_life_date"
+                                invisible="has_status_date"
+                            />
+                            <field name="state" />
+                        </group>
+                        <group>
+                            <div class="alert alert-info" role="alert" colspan="2">
+                                By order of importance, the status is computed by:<br />
+                                <ul>
+                                <li>End-of-life</li>
+                                <li>Discontinued until</li>
+                                <li>New until</li>
+                            </ul>
+                                <strong
+                            >End-of-life</strong> has priority over the other dates.<br
+                            />
+                                <strong
+                            >Discontinued-until</strong> has priority over <strong
+                            >New until</strong>.
+                            </div>
+                        </group>
                     </group>
-                    <!-- prettier-ignore-start -->
-                    <!-- prettier will mess up the code and make it harder to read -->
-                    <div class="alert alert-info" role="alert" colspan="2">
-                        By order of importance, the status is computed by:<br />
-                        <ul>
-                            <li>End-of-life</li>
-                            <li>Discontinued until</li>
-                            <li>New until</li>
-                        </ul>
-                        <strong>End-of-life</strong> has priority over the other dates.<br />
-                        <strong>Discontinued-until</strong> has priority over <strong>New until</strong>.
-                    </div>
-                    <!-- prettier-ignore-end -->
-                </group>
-            </group>
+                </page>
+            </notebook>
         </field>
     </record>
 


### PR DESCRIPTION
  Relocate the product status fields from the sale group into a dedicated
  "Product Status" notebook page on both product.template and
  product.product form views. Applies to 19.0 form view structure.
  
  The view now looks like this:
  
<img width="1332" height="358" alt="image" src="https://github.com/user-attachments/assets/54d82bf2-0534-4071-a035-b10d40f41e6a" />
