### PR TITLE
[14.0][IMP] product_logistics_uom: Length UoM to Settings View

### DIFF
--- a/product_logistics_uom/views/res_config_settings.xml
+++ b/product_logistics_uom/views/res_config_settings.xml
@@ -1,22 +1,42 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-        <record id="res_config_settings_view_form" model="ir.ui.view">
-            <field name="name">res.config.settings.view.form.inherit.product</field>
-            <field name="model">res.config.settings</field>
-            <field name="inherit_id" ref="product.res_config_settings_view_form" />
-            <field name="arch" type="xml">
-                <field name="product_weight_in_lbs" position="attributes">
-                    <attribute name="invisible">1</attribute>
-                </field>
-                <field name="product_weight_in_lbs" position="after">
-                    <field name="product_default_weight_uom_id" />
-                </field>
-                <field name="product_volume_volume_in_cubic_feet" position="attributes">
-                    <attribute name="invisible">1</attribute>
-                </field>
-                <field name="product_volume_volume_in_cubic_feet" position="after">
-                    <field name="product_default_volume_uom_id" />
-                </field>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.product</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="product.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <field name="product_weight_in_lbs" position="attributes">
+                <attribute name="invisible">1</attribute>
             </field>
-        </record>
+            <field name="product_weight_in_lbs" position="after">
+                <field name="product_default_weight_uom_id" />
+            </field>
+            <field name="product_volume_volume_in_cubic_feet" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="product_volume_volume_in_cubic_feet" position="after">
+                <field name="product_default_volume_uom_id" />
+            </field>
+            <xpath expr="//div[@id='manage_volume_uom_setting']" position="after">
+                <div class="col-12 col-lg-6 o_setting_box" id="length_uom_setting">
+                    <div class="o_setting_left_pane">
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label
+                            for="product_default_length_uom_id"
+                            string="Length UoM"
+                        />
+                        <div class="text-muted">
+                                Define your length unit of measure
+                        </div>
+                        <div class="content-group">
+                            <div class="mt16">
+                                <field name="product_default_length_uom_id" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
In later versions the field already exists in the settings view. I added it to the 14.0:

<img width="819" height="467" alt="image" src="https://github.com/user-attachments/assets/0351704a-aede-4599-a171-290f925c083f" />

Code had one intendation too much. I removed it so that the pre-commit changes look better. pre-commit does not re-indent the XML tags, only the attributes
