### PR TITLE
[16.0][FIX] product_state: missing dependency

### DIFF
--- a/product_state/__manifest__.py
+++ b/product_state/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Product",
     "version": "16.0.1.2.0",
     "license": "AGPL-3",
-    "depends": ["product", "sale"],
+    "depends": ["product", "sale", "stock"],
     "data": [
         "data/product_state_data.xml",
         "security/ir.model.access.csv",


### PR DESCRIPTION
Because of the group `"stock.group_stock_manager"` declared inside `ir.model.access.csv`, we need "stock" as a dependency otherwise the module will not install