### PR TITLE
[18.0][IMP] product_sequence: default_code shouldn't be mandatory

### DIFF
--- a/product_sequence/models/product_product.py
+++ b/product_sequence/models/product_product.py
@@ -11,7 +11,6 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     default_code = fields.Char(
-        required=True,
         default="/",
         tracking=True,
         help="Set to '/' and save if you want a new internal reference "


### PR DESCRIPTION
Since there is already a module that makes the field mandatory, such as product_code_mandatory, adding this requirement at the database level, in my opinion, goes beyond the scope of this module.

cc @Tecnativa

ping @pedrobaeza @sergio-teruel 