### PR TITLE
[16.0][IMP] product_is_bulk: correct onchange on product.template model.

### DIFF
--- a/product_is_bulk/models/product_template.py
+++ b/product_is_bulk/models/product_template.py
@@ -2,7 +2,7 @@
 # @author: Quentin DUPONT (quentin.dupont@grap.coop)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
@@ -19,9 +19,14 @@ class ProductTemplate(models.Model):
         " priced per unit but sold in bulk (such as cookies, bread, etc.)",
     )
 
+    @api.onchange("uom_id")
+    def _onchange_uom_id_is_bulk(self):
+        self.is_bulk = self.uom_id.category_id.measure_type in [
+            "weight",
+            "volume",
+        ]
+
     def _get_related_fields_variant_template(self):
         res = super()._get_related_fields_variant_template()
-        res += [
-            "is_bulk",
-        ]
+        res += ["is_bulk"]
         return res


### PR DESCRIPTION
rational: we use the _compute_template_field_from_variant_field / _set_product_variant_field / _get_related_fields_variant_template mechanism to compute correctly is_bulk.
However, for the time being, when user select uom_id on product template form the is_bulk is not computed on the fly, and user should wait for saving. That is not very intuitive. (it occures only on product.template form view, it is OK with product.product form view)