### PR TITLE
[18.0][FIX] product_pricelist_revision: Fix date range in duplicate wizard test

### DIFF
--- a/product_pricelist_revision/tests/test_product_pricelist_revision.py
+++ b/product_pricelist_revision/tests/test_product_pricelist_revision.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -94,7 +94,7 @@ class TestProductPricelistRevision(BaseCommon):
         wizard = wizard_obj.with_context(active_ids=active_ids).create(
             {
                 "date_start": datetime.now(),
-                "date_end": datetime.now(),
+                "date_end": datetime.now() + timedelta(hours=1),
                 "variation_percent": 50,
             }
         )


### PR DESCRIPTION
Odoo 18 enforces a strict date_end > date_start constraint on pricelist items. The test was using the same datetime for both fields, causing a ValidationError.

See https://github.com/odoo/odoo/blob/36a7cadbfb9007ebddd660b7709e4bef58e96c2d/addons/product/models/product_pricelist_item.py#L307

cc @Tecnativa TT62281

ping @pedrobaeza @victoralmau 