### PR TITLE
[17.0][FIX] product_state: add read access for internal users

### DIFF
--- a/product_state/security/ir.model.access.csv
+++ b/product_state/security/ir.model.access.csv
@@ -1,4 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_product_state_sale_manager","product.state","model_product_state","sales_team.group_sale_manager",1,1,1,1
 "access_product_state_stock_manager","product.state","model_product_state","stock.group_stock_manager",1,1,1,1
+"access_product_state_user","product.state.user","model_product_state","base.group_user",1,0,0,0
 "access_product_state_public","product.state.public","model_product_state","base.group_public",1,0,0,0


### PR DESCRIPTION
Normal users with access to products get an access error on `product.state` because the model only grants read access to sales managers, stock managers, and public users. Internal users (`base.group_user`) need read access to view products that reference a state.

**Steps to reproduce:**
1. Install product_state
2. Create a user with only `base.group_user` (no sale/stock manager)
3. Open a product form or report showing `product_state_id`

**Result:** AccessError on product.state

**Fix:** add read-only ACL for `base.group_user`.