### PR TITLE
[18.0][IMP] product_readonly_security: Disable Create/Edit/Delete in the UX if the user does not have the appropriate permissions

### DIFF
--- a/product_readonly_security/models/product_readonly_security_mixin.py
+++ b/product_readonly_security/models/product_readonly_security_mixin.py
@@ -1,8 +1,9 @@
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2026 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import _, api, models
-from odoo.exceptions import AccessError
+import functools
+
+from odoo import models
 from odoo.tools import config
 
 
@@ -10,11 +11,13 @@ class ProductReadonlySecurityMixin(models.AbstractModel):
     _name = "product.readonly.security.mixin"
     _description = "Mixin to use Product Readonly Security"
 
-    @api.model
-    def check_access(self, operation):
-        # Override security returning False/AccessError if not belonging to
-        # the new security group. This makest that the create, edit and delete
-        # buttons are not displayed.
+    def _check_access(self, operation):
+        # We override this method directly because we want to display an error
+        # (similar to what happens if a user don't have access -ACL- to perform
+        # an action on a model) if the user does not have the "Product edition" group.
+        # This method is very useful because it helps ensure that the Create/Edit/Delete
+        # buttons are not displayed across all sections of Odoo, including in many2one
+        # fields (example: the product field in sales order lines).
         user = self.env.user
         group = "product_readonly_security.group_product_edition"
         test_condition = not config["test_enable"] or (
@@ -27,10 +30,9 @@ class ProductReadonlySecurityMixin(models.AbstractModel):
             and not self.env.su
             and not user.has_group(group)
         ):
-            raise AccessError(
-                _(
-                    "Sorry, you are not allowed to create/edit products. Please "
-                    "contact your administrator for further information."
-                )
+            # Similar to https://github.com/odoo/odoo/blob/4b62fa9ba12d0ef40671d31bb33c6eeffda5cd85/odoo/models.py#L4477
+            Access = self.env["ir.model.access"]
+            return self, functools.partial(
+                Access._make_access_error, self._name, operation
             )
-        return super().check_access(operation=operation)
+        return super()._check_access(operation)


### PR DESCRIPTION
Disable Create/Edit/Delete (always) if the user does not have the appropriate group

Related to https://github.com/OCA/product-attribute/pull/2251#pullrequestreview-4083246060

The `_check_access()` method is overridden because this is the appropriate place for Odoo to indirectly prevent the create/edit/delete actions from being displayed.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT61748