### PR TITLE
[FIX] product_expiry_configurable incorrect translation gl.po

### DIFF
--- a/product_expiry_configurable/i18n/gl.po
+++ b/product_expiry_configurable/i18n/gl.po
@@ -212,7 +212,7 @@ msgstr "Recordatorio da data de retirada"
 #: code:addons/product_expiry_configurable/models/stock_lot.py:0
 #, python-format
 msgid "The {date_name} has been reached for this lot/serial number"
-msgstr "Alcanzouse o {dáche_name} para este lote/número de serie"
+msgstr "Alcanzouse o {date_name} para este lote/número de serie"
 
 #. module: product_expiry_configurable
 #: model_terms:ir.ui.view,arch_db:product_expiry_configurable.search_product_lot_filter_inherit_product_expiry


### PR DESCRIPTION
fix 

product_expiry_configurable/i18n/gl.po:214 Translation string couldn't be parsed correctly using str.format KeyError('dáche_name') - [po-python-parse-format]

ref https://github.com/OCA/product-attribute/actions/runs/26475598996/job/77960215800?pr=2314#step:7:25