### PR TITLE
[FIX] product_category_code_unique: writing on many categories is broken.

### DIFF
--- a/product_category_code_unique/models/product_category.py
+++ b/product_category_code_unique/models/product_category.py
@@ -81,5 +81,5 @@ class ProductCategory(models.Model):
             code = value.setdefault("code", category.code)
             if code in [False, "/"]:
                 value["code"] = self._get_next_code()
-            super().write(value)
+            super(ProductCategory, category).write(value)
         return True


### PR DESCRIPTION
rational : with the current implementation, if we write on many categories, on categories that don't have code, it will write the same code on many categories

Fixes CI of https://github.com/OCA/product-attribute/pull/2314