### PR TITLE
[18.0][FIX] product_eprel: build label_url as PDF instead of PNG

### DIFF
--- a/product_eprel/models/product_template.py
+++ b/product_eprel/models/product_template.py
@@ -63,7 +63,7 @@ class ProductTemplate(models.Model):
                 else False
             )
             rec.label_url = (
-                f"{API_URL}labels/{cat}/Label_{reg_num}.png"
+                f"{API_URL}labels/{cat}/Label_{reg_num}.pdf"
                 if cat and reg_num
                 else False
             )

--- a/product_eprel/tests/test_product_eprel.py
+++ b/product_eprel/tests/test_product_eprel.py
@@ -53,3 +53,7 @@ class TestProductModelIdentifier(BaseCommon):
             "https://eprel.ec.europa.eu/fiches/smartphonestablets20231669/Fiche_2266111_EN.pdf",
             self.product.fiche_url,
         )
+        self.assertEqual(
+            "https://eprel.ec.europa.eu/labels/smartphonestablets20231669/Label_2266111.pdf",
+            self.product.label_url,
+        )


### PR DESCRIPTION
@tecnativa TT63123