### PR TITLE
[15.0][FIX] product_pricelist_discount_by_range: use float_compare for price range matching

### DIFF
--- a/product_pricelist_discount_by_range/models/product_pricelist_item.py
+++ b/product_pricelist_discount_by_range/models/product_pricelist_item.py
@@ -30,8 +30,18 @@ class PricelistItem(models.Model):
     def _compute_price(self, price, price_uom, product, quantity=1.0, partner=False):
         if self.discount_type == "range":
             discount = None
+            rounding = self.currency_id.rounding
             for discount_range in self.discount_range_ids:
-                if discount_range.min <= price <= discount_range.max:
+                if (
+                    tools.float_compare(
+                        price, discount_range.min, precision_rounding=rounding
+                    )
+                    >= 0
+                    and tools.float_compare(
+                        price, discount_range.max, precision_rounding=rounding
+                    )
+                    <= 0
+                ):
                     discount = discount_range.percentage
                     break
             if discount is not None:


### PR DESCRIPTION
Comparing the price directly against the range bounds with `min <= price <= max` is subject to floating point precision errors: a value like 50.00 may be stored as 49.999999998 and fall outside a range starting at 50, wrongly raising "Discount range not found for the given price.".

Use tools.float_compare with the currency rounding so both operands are rounded before comparison, avoiding false negatives at the range boundaries.

cc @Tecnativa TT63309

ping @Andrii9090-tecnativa @pedrobaeza 