### PR TITLE
[18.0][FIX] product_pricelist_product_price_history: fix history atta…

### DIFF
--- a/product_pricelist_product_price_history/models/product_pricelist_item.py
+++ b/product_pricelist_product_price_history/models/product_pricelist_item.py
@@ -16,8 +16,9 @@ class ProductPricelistItem(models.Model):
                 ):
                     self.env["product.pricelist.item.history"].create(
                         {
-                            "product_id": item.product_tmpl_id.product_variant_id.id
-                            or item.product_id.id,
+                            # Prioritize the specific variant first.
+                            "product_id": item.product_id.id
+                            or item.product_tmpl_id.product_variant_id.id,
                             "pricelist_id": item.pricelist_id.id,
                             "old_price": item.fixed_price,
                             "new_price": new_price,

--- a/product_pricelist_product_price_history/tests/test_pricelist_history.py
+++ b/product_pricelist_product_price_history/tests/test_pricelist_history.py
@@ -45,6 +45,7 @@ class TestPricelistHistorySimple(TransactionCase):
             }
         )
         cls.variant_1 = cls.template_variants.product_variant_ids[0]
+        cls.variant_2 = cls.template_variants.product_variant_ids[1]
 
     def test_01_history_creation_variant_direct(self):
         item = self.env["product.pricelist.item"].create(
@@ -94,3 +95,87 @@ class TestPricelistHistorySimple(TransactionCase):
             [("product_id", "=", self.product_simple.id)]
         )
         self.assertEqual(len(history), 0)
+
+    def test_04_history_creation_specific_variant(self):
+        """Updating a specific variant (not the first one) logs history correctly."""
+        item = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "product_id": self.variant_2.id,
+                "fixed_price": 20.0,
+            }
+        )
+        item.write({"fixed_price": 25.0})
+
+        # The history record should be strictly attached to variant_2
+        history_v2 = self.env["product.pricelist.item.history"].search(
+            [("product_id", "=", self.variant_2.id)]
+        )
+        self.assertEqual(len(history_v2), 1)
+        self.assertEqual(history_v2.old_price, 20.0)
+        self.assertEqual(history_v2.new_price, 25.0)
+
+        # Ensure the change did NOT incorrectly log against variant_1
+        history_v1 = self.env["product.pricelist.item.history"].search(
+            [("product_id", "=", self.variant_1.id), ("new_price", "=", 25.0)]
+        )
+        self.assertEqual(len(history_v1), 0)
+
+    def test_05_no_history_on_other_field_update(self):
+        """Updating fields other than fixed_price does not trigger a history log."""
+        item = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "product_id": self.product_simple.id,
+                "fixed_price": 40.0,
+                "min_quantity": 1,
+            }
+        )
+
+        # Clear any history created by the initial create/setup if any
+        self.env["product.pricelist.item.history"].search([]).unlink()
+
+        # Update a non-price field
+        item.write({"min_quantity": 10})
+
+        history = self.env["product.pricelist.item.history"].search(
+            [("product_id", "=", self.product_simple.id)]
+        )
+        self.assertEqual(
+            len(history), 0, "Updating min_quantity should not create a history record."
+        )
+
+    def test_06_batch_price_update(self):
+        """Updating multiple pricelist items at once generates history for all"""
+        item1 = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "product_id": self.variant_1.id,
+                "fixed_price": 10.0,
+            }
+        )
+        item2 = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "product_id": self.variant_2.id,
+                "fixed_price": 20.0,
+            }
+        )
+
+        # Perform a batch write
+        items = item1 | item2
+        items.write({"fixed_price": 50.0})
+
+        # Verify history for item1
+        history1 = self.env["product.pricelist.item.history"].search(
+            [("product_id", "=", self.variant_1.id)]
+        )
+        self.assertEqual(len(history1), 1)
+        self.assertEqual(history1.new_price, 50.0)
+
+        # Verify history for item2
+        history2 = self.env["product.pricelist.item.history"].search(
+            [("product_id", "=", self.variant_2.id)]
+        )
+        self.assertEqual(len(history2), 1)
+        self.assertEqual(history2.new_price, 50.0)


### PR DESCRIPTION
…ched to wrong variant

Description of the issue:
When a user updates a pricelist rule for a specific product variant (e.g., the 30ml bottle), the price history log incorrectly attaches itself to the first variant of that product template (e.g., the 8ml bottle). This happens because the system's logic checks for the template's default variant before checking for the specific variant that was actually modified.

Proposed solution:
Reversed the fallback logic in the write method of the pricelist item. By changing the evaluation order to prioritize the specific variant (item.product_id.id or item.product_tmpl_id.product_variant_id.id), the history log now correctly attaches to the exact variant being updated, and only falls back to the template's variant when a global template rule is modified.