### PR TITLE
[18.0][IMP] product_pricelist_direct_print*: batch price computation

### DIFF
--- a/product_pricelist_direct_print/reports/report_product_pricelist.xml
+++ b/product_pricelist_direct_print/reports/report_product_pricelist.xml
@@ -5,6 +5,10 @@
     <template id="report_product_pricelist_document">
         <t t-call="web.html_container">
             <t t-set="o" t-value="o.with_context(lang=o.lang)" />
+            <t
+                t-set="o"
+                t-value="o.with_context(product_prices=o._get_product_prices(o.get_products_to_print()))"
+            />
             <t t-set="pricelist" t-value="o.get_pricelist_to_print()" />
             <t t-set="company" t-value="pricelist.company_id or env.company" />
             <t t-call="web.external_layout">

--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -97,12 +97,36 @@ class ProductPricelistPrint(models.TransientModel):
     def _onchange_categ_ids(self):
         self.print_child_categories = len(self.categ_ids) > 0
 
+    def _get_product_prices(self, products):
+        """Return ``{product_id: price}`` computing every product in a single
+        batched call.
+
+        The native ``_compute_price_rule`` fetches the applicable rules once for
+        the whole recordset, so calling it once for all the products avoids the
+        N+1 of recomputing the price (and re-searching the rules) per report
+        row. The result is meant to be injected in the context as
+        ``product_prices`` so ``_compute_product_price`` reads it instead of
+        recomputing.
+        """
+        self.ensure_one()
+        if not products:
+            return {}
+        return self.get_pricelist_to_print()._get_products_price(
+            products, 1, date=self.date
+        )
+
     @api.depends_context("product")
     def _compute_product_price(self):
         product = self.env.context["product"]
-        price = self.get_pricelist_to_print()._get_product_price(
-            product, 1, date=self.date
-        )
+        # Reuse the batched prices injected by the report when available to
+        # avoid recomputing the price (and re-searching the rules) per product.
+        prices = self.env.context.get("product_prices")
+        if prices is not None and product.id in prices:
+            price = prices[product.id]
+        else:
+            price = self.get_pricelist_to_print()._get_product_price(
+                product, 1, date=self.date
+            )
         if self.vat_mode == "vat_excl":
             self.product_price = product.taxes_id.compute_all(price)["total_excluded"]
         elif self.vat_mode == "vat_incl":

--- a/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py
+++ b/product_pricelist_direct_print_xlsx/report/product_pricelist_xlsx.py
@@ -17,6 +17,11 @@ class ProductPricelistXlsx(models.AbstractModel):
         self = self.with_context(
             lang=book.lang or self.env["res.users"].browse(book.create_uid.id).lang
         )
+        # Precompute every product price in a single batched call so the price
+        # column does not recompute (and re-search the pricelist rules) per row.
+        book = book.with_context(
+            product_prices=book._get_product_prices(book.get_products_to_print())
+        )
         pricelist = book.get_pricelist_to_print()
         sheet = self._create_product_pricelist_sheet(workbook, book, pricelist, formats)
         sheet = self._fill_data(workbook, sheet, book, pricelist, formats)


### PR DESCRIPTION
The price column recomputed the pricelist price one product at a time (``_get_product_price`` per report row), which made the native ``_get_applicable_rules`` rule search run once per product. On large pricelists this dominated the report render time.

Precompute every price in a single batched ``_get_products_price`` call and inject the result in the context as ``product_prices`` so ``_compute_product_price`` reads it instead of recomputing. This collapses the per-product rule searches of the printed pricelist into a single one, both for the PDF report and the xlsx export, without changing the price values nor the public method signatures.

cc @Tecnativa TT63381

ping @pedrobaeza @carlosdauden 