### PR TITLE
[16.0][FIX]product_packaging_level: fix migration path

### DIFF
--- a/product_packaging_level/migrations/16.0.1.0.0/post-migration.py
+++ b/product_packaging_level/migrations/16.0.1.0.0/post-migration.py
@@ -7,7 +7,7 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env.cr, "product_packaging_level", "16.0.1.0.0/noupdate_changes.xml"
+        env.cr, "product_packaging_level", "migrations/16.0.1.0.0/noupdate_changes.xml"
     )
     openupgrade.delete_record_translations(
         env.cr,


### PR DESCRIPTION
I had the following error with during an OpenUpgrade migration:

```
  File "/odoo/links/product_packaging_level/migrations/16.0.1.0.0/post-migration.py", line 9, in migrate
    openupgrade.load_data(
  File "/odoo/lib/python3.11/site-packages/openupgradelib/openupgrade.py", line 399, in load_data
    fp = _file_open(module_name, filename)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/lib/python3.11/site-packages/openupgradelib/openupgrade.py", line 321, in _file_open
    raise OSError(
OSError: Couldn't find file 16.0.1.0.0/noupdate_changes.xml in the upgrade paths (/odoo/external-src/openupgrade/openupgrade_scripts/scripts)
``` 

This script was introduced in https://github.com/OCA/product-attribute/pull/1963, then corrected in https://github.com/OCA/product-attribute/pull/2205 


See other working examples:
- https://github.com/oca/reporting-engine/blob/16.0/sql_export_mail/migrations/16.0.1.0.0/post-migration.py#L7
- https://github.com/oca/helpdesk/blob/16.0/helpdesk_mgmt_rating/migrations/16.0.1.0.0/post-migration.py#L10


FYI @baguenth @MiquelRForgeFlow 