### PR TITLE
[18.0][FIX] product_category_code: fixed issue when duplicating a product category

### DIFF
--- a/product_category_code/models/product_category.py
+++ b/product_category_code/models/product_category.py
@@ -1,7 +1,7 @@
 # Copyright 2021 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import _, fields, models
 
 
 class ProductCategory(models.Model):
@@ -12,7 +12,6 @@ class ProductCategory(models.Model):
         index=True,
     )
 
-    @api.returns("self", lambda value: value.id)
     def copy(self, default=None):
         default = default or {}
         default.setdefault("code", self.code + _("-copy"))


### PR DESCRIPTION
Removed @api.returns("self", lambda value: value.id) from the copy() method because it must return a recordset, not an ID. Returning an ID causes an error when duplicating records, since the ORM expects a record, not a primitive value.