### PR TITLE
[19.0][REF] product_pricelist_item_uom: backport from odoo 19.3

### DIFF
--- a/product_pricelist_item_uom/README.rst
+++ b/product_pricelist_item_uom/README.rst
@@ -32,23 +32,50 @@ Pricelist Rule UoM
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Set UoM in Pricelist Rules.
+This module allows a pricelist rule to be restricted to a specific
+packaging (unit of measure) of a product, instead of always applying to
+the product's base unit.
+
+A rule that targets a single product can be given a *Packaging*. The
+rule is then only taken into account when the price is computed for that
+packaging, and its *Min. Quantity* is expressed in that packaging rather
+than in the product base unit. Rules without a packaging keep their
+standard behaviour and apply whatever the unit of measure used.
+
+The pricelist report is extended accordingly: a product sold in several
+packagings shows one price row per packaging that has its own rule.
+
+This is a backport of the standard implementation Odoo introduces in
+version 19.3, see
+`odoo/odoo@d2648b1 <https://github.com/odoo/odoo/commit/d2648b1d983927b5df7260a16d6d1d33c213ddeb#diff-5a563f36ffd028b0d8510c6d1339b097a5067a2247cc35c0f9bdd1fd0b5a0b0>`__.
 
 **Table of contents**
 
 .. contents::
    :local:
 
-Configuration
-=============
-
-In any Pricelist Rule for a Product, set the Min. Quantity and the UoM.
-
-Note that prices in the Pricelist Rule (fixed, margins, surcharge) have
-to be proportional to the UoM of the Product.
-
 Usage
 =====
+
+Configuration
+-------------
+
+1. Enable *Sales → Configuration → Settings → Units of Measure &
+   Packagings*.
+2. Open a product and add the packagings it is sold in (*Sales* tab,
+   *Packagings*).
+
+Defining a rule per packaging
+-----------------------------
+
+1. Go to *Sales → Products → Pricelists* and open a pricelist.
+2. Add a price rule applied on a single product.
+3. Set the *Packaging* field to one of the product's packagings, and the
+   *Min. Quantity* in that same packaging.
+
+Leaving *Packaging* empty keeps the standard behaviour: the rule applies
+to any unit of measure and its *Min. Quantity* is expressed in the
+product base unit.
 
 You sell Sugar by the kg, so its UoM is kg and the product price is
 1000€: you are selling it at 1000€/kg (a bit expensive as sugar goes,
@@ -59,11 +86,17 @@ One customer is asking for 10g but the price you need for 10g is not 10€
 
 With this module, you can configure two price rules:
 
-- | minimum quantity 1g and a surcharge,
+- | Packaging *g*, minimum quantity 1 and a surcharge,
   | note that the surcharge is proportional to the original UoM (kg),
   | so in this example the surcharge must be 500€
 
-- minimum quantity 1kg and original price
+- Packaging *kg*, minimum quantity 1 and original price
+
+Report
+------
+
+Select the products, then *Print → Pricelist*. Products having a rule
+per packaging are printed with one price row per packaging.
 
 Bug Tracker
 ===========
@@ -82,6 +115,7 @@ Authors
 -------
 
 * Aion Tech
+* Camptocamp SA
 
 Contributors
 ------------
@@ -89,6 +123,10 @@ Contributors
 - `Aion Tech <https://aiontech.company/>`__:
 
   - Simone Rubino <simone.rubino@aion-tech.it>
+
+- `Camptocamp <https://www.camptocamp.com>`__:
+
+  - Ricardo Almeida Soares <ricardo.almeidasoares@camptocamp.com>
 
 Maintainers
 -----------
@@ -102,14 +140,6 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
-
-.. |maintainer-SirAionTech| image:: https://github.com/SirAionTech.png?size=40px
-    :target: https://github.com/SirAionTech
-    :alt: SirAionTech
-
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
-
-|maintainer-SirAionTech| 
 
 This module is part of the `OCA/product-attribute <https://github.com/OCA/product-attribute/tree/19.0/product_pricelist_item_uom>`_ project on GitHub.
 

--- a/product_pricelist_item_uom/__init__.py
+++ b/product_pricelist_item_uom/__init__.py
@@ -1,3 +1,4 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import report

--- a/product_pricelist_item_uom/__manifest__.py
+++ b/product_pricelist_item_uom/__manifest__.py
@@ -7,10 +7,7 @@
     "version": "19.0.1.0.0",
     "category": "Sales/Sales",
     "website": "https://github.com/OCA/product-attribute",
-    "author": "Aion Tech, Odoo Community Association (OCA)",
-    "maintainers": [
-        "SirAionTech",
-    ],
+    "author": "Aion Tech, Camptocamp SA, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": [
         "product",
@@ -19,5 +16,7 @@
     "data": [
         "views/product_pricelist_item_views.xml",
         "views/product_pricelist_views.xml",
+        "views/product_views.xml",
+        "report/product_pricelist_report_templates.xml",
     ],
 }

--- a/product_pricelist_item_uom/models/__init__.py
+++ b/product_pricelist_item_uom/models/__init__.py
@@ -1,3 +1,4 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import product_pricelist
 from . import product_pricelist_item

--- a/product_pricelist_item_uom/models/product_pricelist.py
+++ b/product_pricelist_item_uom/models/product_pricelist.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.fields import Domain
+
+
+class ProductPricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    def _compute_price_rule(self, products, quantity, *, uom=None, **kwargs):
+        self_with_uom = self.with_context(pricelist_item_uom_id=uom.id) if uom else self
+        return super(ProductPricelist, self_with_uom)._compute_price_rule(
+            products, quantity, uom=uom, **kwargs
+        )
+
+    def _get_applicable_rules_domain(self, products, date, **kwargs):
+        domain = Domain(super()._get_applicable_rules_domain(products, date, **kwargs))
+        uom_id = self.env.context.get("pricelist_item_uom_id")
+        if uom_id:
+            domain &= Domain("uom_id", "=", False) | Domain("uom_id", "=", uom_id)
+        return domain
+
+    def _get_related_uoms(self, product):
+        """Return the packagings having their own rule in this pricelist.
+
+        :param product: product template or product variant record.
+        :return: UoMs defined on the matching pricelist items.
+        :rtype: uom.uom
+        """
+        domain = self._get_applicable_rules_domain(
+            product, fields.Datetime.now()
+        ) & Domain("uom_id", "!=", False)
+        return (
+            self.env["product.pricelist.item"].search_fetch(domain, ["uom_id"]).uom_id
+        )

--- a/product_pricelist_item_uom/models/product_pricelist_item.py
+++ b/product_pricelist_item_uom/models/product_pricelist_item.py
@@ -2,100 +2,46 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.tools import float_compare
 
 
 class ProductPricelistItem(models.Model):
     _inherit = "product.pricelist.item"
 
     uom_id = fields.Many2one(
-        string="UoM",
+        string="Packaging",
         comodel_name="uom.uom",
-        compute="_compute_uom_id",
-        store=True,
-        readonly=False,
+        help="Restrict this rule to a specific packaging of the product. "
+        "When empty, the rule applies to the product base unit of measure.",
     )
-    uom_min_quantity = fields.Float(
-        string="Min. Quantity in UoM",
-        digits="Product Unit",
-        compute="_compute_uom_min_quantity",
-        store=True,
-        readonly=False,
-    )
+    allowed_uom_ids = fields.Many2many("uom.uom", compute="_compute_allowed_uom_ids")
 
-    @api.depends(
-        "product_id",
-        "product_tmpl_id",
-    )
-    def _compute_uom_id(self):
+    @api.depends("product_tmpl_id", "product_tmpl_id.uom_id", "product_tmpl_id.uom_ids")
+    def _compute_allowed_uom_ids(self):
         for item in self:
-            product = item.product_id or item.product_tmpl_id
-            product_uom = product.uom_id
-            if item.uom_id != product_uom:
-                item.uom_id = product_uom
+            item.allowed_uom_ids = (
+                item.product_tmpl_id.uom_id | item.product_tmpl_id.uom_ids
+            )
 
-    def _sync_uom_min_quantity(
-        self, source_quantity, source_uom, target_uom, target_qty_field
-    ):
-        """Convert `source_quantity` (in `source_uom`) to `target_uom`.
-        Assign the result to field `self.target_qty_field`, if different."""
+    @api.model_create_multi
+    def create(self, vals_list):
+        items = super().create(vals_list)
+        items.filtered(
+            lambda item: item.applied_on == "2_product_category"
+        ).uom_id = False
+        return items
+
+    def write(self, vals):
+        if vals.get("applied_on") == "2_product_category":
+            vals["uom_id"] = False
+        return super().write(vals)
+
+    def _is_applicable_for(self, product, qty_in_product_uom):
         self.ensure_one()
-        if target_uom != source_uom:
-            expected_target_quantity = source_uom._compute_quantity(
-                source_quantity,
-                target_uom,
-                raise_if_failure=False,
-                round=False,
-            )
-        else:
-            expected_target_quantity = source_quantity
-
-        # Assign only if different,
-        # according to the precision of target field
-        all_digits, precision_digits = self.fields_get(
-            allfields=[
-                target_qty_field,
-            ],
-            attributes=[
-                "digits",
-            ],
-        )[target_qty_field]["digits"]
-        if float_compare(
-            self[target_qty_field],
-            expected_target_quantity,
-            precision_digits=precision_digits,
-        ):
-            self[target_qty_field] = expected_target_quantity
-
-    @api.onchange(
-        "product_id",
-        "product_tmpl_id",
-        "uom_id",
-        "uom_min_quantity",
-    )
-    def onchange_uom_min_quantity(self):
-        for item in self:
-            product = item.product_id or item.product_tmpl_id
-            product_uom = product.uom_id
-            item._sync_uom_min_quantity(
-                item.uom_min_quantity,
-                item.uom_id,
-                product_uom,
-                "min_quantity",
+        product.ensure_one()
+        qty_to_consider = qty_in_product_uom
+        if self.uom_id and self.uom_id != product.uom_id:
+            qty_to_consider = product.uom_id._compute_quantity(
+                qty_in_product_uom, self.uom_id
             )
 
-    @api.depends(
-        "product_id",
-        "product_tmpl_id",
-        "min_quantity",
-    )
-    def _compute_uom_min_quantity(self):
-        for item in self:
-            product = item.product_id or item.product_tmpl_id
-            product_uom = product.uom_id
-            item._sync_uom_min_quantity(
-                item.min_quantity,
-                product_uom,
-                item.uom_id,
-                "uom_min_quantity",
-            )
+        return super()._is_applicable_for(product, qty_to_consider)

--- a/product_pricelist_item_uom/readme/CONFIGURE.md
+++ b/product_pricelist_item_uom/readme/CONFIGURE.md
@@ -1,4 +1,0 @@
-In any Pricelist Rule for a Product, set the Min. Quantity and the UoM.
-
-Note that prices in the Pricelist Rule (fixed, margins, surcharge) have
-to be proportional to the UoM of the Product.

--- a/product_pricelist_item_uom/readme/CONTRIBUTORS.md
+++ b/product_pricelist_item_uom/readme/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
 - [Aion Tech](https://aiontech.company/):
   - Simone Rubino \<simone.rubino@aion-tech.it\>
+- [Camptocamp](https://www.camptocamp.com):
+  - Ricardo Almeida Soares \<<ricardo.almeidasoares@camptocamp.com>\>

--- a/product_pricelist_item_uom/readme/DESCRIPTION.md
+++ b/product_pricelist_item_uom/readme/DESCRIPTION.md
@@ -1,1 +1,16 @@
-Set UoM in Pricelist Rules.
+This module allows a pricelist rule to be restricted to a specific packaging
+(unit of measure) of a product, instead of always applying to the product's
+base unit.
+
+A rule that targets a single product can be given a *Packaging*. The rule is
+then only taken into account when the price is computed for that packaging,
+and its *Min. Quantity* is expressed in that packaging rather than in the
+product base unit. Rules without a packaging keep their standard behaviour and
+apply whatever the unit of measure used.
+
+The pricelist report is extended accordingly: a product sold in several
+packagings shows one price row per packaging that has its own rule.
+
+This is a backport of the standard implementation Odoo introduces in
+version 19.3, see
+[odoo/odoo@d2648b1](https://github.com/odoo/odoo/commit/d2648b1d983927b5df7260a16d6d1d33c213ddeb#diff-5a563f36ffd028b0d8510c6d1339b097a5067a2247cc35c0f9bdd1fd0b5a0b0).

--- a/product_pricelist_item_uom/readme/USAGE.md
+++ b/product_pricelist_item_uom/readme/USAGE.md
@@ -1,3 +1,21 @@
+Configuration
+-------------
+
+1. Enable *Sales → Configuration → Settings → Units of Measure & Packagings*.
+2. Open a product and add the packagings it is sold in
+   (*Sales* tab, *Packagings*).
+
+Defining a rule per packaging
+-----------------------------
+
+1. Go to *Sales → Products → Pricelists* and open a pricelist.
+2. Add a price rule applied on a single product.
+3. Set the *Packaging* field to one of the product's packagings, and the
+   *Min. Quantity* in that same packaging.
+
+Leaving *Packaging* empty keeps the standard behaviour: the rule applies to any
+unit of measure and its *Min. Quantity* is expressed in the product base unit.
+
 You sell Sugar by the kg, so its UoM is kg and the product price is
 1000€: you are selling it at 1000€/kg (a bit expensive as sugar goes,
 but you can see why).
@@ -7,8 +25,14 @@ One customer is asking for 10g but the price you need for 10g is not 10€
 
 With this module, you can configure two price rules:
 
-- minimum quantity 1g and a surcharge,  
+- Packaging *g*, minimum quantity 1 and a surcharge,  
   note that the surcharge is proportional to the original UoM (kg),  
   so in this example the surcharge must be 500€
 
-- minimum quantity 1kg and original price
+- Packaging *kg*, minimum quantity 1 and original price
+
+Report
+------
+
+Select the products, then *Print → Pricelist*. Products having a rule per
+packaging are printed with one price row per packaging.

--- a/product_pricelist_item_uom/report/__init__.py
+++ b/product_pricelist_item_uom/report/__init__.py
@@ -1,0 +1,1 @@
+from . import product_pricelist_report

--- a/product_pricelist_item_uom/report/product_pricelist_report.py
+++ b/product_pricelist_item_uom/report/product_pricelist_report.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ReportProductReport_Pricelist(models.AbstractModel):
+    _inherit = "report.product.report_pricelist"
+
+    def _get_product_data(self, is_product_tmpl, product, pricelist, quantities):
+        # OVERRIDE: report one price row per packaging having its own rule in
+        # the pricelist, instead of a single row in the product base UoM.
+        data = super()._get_product_data(
+            is_product_tmpl, product, pricelist, quantities
+        )
+        template = product if is_product_tmpl else product.product_tmpl_id
+        has_multiple_variants = is_product_tmpl and product.product_variant_count > 1
+
+        if template._has_multiple_uoms() and not has_multiple_variants:
+            product_uoms = pricelist._get_related_uoms(product) | product.uom_id
+        else:
+            product_uoms = product.uom_id
+
+        data["price"] = {
+            product_uom.id: {
+                qty: pricelist._get_product_price(product, qty, uom=product_uom)
+                for qty in quantities
+            }
+            for product_uom in product_uoms
+        }
+        data["uoms"] = product_uoms.read(["id", "name"])
+
+        if has_multiple_variants:
+            # Flattened (variant, packaging) rows: keeps the report template a
+            # single-level t-foreach instead of a nested loop, which would
+            # require replacing (not just patching) the core row markup.
+            data["variant_rows"] = [
+                {
+                    "variant_id": variant_data["id"],
+                    "variant_name": variant_data["name"],
+                    "uom_id": product_uom["id"],
+                    "uom_name": product_uom["name"],
+                    "price": variant_data["price"][product_uom["id"]],
+                }
+                for variant_data in data["variants"]
+                for product_uom in variant_data["uoms"]
+            ]
+
+        return data

--- a/product_pricelist_item_uom/report/product_pricelist_report_templates.xml
+++ b/product_pricelist_item_uom/report/product_pricelist_report_templates.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <template id="report_pricelist_page" inherit_id="product.report_pricelist_page">
+        <xpath expr="//tbody/t[@t-foreach='products']/tr" position="attributes">
+            <attribute name="t-foreach">product['uoms']</attribute>
+            <attribute name="t-as">product_uom</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/tr/td[@groups='uom.group_uom']"
+            position="attributes"
+        >
+            <attribute name="t-out">product_uom['name']</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/tr/t/td/span"
+            position="attributes"
+        >
+            <attribute name="t-out">product['price'][product_uom['id']][qty]</attribute>
+        </xpath>
+
+        <!--
+            Same, for each (variant, packaging) pair of a multi-variant
+            template. The pairs are pre-flattened in Python
+            (`data['variant_rows']`) so this stays a single t-foreach on the
+            existing row, patched via `attributes` only. No position
+            "replace" is needed, which would otherwise discard whatever any
+            other module's inheritance of this same row had added.
+        -->
+        <xpath expr="//tbody/t[@t-foreach='products']/t/tr" position="attributes">
+            <attribute name="t-foreach">product['variant_rows']</attribute>
+            <attribute name="t-as">row</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/t/tr/td/a[@t-if='is_html_type']"
+            position="attributes"
+        >
+            <attribute name="t-att-data-res-id">row['variant_id']</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/t/tr/td/a[@t-if='is_html_type']/span"
+            position="attributes"
+        >
+            <attribute name="t-out">row['variant_name']</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/t/tr/td/span[@t-else='']"
+            position="attributes"
+        >
+            <attribute name="t-out">row['variant_name']</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/t/tr/td[@groups='uom.group_uom']"
+            position="attributes"
+        >
+            <attribute name="t-out">row['uom_name']</attribute>
+        </xpath>
+        <xpath
+            expr="//tbody/t[@t-foreach='products']/t/tr/t/td/span"
+            position="attributes"
+        >
+            <attribute name="t-out">row['price'][qty]</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/product_pricelist_item_uom/static/description/index.html
+++ b/product_pricelist_item_uom/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Pricelist Rule UoM</title>
 <style type="text/css">
 
 /*
@@ -375,29 +375,59 @@ ul.auto-toc {
 !! source digest: sha256:43c51f2fb78219eddc980cbc7dd814a69c06bb21b7216b6c0e4723dd92673a9a
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/product-attribute/tree/19.0/product_pricelist_item_uom"><img alt="OCA/product-attribute" src="https://img.shields.io/badge/github-OCA%2Fproduct--attribute-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/product-attribute-19-0/product-attribute-19-0-product_pricelist_item_uom"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/product-attribute&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>Set UoM in Pricelist Rules.</p>
+<p>This module allows a pricelist rule to be restricted to a specific
+packaging (unit of measure) of a product, instead of always applying to
+the product’s base unit.</p>
+<p>A rule that targets a single product can be given a <em>Packaging</em>. The
+rule is then only taken into account when the price is computed for that
+packaging, and its <em>Min. Quantity</em> is expressed in that packaging rather
+than in the product base unit. Rules without a packaging keep their
+standard behaviour and apply whatever the unit of measure used.</p>
+<p>The pricelist report is extended accordingly: a product sold in several
+packagings shows one price row per packaging that has its own rule.</p>
+<p>This is a backport of the standard implementation Odoo introduces in
+version 19.3, see
+<a class="reference external" href="https://github.com/odoo/odoo/commit/d2648b1d983927b5df7260a16d6d1d33c213ddeb#diff-5a563f36ffd028b0d8510c6d1339b097a5067a2247cc35c0f9bdd1fd0b5a0b0">odoo/odoo&#64;d2648b1</a>.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a><ul>
+<li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
+<li><a class="reference internal" href="#defining-a-rule-per-packaging" id="toc-entry-3">Defining a rule per packaging</a></li>
+<li><a class="reference internal" href="#report" id="toc-entry-4">Report</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="section" id="configuration">
-<h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
-<p>In any Pricelist Rule for a Product, set the Min. Quantity and the UoM.</p>
-<p>Note that prices in the Pricelist Rule (fixed, margins, surcharge) have
-to be proportional to the UoM of the Product.</p>
-</div>
 <div class="section" id="usage">
-<h2><a class="toc-backref" href="#toc-entry-2">Usage</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
+<div class="section" id="configuration">
+<h3><a class="toc-backref" href="#toc-entry-2">Configuration</a></h3>
+<ol class="arabic simple">
+<li>Enable <em>Sales → Configuration → Settings → Units of Measure &amp;
+Packagings</em>.</li>
+<li>Open a product and add the packagings it is sold in (<em>Sales</em> tab,
+<em>Packagings</em>).</li>
+</ol>
+</div>
+<div class="section" id="defining-a-rule-per-packaging">
+<h3><a class="toc-backref" href="#toc-entry-3">Defining a rule per packaging</a></h3>
+<ol class="arabic simple">
+<li>Go to <em>Sales → Products → Pricelists</em> and open a pricelist.</li>
+<li>Add a price rule applied on a single product.</li>
+<li>Set the <em>Packaging</em> field to one of the product’s packagings, and the
+<em>Min. Quantity</em> in that same packaging.</li>
+</ol>
+<p>Leaving <em>Packaging</em> empty keeps the standard behaviour: the rule applies
+to any unit of measure and its <em>Min. Quantity</em> is expressed in the
+product base unit.</p>
 <p>You sell Sugar by the kg, so its UoM is kg and the product price is
 1000€: you are selling it at 1000€/kg (a bit expensive as sugar goes,
 but you can see why).</p>
@@ -406,17 +436,23 @@ but you can see why).</p>
 <p>With this module, you can configure two price rules:</p>
 <ul>
 <li><div class="first line-block">
-<div class="line">minimum quantity 1g and a surcharge,</div>
+<div class="line">Packaging <em>g</em>, minimum quantity 1 and a surcharge,</div>
 <div class="line">note that the surcharge is proportional to the original UoM (kg),</div>
 <div class="line">so in this example the surcharge must be 500€</div>
 </div>
 </li>
-<li><p class="first">minimum quantity 1kg and original price</p>
+<li><p class="first">Packaging <em>kg</em>, minimum quantity 1 and original price</p>
 </li>
 </ul>
 </div>
+<div class="section" id="report">
+<h3><a class="toc-backref" href="#toc-entry-4">Report</a></h3>
+<p>Select the products, then <em>Print → Pricelist</em>. Products having a rule
+per packaging are printed with one price row per packaging.</p>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/product-attribute/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -424,24 +460,29 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Authors</a></h3>
 <ul class="simple">
 <li>Aion Tech</li>
+<li>Camptocamp SA</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a>:<ul>
+<li>Ricardo Almeida Soares &lt;<a class="reference external" href="mailto:ricardo.almeidasoares&#64;camptocamp.com">ricardo.almeidasoares&#64;camptocamp.com</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
@@ -449,8 +490,6 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/SirAionTech"><img alt="SirAionTech" src="https://github.com/SirAionTech.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/product-attribute/tree/19.0/product_pricelist_item_uom">OCA/product-attribute</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/product_pricelist_item_uom/tests/__init__.py
+++ b/product_pricelist_item_uom/tests/__init__.py
@@ -1,3 +1,4 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_product_pricelist_item
+from . import test_product_pricelist_report

--- a/product_pricelist_item_uom/tests/common.py
+++ b/product_pricelist_item_uom/tests/common.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.api import SUPERUSER_ID
+from odoo.fields import Command
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestPricelistItemUomCommon(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.uom_pack_6 = cls.env.ref("uom.product_uom_pack_6")
+
+        cls.product_tmpl = cls.env["product.template"].create(
+            {
+                "name": "Test Packaging Product",
+                "list_price": 100.0,
+                "uom_id": cls.uom_unit.id,
+                "uom_ids": [Command.link(cls.uom_pack_6.id)],
+            }
+        )
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {"name": "Test Packaging Pricelist"}
+        )
+        cls.product_category = cls.env["product.category"].create(
+            {"name": "Test Packaging Category"}
+        )
+        cls._enable_uom_feature()
+
+    @classmethod
+    def _enable_uom_feature(cls):
+        """Turn on the "Units of Measure & Packagings" feature.
+
+        ``_has_multiple_uoms`` reports the feature as enabled only when the
+        root user belongs to the group, hence the direct membership.
+        """
+        cls.env.ref("uom.group_uom").sudo().user_ids |= cls.env["res.users"].browse(
+            SUPERUSER_ID
+        )
+
+    @classmethod
+    def _create_rule(cls, **values):
+        return cls.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": cls.pricelist.id,
+                "applied_on": "1_product",
+                "product_tmpl_id": cls.product_tmpl.id,
+                "compute_price": "fixed",
+                **values,
+            }
+        )

--- a/product_pricelist_item_uom/tests/test_product_pricelist_item.py
+++ b/product_pricelist_item_uom/tests/test_product_pricelist_item.py
@@ -1,85 +1,96 @@
 #  Copyright 2023 Simone Rubino - Aion Tech
-#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from math import log10
+from odoo.tests.common import tagged
 
-from odoo.tests import Form
-
-from odoo.addons.base.tests.common import BaseCommon
+from .common import TestPricelistItemUomCommon
 
 
-class TestProductPricelistItem(BaseCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.g_uom = cls.env.ref("uom.product_uom_gram")
-        cls.kg_uom = cls.env.ref("uom.product_uom_kgm")
+@tagged("post_install", "-at_install")
+class TestProductPricelistItemUom(TestPricelistItemUomCommon):
+    def test_allowed_uom_ids(self):
+        rule = self._create_rule(fixed_price=10.0)
+        self.assertEqual(rule.allowed_uom_ids, self.uom_unit | self.uom_pack_6)
 
-        # Converting g to kg needs to increase accuracy
-        cls.uom_accuracy = cls.env.ref("uom.decimal_product_uom")
-        cls.uom_accuracy.digits = log10(cls.kg_uom.factor)
+    def test_pricelist_packaging_rules(self):
+        """The rule matching the requested packaging is the one selected."""
+        # Unscoped rule, created first so that it is last in ``_order``.
+        self._create_rule(fixed_price=30.0, min_quantity=6)
+        rule_unit = self._create_rule(
+            fixed_price=10.0, min_quantity=6, uom_id=self.uom_unit.id
+        )
+        rule_pack = self._create_rule(
+            fixed_price=20.0, min_quantity=6, uom_id=self.uom_pack_6.id
+        )
 
-        # UoM group needed to see UoM field
-        cls.env.user.group_ids += cls.env.ref("uom.group_uom")
-        product_1000_kg_form = Form(cls.env["product.product"])
-        product_1000_kg_form.name = "Test product"
-        product_1000_kg_form.uom_id = cls.kg_uom
-        product_1000_kg_form.lst_price = 1000
-        cls.product_1000_kg = product_1000_kg_form.save()
+        self.assertEqual(
+            self.pricelist._get_product_rule(self.product_tmpl, 6.0, uom=self.uom_unit),
+            rule_unit.id,
+        )
+        self.assertEqual(
+            self.pricelist._get_product_rule(
+                self.product_tmpl, 6.0, uom=self.uom_pack_6
+            ),
+            rule_pack.id,
+        )
 
-        # Activate advanced pricelist to apply surcharge
-        cls.env.user.group_ids += cls.env.ref("product.group_product_pricelist")
-        pricelist_g_kg_form = Form(cls.env["product.pricelist"])
-        pricelist_g_kg_form.name = "Test pricelist"
-        with pricelist_g_kg_form.item_ids.new() as item:
-            item.product_tmpl_id = cls.product_1000_kg.product_tmpl_id
-            item.compute_price = "formula"
-            item.price_surcharge = 500
-            item.uom_id = cls.g_uom
-            item.uom_min_quantity = 1
-        with pricelist_g_kg_form.item_ids.new() as item:
-            item.product_tmpl_id = cls.product_1000_kg.product_tmpl_id
-            item.compute_price = "formula"
-            item.uom_id = cls.kg_uom
-            item.uom_min_quantity = 1
-        cls.pricelist_g_kg = pricelist_g_kg_form.save()
+    def test_rule_without_uom_stays_unrestricted(self):
+        """A rule without packaging keeps applying whatever the requested UoM."""
+        rule = self._create_rule(fixed_price=10.0, min_quantity=6)
 
-    def test_sync_uom_min_quantity(self):
-        g_uom = self.g_uom
-        kg_uom = self.kg_uom
-        pricelist = self.pricelist_g_kg
-        pricelist_form = Form(pricelist)
-        with pricelist_form.item_ids.edit(0) as item:
-            self.assertEqual(item.uom_id, kg_uom)
-            self.assertEqual(item.min_quantity, 1)
-            self.assertEqual(item.uom_min_quantity, 1)
+        self.assertEqual(
+            self.pricelist._get_product_rule(self.product_tmpl, 6.0, uom=self.uom_unit),
+            rule.id,
+        )
+        self.assertEqual(
+            self.pricelist._get_product_rule(
+                self.product_tmpl, 1.0, uom=self.uom_pack_6
+            ),
+            rule.id,
+        )
+        self.assertFalse(
+            self.pricelist._get_product_rule(self.product_tmpl, 5.0, uom=self.uom_unit)
+        )
 
-            item.uom_id = g_uom
-            self.assertEqual(item.min_quantity, 0.001)
-            self.assertEqual(item.uom_min_quantity, 1)
+    def test_min_quantity_expressed_in_rule_uom(self):
+        """``min_quantity`` is compared in the packaging of the rule."""
+        rule = self._create_rule(
+            fixed_price=10.0, min_quantity=5, uom_id=self.uom_pack_6.id
+        )
 
-            item.min_quantity = 1
-            self.assertEqual(item.uom_min_quantity, 1000)
+        self.assertEqual(
+            self.pricelist._get_product_rule(
+                self.product_tmpl, 5.0, uom=self.uom_pack_6
+            ),
+            rule.id,
+        )
+        self.assertFalse(
+            self.pricelist._get_product_rule(
+                self.product_tmpl, 4.0, uom=self.uom_pack_6
+            )
+        )
 
-            item.uom_min_quantity = 1
-            self.assertEqual(item.min_quantity, 0.001)
+    def test_uom_cleared_on_category_rule_creation(self):
+        rule = self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "applied_on": "2_product_category",
+                "categ_id": self.product_category.id,
+                "compute_price": "fixed",
+                "fixed_price": 10.0,
+                "uom_id": self.uom_pack_6.id,
+            }
+        )
+        self.assertFalse(rule.uom_id)
 
-    def test_product_price(self):
-        g_uom = self.g_uom
-        kg_uom = self.kg_uom
-        product = self.product_1000_kg
-        pricelist = self.pricelist_g_kg
+    def test_uom_cleared_on_category_rule_write(self):
+        rule = self._create_rule(fixed_price=10.0, uom_id=self.uom_pack_6.id)
+        self.assertEqual(rule.uom_id, self.uom_pack_6)
 
-        g_price, g_rule = pricelist._compute_price_rule(
-            product,
-            1,
-            uom=g_uom,
-        )[product.id]
-        kg_price, kg_rule = pricelist._compute_price_rule(
-            product,
-            1,
-            uom=kg_uom,
-        )[product.id]
-
-        self.assertEqual(g_price, 1.5)
-        self.assertEqual(kg_price, 1000)
+        rule.write(
+            {
+                "applied_on": "2_product_category",
+                "categ_id": self.product_category.id,
+            }
+        )
+        self.assertFalse(rule.uom_id)

--- a/product_pricelist_item_uom/tests/test_product_pricelist_report.py
+++ b/product_pricelist_item_uom/tests/test_product_pricelist_report.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.fields import Command
+from odoo.tests.common import tagged
+
+from .common import TestPricelistItemUomCommon
+
+
+@tagged("post_install", "-at_install")
+class TestProductPricelistReport(TestPricelistItemUomCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.report = cls.env["report.product.report_pricelist"]
+
+    def _get_report_products(self, records):
+        return self.report._get_report_data(
+            {
+                "pricelist_id": self.pricelist.id,
+                "active_model": records._name,
+                "active_ids": records.ids,
+                "quantities": [1],
+            }
+        )["products"]
+
+    def test_report_one_row_per_packaging(self):
+        self._create_rule(fixed_price=10.0, uom_id=self.uom_unit.id)
+        self._create_rule(fixed_price=20.0, uom_id=self.uom_pack_6.id)
+
+        product_data = self._get_report_products(self.product_tmpl)[0]
+
+        self.assertEqual(
+            {uom["id"] for uom in product_data["uoms"]},
+            {self.uom_unit.id, self.uom_pack_6.id},
+        )
+        self.assertEqual(product_data["price"][self.uom_unit.id][1], 10.0)
+        # Fixed prices are expressed in the product base UoM, so the packaging
+        # row shows the price of the six units of the packaging-specific rule.
+        self.assertEqual(product_data["price"][self.uom_pack_6.id][1], 120.0)
+
+    def test_report_single_row_without_packaging_rule(self):
+        """Without a packaging rule, the report keeps a single row."""
+        self._create_rule(fixed_price=10.0)
+
+        product_data = self._get_report_products(self.product_tmpl)[0]
+
+        self.assertEqual(
+            [uom["id"] for uom in product_data["uoms"]], [self.uom_unit.id]
+        )
+        self.assertEqual(product_data["price"][self.uom_unit.id][1], 10.0)
+
+    def test_report_renders_with_variants(self):
+        """The rendered report has one row per variant and per packaging."""
+        attribute = self.env["product.attribute"].create(
+            {
+                "name": "Test Colour",
+                "value_ids": [
+                    Command.create({"name": "Test Red"}),
+                    Command.create({"name": "Test Blue"}),
+                ],
+            }
+        )
+        self.product_tmpl.attribute_line_ids = [
+            Command.create(
+                {
+                    "attribute_id": attribute.id,
+                    "value_ids": [Command.set(attribute.value_ids.ids)],
+                }
+            )
+        ]
+        self._create_rule(fixed_price=20.0, uom_id=self.uom_pack_6.id)
+
+        render_values = self.report._get_report_data(
+            {
+                "pricelist_id": self.pricelist.id,
+                "active_model": "product.template",
+                "active_ids": self.product_tmpl.ids,
+                "quantities": [1],
+            }
+        )
+        product_data = render_values["products"][0]
+
+        self.assertEqual(len(product_data["variants"]), 2)
+        for variant_data in product_data["variants"]:
+            self.assertEqual(
+                {uom["id"] for uom in variant_data["uoms"]},
+                {self.uom_unit.id, self.uom_pack_6.id},
+            )
+
+        html = self.env["ir.qweb"]._render(
+            "product.report_pricelist_page", render_values
+        )
+        self.assertIn("Test Red", str(html))

--- a/product_pricelist_item_uom/views/product_pricelist_item_views.xml
+++ b/product_pricelist_item_uom/views/product_pricelist_item_views.xml
@@ -4,26 +4,51 @@
   ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
   -->
 <odoo>
+    <!--
+        Priority is raised because ``sale`` replaces the whole
+        ``pricelist_rule_limits`` group of this form; this inheritance has to be
+        applied after it so that the packaging field is not dropped.
+    -->
     <record id="product_pricelist_item_form_view" model="ir.ui.view">
-        <field
-            name="name"
-        >Add Pricelist Rule UoM fields to Pricelist Rule form view</field>
         <field name="model">product.pricelist.item</field>
         <field name="inherit_id" ref="product.product_pricelist_item_form_view" />
+        <field name="priority">110</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='min_quantity']" position="after">
-                <label
-                    for="uom_min_quantity"
-                    invisible="applied_on not in ['1_product', '0_product_variant']"
+            <field name="min_quantity" position="after">
+                <field name="allowed_uom_ids" invisible="1" />
+                <field
+                    name="uom_id"
+                    widget="many2one_uom"
+                    groups="uom.group_uom"
+                    invisible="display_applied_on != '1_product'"
+                    domain="[('id', 'in', allowed_uom_ids)] if allowed_uom_ids else []"
+                    options="{'no_create': 1, 'product_field': 'product_tmpl_id'}"
+                    placeholder="Product unit"
                 />
-                <div
-                    class="o_row"
-                    invisible="applied_on not in ['1_product', '0_product_variant']"
-                >
-                    <field name="uom_min_quantity" />
-                    <field name="uom_id" />
-                </div>
-            </xpath>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_pricelist_item_view_list_from_product" model="ir.ui.view">
+        <field name="model">product.pricelist.item</field>
+        <field
+            name="inherit_id"
+            ref="product.product_pricelist_item_tree_view_from_product"
+        />
+        <field name="arch" type="xml">
+            <field name="min_quantity" position="after">
+                <field name="display_applied_on" column_invisible="True" />
+                <field name="allowed_uom_ids" column_invisible="True" />
+                <field
+                    name="uom_id"
+                    widget="many2one_uom"
+                    groups="uom.group_uom"
+                    invisible="display_applied_on != '1_product'"
+                    domain="[('id', 'in', allowed_uom_ids)] if allowed_uom_ids else []"
+                    options="{'no_create': 1, 'product_field': 'product_tmpl_id'}"
+                    optional="show"
+                />
+            </field>
         </field>
     </record>
 </odoo>

--- a/product_pricelist_item_uom/views/product_pricelist_views.xml
+++ b/product_pricelist_item_uom/views/product_pricelist_views.xml
@@ -5,23 +5,18 @@
   -->
 <odoo>
     <record id="product_pricelist_view" model="ir.ui.view">
-        <field name="name">Add Pricelist Rule UoM fields to Pricelist form view</field>
         <field name="model">product.pricelist</field>
         <field name="inherit_id" ref="product.product_pricelist_view" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//field[@name='item_ids']/list/field[@name='min_quantity']"
-                position="attributes"
-            >
-                <attribute name="column_invisible">True</attribute>
-            </xpath>
-            <xpath
-                expr="//field[@name='item_ids']/list/field[@name='min_quantity']"
-                position="after"
-            >
-                <field name="uom_min_quantity" string="Min. Quantity" />
-                <field name="uom_id" />
-            </xpath>
+            <field name="min_quantity" position="after">
+                <field name="display_applied_on" column_invisible="True" />
+                <field
+                    name="uom_id"
+                    groups="uom.group_uom"
+                    invisible="display_applied_on != '1_product'"
+                    optional="show"
+                />
+            </field>
         </field>
     </record>
 </odoo>

--- a/product_pricelist_item_uom/views/product_views.xml
+++ b/product_pricelist_item_uom/views/product_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2026 Camptocamp SA (https://www.camptocamp.com).
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="product_template_view_form" model="ir.ui.view">
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='pricelist_rule_ids']//list//field[@name='min_quantity']"
+                position="after"
+            >
+                <field name="allowed_uom_ids" column_invisible="True" />
+                <field
+                    name="uom_id"
+                    widget="many2one_uom"
+                    groups="uom.group_uom"
+                    domain="[('id', 'in', allowed_uom_ids)] if allowed_uom_ids else []"
+                    options="{'no_create': 1, 'product_field': 'product_tmpl_id'}"
+                    optional="show"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a backport of Odoo 19.3's native pricelist-rule-by-UoM feature (odoo/odoo@d2648b1d9839), restricting pricelist item rules to a specific product packaging.

OCA/product-attribute already ships product_pricelist_item_uom, but it defines uom_id on product.pricelist.item as a computed field always defaulted to the product's base UoM, and it never filters rule selection. The two modules are declared mutually exclusive via the manifest excludes key.



- [x] Will be applied above https://github.com/OCA/product-attribute/pull/2308 using a refactoring commit ([REF] product_pricelist_item_uom: backport from odoo 19.3). Check https://github.com/OCA/product-attribute/pull/2308#pullrequestreview-4868407755