### PR TITLE
[18.0] nutritional_info: add Polish translation

### DIFF
--- a/nutritional_info/i18n/pl.po
+++ b/nutritional_info/i18n/pl.po
@@ -1,0 +1,156 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* nutritional_info
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#. module: nutritional_info
+#: model_terms:ir.ui.view,arch_db:nutritional_info.nutritional_info_table_title
+msgid "<span>)</span>"
+msgstr "<span>)</span>"
+
+#. module: nutritional_info
+#: model_terms:ir.ui.view,arch_db:nutritional_info.nutritional_info_table_title
+msgid "<span>Nutrition facts (</span>"
+msgstr "<span>Wartości odżywcze (</span>"
+
+#. module: nutritional_info
+#: model_terms:ir.ui.view,arch_db:nutritional_info.res_config_settings_view_form
+msgid "Configure your nutritional types"
+msgstr "Skonfiguruj typy wartości odżywczych"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__create_uid
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__create_uid
+msgid "Created by"
+msgstr "Utworzył(a)"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__create_date
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__create_date
+msgid "Created on"
+msgstr "Data utworzenia"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__display_name
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__display_name
+msgid "Display Name"
+msgstr "Nazwa wyświetlana"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__id
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__id
+msgid "ID"
+msgstr "ID"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__write_uid
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__write_uid
+msgid "Last Updated by"
+msgstr "Ostatnio aktualizowane przez"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__write_date
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__write_date
+msgid "Last Updated on"
+msgstr "Data ostatniej aktualizacji"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__name
+msgid "Name"
+msgstr "Nazwa"
+
+#. module: nutritional_info
+#: model_terms:ir.ui.view,arch_db:nutritional_info.product_normal_form_view
+#: model_terms:ir.ui.view,arch_db:nutritional_info.product_template_only_form_view
+msgid "Nutrition"
+msgstr "Wartości Odżywcze"
+
+#. module: nutritional_info
+#: model:ir.actions.report,name:nutritional_info.action_nutritional_info_product_report
+#: model:ir.actions.report,name:nutritional_info.action_nutritional_info_template_report
+msgid "Nutritional Info"
+msgstr "Wartości odżywcze"
+
+#. module: nutritional_info
+#: model_terms:ir.ui.view,arch_db:nutritional_info.res_config_settings_view_form
+msgid "Nutritional Information"
+msgstr "Informacje o wartościach odżywczych"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_product_product__nutritional_reference_uom
+#: model:ir.model.fields,field_description:nutritional_info.field_product_template__nutritional_reference_uom
+msgid "Nutritional Reference Uom"
+msgstr "Jednostka miary odniesienia wartości odżywczych"
+
+#. module: nutritional_info
+#: model:ir.actions.act_window,name:nutritional_info.action_nutritional_type
+#: model_terms:ir.ui.view,arch_db:nutritional_info.res_config_settings_view_form
+msgid "Nutritional Types"
+msgstr "Typy wartości odżywczych"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_product_product__nutritional_value_ids
+#: model:ir.model.fields,field_description:nutritional_info.field_product_template__nutritional_value_ids
+msgid "Nutritional Value"
+msgstr "Wartość odżywcza"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_product_product__nutritional_reference_qty
+#: model:ir.model.fields,field_description:nutritional_info.field_product_template__nutritional_reference_qty
+msgid "Nutritional reference quantity"
+msgstr "Ilość odniesienia wartości odżywczych"
+
+#. module: nutritional_info
+#: model:ir.model,name:nutritional_info.model_nutritional_value
+msgid "Nutritional values for a given product"
+msgstr "Wartości odżywcze danego produktu"
+
+#. module: nutritional_info
+#: model:ir.model,name:nutritional_info.model_product_template
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__product_id
+msgid "Product"
+msgstr "Produkt"
+
+#. module: nutritional_info
+#: model:ir.model,name:nutritional_info.model_product_product
+msgid "Product Variant"
+msgstr "Wariant produktu"
+
+#. module: nutritional_info
+#. odoo-python
+#: code:addons/nutritional_info/models/product_template.py:0
+msgid "Repeating types of nutritional values is not allowed."
+msgstr "Powtarzanie typów wartości odżywczych jest niedozwolone."
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_type__sequence
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__sequence
+msgid "Sequence"
+msgstr "Sekwencja"
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__type_id
+msgid "Type"
+msgstr "Typ"
+
+#. module: nutritional_info
+#: model:ir.model,name:nutritional_info.model_nutritional_type
+msgid "Types used to inform about nutritional values at products."
+msgstr "Typy używane do informowania o wartościach odżywczych produktów."
+
+#. module: nutritional_info
+#: model:ir.model.fields,field_description:nutritional_info.field_nutritional_value__value
+msgid "Value"
+msgstr "Wartość"


### PR DESCRIPTION
Add Polish translation for `nutritional_info` — all 24 entries of the current 18.0 template translated, generic field labels aligned with Odoo core Polish terms.
