### PR TITLE
[18.0][IMP] product_secondary_unit: hook for the product the factor refers to

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -55,6 +55,16 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
     def _get_uom_line(self):
         return self[self._secondary_unit_fields["uom_field"]]
 
+    def _get_product_uom(self):
+        """Return the UoM the secondary unit factor refers to.
+
+        Models where ``product_id`` is optional (a bill of materials defined at
+        template level, for instance) can override this to fall back on the
+        product template.
+        """
+        self.ensure_one()
+        return self.product_id[self._product_uom_field]
+
     # TODO: This method is now not used in this module. Deprecate it in future.
     def _get_factor_line(self):
         uom_line = self._get_uom_line()
@@ -78,7 +88,7 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
         # Intended to be called from other operations if needed.
         self.ensure_one()
         uom_line = self._get_uom_line()
-        uom_product = self.product_id[self._product_uom_field]
+        uom_product = self._get_product_uom()
         if uom_line != uom_product:
             qty = uom_line._compute_quantity(qty, uom_product)
         return float_round(
@@ -125,7 +135,7 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
             )
             qty_base = rec.secondary_uom_qty * rec.secondary_uom_id.factor
             uom_line = rec._get_uom_line()
-            uom_product = rec.product_id[rec._product_uom_field]
+            uom_product = rec._get_product_uom()
             qty_line = uom_product._compute_quantity(qty_base, uom_line)
             rec[rec._secondary_unit_fields["qty_field"]] = qty_line
 


### PR DESCRIPTION
The mixin resolves the unit the secondary factor refers to by reading `product_id` directly:

```python
uom_product = self.product_id[self._product_uom_field]
```

That does not work on a model where the variant is optional and the template holds the reference unit — a bill of materials defined at template level, for instance. `product_id` is then empty, so `uom_product` is an empty `uom.uom`, and the conversion in `_convert_qty_to_secondary_uom` / `_compute_helper_target_field_qty` silently returns a wrong quantity rather than failing.

This moves the lookup into a `_get_product_uom()` hook that such a model can override:

```python
def _get_product_uom(self):
    self.ensure_one()
    return (self.product_id or self.product_tmpl_id)[self._product_uom_field]
```

`product.secondary.unit._get_secondary_qty` already falls back on the template in exactly that way, so this only makes the mixin consistent with it. The default implementation returns `self.product_id`, so behaviour is unchanged for every current inheritor (`purchase.order.line`, `sale.order.line`, `stock.move`, `stock.move.line`, `account.move.line`).

Needed by a new `mrp_secondary_unit` in OCA/manufacture, whose `mrp.bom` needs the template fallback.

Assisted-by: Claude Opus 5

@qrtl QT6876