### PR TITLE
[18.0][FIX] product_variant_route_mto: variant creation fix

### DIFF
--- a/product_variant_route_mto/__manifest__.py
+++ b/product_variant_route_mto/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Product Variant Route MTO",
     "summary": "Allow to individually set variants as MTO",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/product-attribute",

--- a/product_variant_route_mto/models/product_product.py
+++ b/product_variant_route_mto/models/product_product.py
@@ -33,6 +33,9 @@ class ProductProduct(models.Model):
         inverse="_inverse_route_ids",
     )
 
+    # depending on product_tmpl_id, so that is_mto is computed when the
+    # variant is created
+    @api.depends("product_tmpl_id")
     def _compute_is_mto(self):
         for product in self:
             product.is_mto = product.product_tmpl_id.is_mto

--- a/product_variant_route_mto/models/product_template.py
+++ b/product_variant_route_mto/models/product_template.py
@@ -8,6 +8,14 @@ from odoo import api, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        templates = super().create(vals_list)
+        # variants are created before route_ids is written, so their is_mto has been
+        # computed on a not yet mto template
+        templates.filtered("is_mto").product_variant_ids._compute_is_mto()
+        return templates
+
     def write(self, values):
         if "route_ids" not in values:
             return super().write(values)

--- a/product_variant_route_mto/tests/__init__.py
+++ b/product_variant_route_mto/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_mto_variant
+from . import test_mto_variant_routes

--- a/product_variant_route_mto/tests/test_mto_variant_routes.py
+++ b/product_variant_route_mto/tests/test_mto_variant_routes.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.fields import Command
+
+from .common import TestMTOVariantCommon
+
+
+class TestMTOVariantRoutes(TestMTOVariantCommon):
+    def test_variant_created_on_mto_template(self):
+        template = self.env["product.template"].create(
+            {"name": "mto pen", "route_ids": [Command.link(self.mto_route.id)]}
+        )
+        self.assertTrue(template.is_mto)
+        self.assertVariantsMTO(template.product_variant_ids)
+
+    def test_variants_created_on_mto_template_with_attributes(self):
+        template = self.env["product.template"].create(
+            {
+                "name": "mto pen",
+                "route_ids": [Command.link(self.mto_route.id)],
+                "attribute_line_ids": [
+                    Command.create(
+                        {
+                            "attribute_id": self.color.id,
+                            "value_ids": [Command.set(self.values.ids)],
+                        }
+                    )
+                ],
+            }
+        )
+        self.assertEqual(len(template.product_variant_ids), 4)
+        self.assertVariantsMTO(template.product_variant_ids)
+
+    def test_variant_created_on_already_mto_template(self):
+        self.template_pen.route_ids = [Command.link(self.mto_route.id)]
+        self.assertVariantsMTO(self.variants_pen)
+        value_white = self.env["product.attribute.value"].create(
+            {"name": "white", "attribute_id": self.color.id}
+        )
+        self.template_pen.attribute_line_ids.value_ids = [Command.link(value_white.id)]
+        white_pen = self.template_pen.product_variant_ids - self.variants_pen
+        self.assertEqual(len(white_pen), 1)
+        self.assertVariantsMTO(white_pen)
+
+    def test_variant_created_with_mto_route(self):
+        product = self.env["product.product"].create(
+            {"name": "mto pen", "route_ids": [Command.link(self.mto_route.id)]}
+        )
+        self.assertVariantsMTO(product)
+        self.assertNotIn(self.mto_route, product.product_tmpl_id.route_ids)
+
+    def test_write_mto_route_on_variant(self):
+        template_routes = self.template_pen.route_ids
+        self.assertVariantsNotMTO(self.variants_pen)
+        self.black_pen.route_ids = [Command.link(self.mto_route.id)]
+        self.assertVariantsMTO(self.black_pen)
+        self.assertVariantsNotMTO(self.blue_pen | self.red_pen | self.green_pen)
+        # the mto route is carried by the variant, not by the template
+        self.assertEqual(self.template_pen.route_ids, template_routes)
+
+    def test_write_other_route_on_variant(self):
+        template_routes = self.template_pen.route_ids
+        route = self.env["stock.route"].create({"name": "other route"})
+        self.black_pen.route_ids = [Command.link(route.id)]
+        self.assertEqual(
+            self.template_pen.route_ids.sorted(), (template_routes | route).sorted()
+        )
+        self.assertVariantsNotMTO(self.variants_pen)


### PR DESCRIPTION
When new template or variant is created, the variants don't get the `is_mto` set correctly. Added a template dependency on the variant `_compute_is_mto` to trigger recompute on variant creation and create hook to recompute the variants on template creation.

These issues surfaced while working on `stock-logistics-orderpoint` PR:
- https://github.com/OCA/stock-logistics-orderpoint/pull/58