### PR TITLE
[18.0][FIX] product_catalog_stock: Remove Form usage outside tests

### DIFF
--- a/product_catalog_stock/models/stock_picking_type.py
+++ b/product_catalog_stock/models/stock_picking_type.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import models
-from odoo.tests import Form
 
 
 class StockPickingType(models.Model):
@@ -9,14 +8,14 @@ class StockPickingType(models.Model):
 
     def action_new_draft_picking_from_catalog(self):
         """Create a new draft picking from the catalog view"""
-        picking_form = Form(
-            self.env["stock.picking"].with_context(
-                search_default_picking_type_id=self.ids,
+        picking = (
+            self.env["stock.picking"]
+            .with_context(
                 default_picking_type_id=self.id,
                 contact_display="partner_address",
             )
+            .create({})
         )
-        picking = picking_form.save()
         action = picking.action_add_from_catalog()
         # So we can go back safely to the new picking instead of returning to the
         # previous screen


### PR DESCRIPTION
Because of the use of Form, I have these error logs using this module. (we can't see in the OCA CI logs because it does not trigger when test-enable option is passed.
This PR aims to remove the use of Form which does not seem unavoidable in this case.

 @CarlosRoca13 @victoralmau @pedrobaeza 

```
2026-09-09 13:05:04,344 2173 ERROR db odoo.tests.common: Importing test framework, avoid importing from business modules and when not running in test mode 
Stack (most recent call last):
  File "/odoo/bin/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/cli/command.py", line 76, in main
    o.run(args)
  File "/odoo/src/odoo/cli/server.py", line 182, in run
    main(args)
  File "/odoo/src/odoo/cli/server.py", line 175, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/src/odoo/service/server.py", line 1512, in start
    rc = server.run(preload, stop)
  File "/odoo/src/odoo/service/server.py", line 646, in run
    rc = preload_registries(preload)
  File "/odoo/src/odoo/service/server.py", line 1416, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/lib/python3.12/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/modules/registry.py", line 118, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/odoo/src/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 186, in load_module_graph
    load_openerp_module(package.name)
  File "/odoo/src/odoo/modules/module.py", line 384, in load_openerp_module
    __import__(qualname)
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/odoo/links/product_catalog_stock/__init__.py", line 1, in <module>
    from . import models
  File "<frozen importlib._bootstrap>", line 1415, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/odoo/links/product_catalog_stock/models/__init__.py", line 2, in <module>
    from . import stock_picking_type
  File "<frozen importlib._bootstrap>", line 1415, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/odoo/links/product_catalog_stock/models/stock_picking_type.py", line 4, in <module>
    from odoo.tests import Form
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/odoo/src/odoo/tests/__init__.py", line 8, in <module>
    from . import common
  File "<frozen importlib._bootstrap>", line 1415, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/odoo/src/odoo/tests/common.py", line 100, in <module>
    _logger.error(
```