### PR TITLE
[18.0][FIX] product_state: Field 'id' is not defined in domain of `action_open_state_products`

### DIFF
--- a/product_state/views/product_template_views.xml
+++ b/product_state/views/product_template_views.xml
@@ -5,7 +5,7 @@
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,form,list</field>
         <field name="context">{}</field>
-        <field name="domain">[('product_state_id', '=', id)]</field>
+        <field name="domain">[('product_state_id', '=', active_id)]</field>
     </record>
     <record id="view_product_template_search_state" model="ir.ui.view">
         <field name="name">product.template.search.state</field>


### PR DESCRIPTION
Supersedes #2200 